### PR TITLE
Refactor quote storage to dictionary

### DIFF
--- a/MainProgramLibrary/MainProgramCode.cs
+++ b/MainProgramLibrary/MainProgramCode.cs
@@ -17,12 +17,12 @@ namespace QuoteSwift
 
         public static Quote GetLastQuote(ref Pass passed)
         {
-            if (passed != null && passed.PassQuoteList != null)
+            if (passed != null && passed.PassQuoteMap != null && passed.PassQuoteMap.Count > 0)
             {
-                Quote latest = passed.PassQuoteList[0];
+                Quote latest = passed.PassQuoteMap.First().Value;
                 DateTime dt = latest.QuoteCreationDate;
 
-                foreach (var quote in passed.PassQuoteList.Skip(1))
+                foreach (var quote in passed.PassQuoteMap.Values.Skip(1))
                 {
                     if (quote.QuoteCreationDate.Date > dt)
                     {
@@ -296,12 +296,12 @@ namespace QuoteSwift
 
         // Serialize Quote List Method
 
-        public static byte[] SerializeQuoteList(BindingList<Quote> QuoteList)
+        public static byte[] SerializeQuoteList(SortedDictionary<string, Quote> QuoteList)
         {
             byte[] tempByte;
             try
             {
-                tempByte = MainProgramCode.JsonSerialize<BindingList<Quote>>(QuoteList);
+                tempByte = MainProgramCode.JsonSerialize<SortedDictionary<string, Quote>>(QuoteList);
             }
             catch
             {
@@ -313,11 +313,11 @@ namespace QuoteSwift
 
         // De-serialize Quote List Method
 
-        public static BindingList<Quote> DeserializeQuoteList(byte[] tempByte)
+        public static SortedDictionary<string, Quote> DeserializeQuoteList(byte[] tempByte)
         {
             try
             {
-                return MainProgramCode.JsonDeserialize<BindingList<Quote>>(tempByte);
+                return MainProgramCode.JsonDeserialize<SortedDictionary<string, Quote>>(tempByte);
             }
             catch
             {
@@ -331,9 +331,9 @@ namespace QuoteSwift
         {
             //Determine if Pump List exist:
 
-            if (passed != null && passed.PassQuoteList != null && passed.PassQuoteList.Count > 0)
+            if (passed != null && passed.PassQuoteMap != null && passed.PassQuoteMap.Count > 0)
             {
-                byte[] ToStore = MainProgramCode.SerializeQuoteList(passed.PassQuoteList);
+                byte[] ToStore = MainProgramCode.SerializeQuoteList(passed.PassQuoteMap);
                 MainProgramCode.SaveData("QuoteList.json", ToStore);
             }
         }

--- a/MainProgramLibrary/Pass.cs
+++ b/MainProgramLibrary/Pass.cs
@@ -6,7 +6,7 @@ namespace QuoteSwift
 {
     public class Pass
     {
-        private BindingList<Quote> mPassQuoteList;
+        private SortedDictionary<string, Quote> mPassQuoteMap;
         private BindingList<Business> mPassBusinessList;
         private BindingList<Pump> mPassPumpList;
         private BindingList<Part> mPassMandatoryPartList;
@@ -29,9 +29,9 @@ namespace QuoteSwift
 
         //Pass All Constructor :
 
-        public Pass(BindingList<Quote> mPassQuoteList, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList)
         {
-            PassQuoteList = mPassQuoteList;
+            PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
             PassPumpList = mPassPumpList;
             PassMandatoryPartList = mPassMandatoryPartList;
@@ -40,9 +40,9 @@ namespace QuoteSwift
 
         //Pass Quote Constructor:
 
-        public Pass(BindingList<Quote> mPassQuoteList, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Quote mQuoteTOChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Quote mQuoteTOChange, bool mChangeSpecificObject = false)
         {
-            PassQuoteList = mPassQuoteList;
+            PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
             PassPumpList = mPassPumpList;
             PassMandatoryPartList = mPassMandatoryPartList;
@@ -53,9 +53,9 @@ namespace QuoteSwift
 
         //Pass Business Constructor:
 
-        public Pass(BindingList<Quote> mPassQuoteList, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Business mBusinessToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Business mBusinessToChange, bool mChangeSpecificObject = false)
         {
-            PassQuoteList = mPassQuoteList;
+            PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
             PassPumpList = mPassPumpList;
             PassMandatoryPartList = mPassMandatoryPartList;
@@ -66,9 +66,9 @@ namespace QuoteSwift
 
         //Pass Customer Constructor:
 
-        public Pass(BindingList<Quote> mPassQuoteList, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Customer mCustomerToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Customer mCustomerToChange, bool mChangeSpecificObject = false)
         {
-            PassQuoteList = mPassQuoteList;
+            PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
             PassPumpList = mPassPumpList;
             PassMandatoryPartList = mPassMandatoryPartList;
@@ -79,9 +79,9 @@ namespace QuoteSwift
 
         //Pass Pump Constructor:
 
-        public Pass(BindingList<Quote> mPassQuoteList, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Pump mPumpToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Pump mPumpToChange, bool mChangeSpecificObject = false)
         {
-            PassQuoteList = mPassQuoteList;
+            PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
             PassPumpList = mPassPumpList;
             PassMandatoryPartList = mPassMandatoryPartList;
@@ -92,9 +92,9 @@ namespace QuoteSwift
 
         //Pass Part Constructor:
 
-        public Pass(BindingList<Quote> mPassQuoteList, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Part mPartToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Part mPartToChange, bool mChangeSpecificObject = false)
         {
-            PassQuoteList = mPassQuoteList;
+            PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
             PassPumpList = mPassPumpList;
             PassMandatoryPartList = mPassMandatoryPartList;
@@ -103,7 +103,8 @@ namespace QuoteSwift
             ChangeSpecificObject = mChangeSpecificObject;
         }
 
-        public BindingList<Quote> PassQuoteList { get => mPassQuoteList; set => mPassQuoteList = value; }
+        public SortedDictionary<string, Quote> PassQuoteMap { get => mPassQuoteMap; set => mPassQuoteMap = value; }
+        public IEnumerable<Quote> PassQuoteList => mPassQuoteMap?.Values;
         public BindingList<Business> PassBusinessList
         {
             get => mPassBusinessList;

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -113,12 +113,12 @@ namespace QuoteSwift
 
         private string GetPreviousQuoteDate(Customer c)
         {
-            if (passed.PassQuoteList != null)
+            if (passed.PassQuoteMap != null)
             {
                 DateTime latest = DateTime.MinValue;
                 bool found = false;
 
-                foreach (var q in passed.PassQuoteList)
+                foreach (var q in passed.PassQuoteMap.Values)
                 {
                     if (q.QuoteCustomer != null && c != null &&
                         q.QuoteCustomer.CustomerCompanyName == c.CustomerCompanyName)

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Forms;
+using System.Collections.Generic;
 
 namespace QuoteSwift
 {
@@ -15,7 +17,7 @@ namespace QuoteSwift
         {
             InitializeComponent();
             this.passed = passed;
-            if (this.passed == null) passed = new Pass(new BindingList<Quote>(), new BindingList<Business>(), new BindingList<Pump>(), new BindingList<Part>(), new BindingList<Part>());
+            if (this.passed == null) passed = new Pass(new SortedDictionary<string, Quote>(), new BindingList<Business>(), new BindingList<Pump>(), new BindingList<Part>(), new BindingList<Part>());
 
         }
 
@@ -150,7 +152,7 @@ namespace QuoteSwift
 
         private void BtnViewSelectedQuote_Click(object sender, EventArgs e)
         {
-            if (passed != null && passed.PassQuoteList != null && dgvPreviousQuotes.SelectedItem as Quote != null)
+            if (passed != null && passed.PassQuoteMap != null && dgvPreviousQuotes.SelectedItem as Quote != null)
             {
                 Hide();
                 passed.QuoteTOChange = dgvPreviousQuotes.SelectedItem as Quote;
@@ -164,7 +166,7 @@ namespace QuoteSwift
 
         private void BtnCreateNewQuoteOnSelection_Click(object sender, EventArgs e)
         {
-            if (passed != null && passed.PassQuoteList != null && dgvPreviousQuotes.SelectedItem as Quote != null)
+            if (passed != null && passed.PassQuoteMap != null && dgvPreviousQuotes.SelectedItem as Quote != null)
             {
                 this.Hide();
                 passed.QuoteTOChange = dgvPreviousQuotes.SelectedItem as Quote;
@@ -235,7 +237,8 @@ namespace QuoteSwift
 
                     byte[] RetreiveQuoteList = MainProgramCode.RetreiveData("QuoteList.json");
 
-                    if (RetreiveQuoteList != null && RetreiveQuoteList.Length > 0) passed.PassQuoteList = new BindingList<Quote>(MainProgramCode.DeserializeQuoteList(RetreiveQuoteList));
+                    if (RetreiveQuoteList != null && RetreiveQuoteList.Length > 0)
+                        passed.PassQuoteMap = MainProgramCode.DeserializeQuoteList(RetreiveQuoteList);
                 }
                 catch (Exception Ex)
                 {
@@ -262,8 +265,8 @@ namespace QuoteSwift
 
 
             BindingSource PreviousQuotesDatagridBindingSource = null;
-            if (passed != null && passed.PassQuoteList != null)
-                PreviousQuotesDatagridBindingSource = new BindingSource { DataSource = passed.PassQuoteList };
+            if (passed != null && passed.PassQuoteMap != null)
+                PreviousQuotesDatagridBindingSource = new BindingSource { DataSource = new BindingList<Quote>(passed.PassQuoteMap.Values.ToList()) };
 
             if (PreviousQuotesDatagridBindingSource != null)
             {


### PR DESCRIPTION
## Summary
- keep quotes in a `SortedDictionary` inside `Pass`
- update serializers in `MainProgramCode`
- adapt quoting UI and logic for new dictionary structure

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711d67c38c8325ae670c0920ca862a