### PR TITLE
Fix cell phone check in PhoneNumberExisting

### DIFF
--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -535,11 +535,11 @@ namespace QuoteSwift
                 }
             }
 
-            if (Customer.CustomerTelephoneNumberList != null)
+            if (Customer.CustomerCellphoneNumberList != null)
             {
-                for (int i = 0; i < Customer.CustomerTelephoneNumberList.Count; i++)
+                for (int i = 0; i < Customer.CustomerCellphoneNumberList.Count; i++)
                 {
-                    if (Customer.CustomerTelephoneNumberList.SingleOrDefault(p => p == s) != null)
+                    if (Customer.CustomerCellphoneNumberList.SingleOrDefault(p => p == s) != null)
                     {
                         MainProgramCode.ShowError("This number has already been added previously to the Cellphone Number List.", "ERROR - Number Already Added");
                         return true;


### PR DESCRIPTION
## Summary
- fix `PhoneNumberExisting` so that the second phone list check uses `CustomerCellphoneNumberList`

## Testing
- ❌ `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fd062fa88325b186e9724ef9403a