### PR TITLE
Remove unused helper from Address class

### DIFF
--- a/MainProgramLibrary/Address.cs
+++ b/MainProgramLibrary/Address.cs
@@ -52,9 +52,5 @@ namespace QuoteSwift
         public string AddressCity { get => mAddressCity; set => mAddressCity = value; }
         public int AddressAreaCode { get => mAddressAreaCode; set => mAddressAreaCode = value; }
 
-        internal object SingleOrDefault(Func<object, bool> p)
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Address.cs declared a `SingleOrDefault` stub that was never used anywhere in the project
- removed the unused method

## Testing
- `dotnet build QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711629b3848325b78b23a59acc9a90