### PR TITLE
Remove duplicate GetLastQuote method

### DIFF
--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -54,29 +54,7 @@ namespace QuoteSwift
             }
         }
 
-        //Get Last Quote
 
-        public static Quote GetLastQuote(ref Pass passed)
-        {
-            if (passed != null && passed.PassQuoteList != null)
-            {
-                Quote latest = passed.PassQuoteList[0];
-                DateTime dt = latest.QuoteCreationDate;
-
-                foreach (var quote in passed.PassQuoteList.Skip(1))
-                {
-                    if (quote.QuoteCreationDate.Date > dt)
-                    {
-                        dt = quote.QuoteCreationDate.Date;
-                        latest = quote;
-                    }
-                }
-
-                return latest;
-            }
-
-            return null;
-        }
 
 
         /** Message Box Custom Functions */


### PR DESCRIPTION
## Summary
- remove redundant `GetLastQuote` method from `QuoteSwiftMainCode`
- rely on `MainProgramCode.GetLastQuote` as the single implementation

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871161c44f48325b6966ef5768fcc0a