### PR TITLE
Update QuoteTOChange handling

### DIFF
--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -63,7 +63,6 @@ namespace QuoteSwift
                     passed.QuoteTOChange = NewQuote;
                     ConvertToReadOnly();
                     createNewQuoteUsingThisQuoteToolStripMenuItem.Enabled = true;
-                    passed.QuoteTOChange = null;
                 }
                 else MainProgramCode.ShowError("The Quote could not be created successfully.", "ERROR - Quote Creation Unsuccessful");
             }


### PR DESCRIPTION
## Summary
- keep QuoteTOChange reference after creating a quote

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6870fd451098832595bce503063e079f