### PR TITLE
Replace Syncfusion controls

### DIFF
--- a/Controls/NumericTextBox.cs
+++ b/Controls/NumericTextBox.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Windows.Forms;
+
+namespace QuoteSwift.Controls
+{
+    /// <summary>
+    /// Simple textbox that only accepts decimal numeric input.
+    /// </summary>
+    public class NumericTextBox : TextBox
+    {
+        private decimal minValue = 0m;
+        private decimal maxValue = decimal.MaxValue;
+        private decimal currentValue = 0m;
+
+        public decimal MinValue
+        {
+            get => minValue;
+            set { minValue = value; ValidateValue(); }
+        }
+
+        public decimal MaxValue
+        {
+            get => maxValue;
+            set { maxValue = value; ValidateValue(); }
+        }
+
+        public decimal Value
+        {
+            get
+            {
+                if (decimal.TryParse(Text, out var v))
+                {
+                    currentValue = Clamp(v);
+                }
+                return currentValue;
+            }
+            set
+            {
+                currentValue = Clamp(value);
+                Text = currentValue.ToString("0.##");
+            }
+        }
+
+        private decimal Clamp(decimal v)
+        {
+            if (v < MinValue) v = MinValue;
+            if (v > MaxValue) v = MaxValue;
+            return v;
+        }
+
+        private void ValidateValue()
+        {
+            Value = Value;
+        }
+
+        protected override void OnKeyPress(KeyPressEventArgs e)
+        {
+            base.OnKeyPress(e);
+            char ch = e.KeyChar;
+            if (!char.IsControl(ch) && !char.IsDigit(ch) && ch != '.' && ch != '-')
+            {
+                e.Handled = true;
+            }
+            if (ch == '.' && Text.Contains("."))
+            {
+                e.Handled = true;
+            }
+            if (ch == '-' && (SelectionStart != 0 || Text.Contains("-")))
+            {
+                e.Handled = true;
+            }
+        }
+
+        protected override void OnLeave(EventArgs e)
+        {
+            base.OnLeave(e);
+            Value = Value; // clamp and format
+        }
+    }
+}

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -251,6 +251,7 @@
       <DependentUpon>FrmViewPump.cs</DependentUpon>
     </Compile>
     <Compile Include="QuoteSwiftMainCode.cs" />
+    <Compile Include="Controls\NumericTextBox.cs" />
     <Compile Include="FrmViewQuotes.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -29,7 +29,7 @@ namespace QuoteSwift
                 foreach (DataGridView dgv in cc.OfType<DataGridView>()) dgv.ReadOnly = false;
                 foreach (Button btn in cc.OfType<Button>()) btn.Enabled = true;
                 foreach (CheckBox cbx in cc.OfType<CheckBox>()) cbx.Enabled = true;
-                foreach (Syncfusion.Windows.Forms.Tools.DoubleTextBox dtxt in cc.OfType<Syncfusion.Windows.Forms.Tools.DoubleTextBox>()) dtxt.Enabled = true;
+                foreach (QuoteSwift.Controls.NumericTextBox dtxt in cc.OfType<QuoteSwift.Controls.NumericTextBox>()) dtxt.Enabled = true;
             }
         }
 
@@ -50,7 +50,7 @@ namespace QuoteSwift
                 foreach (DataGridView dgv in cc.OfType<DataGridView>()) dgv.ReadOnly = true;
                 foreach (Button btn in cc.OfType<Button>()) btn.Enabled = false;
                 foreach (CheckBox cbx in cc.OfType<CheckBox>()) cbx.Enabled = false;
-                foreach (Syncfusion.Windows.Forms.Tools.DoubleTextBox dtxt in cc.OfType<Syncfusion.Windows.Forms.Tools.DoubleTextBox>()) dtxt.Enabled = false;
+                foreach (QuoteSwift.Controls.NumericTextBox dtxt in cc.OfType<QuoteSwift.Controls.NumericTextBox>()) dtxt.Enabled = false;
             }
         }
 

--- a/frmAddPart.Designer.cs
+++ b/frmAddPart.Designer.cs
@@ -51,10 +51,9 @@ namespace QuoteSwift
             this.lblnewPartQuantity = new System.Windows.Forms.Label();
             this.NudQuantity = new System.Windows.Forms.NumericUpDown();
             this.OfdOpenCSVFile = new System.Windows.Forms.OpenFileDialog();
-            this.mtxtPartPrice = new Syncfusion.Windows.Forms.Tools.DoubleTextBox();
+            this.mtxtPartPrice = new QuoteSwift.Controls.NumericTextBox();
             this.msAddPartControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NudQuantity)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mtxtPartPrice)).BeginInit();
             this.SuspendLayout();
             // 
             // msAddPartControls
@@ -267,12 +266,11 @@ namespace QuoteSwift
             // 
             // mtxtPartPrice
             // 
-            this.mtxtPartPrice.BeforeTouchSize = new System.Drawing.Size(148, 24);
-            this.mtxtPartPrice.DoubleValue = 0D;
+            this.mtxtPartPrice.Value = 0M;
             this.mtxtPartPrice.Location = new System.Drawing.Point(181, 184);
             this.mtxtPartPrice.Margin = new System.Windows.Forms.Padding(4);
-            this.mtxtPartPrice.MaxValue = 5000000D;
-            this.mtxtPartPrice.MinValue = 0D;
+            this.mtxtPartPrice.MaxValue = 5000000M;
+            this.mtxtPartPrice.MinValue = 0M;
             this.mtxtPartPrice.Name = "mtxtPartPrice";
             this.mtxtPartPrice.Size = new System.Drawing.Size(139, 24);
             this.mtxtPartPrice.TabIndex = 4;
@@ -312,7 +310,6 @@ namespace QuoteSwift
             this.msAddPartControls.ResumeLayout(false);
             this.msAddPartControls.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NudQuantity)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mtxtPartPrice)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -342,6 +339,6 @@ namespace QuoteSwift
         private System.Windows.Forms.ToolStripMenuItem loadPartBatchToolStripMenuItem;
         private System.Windows.Forms.OpenFileDialog OfdOpenCSVFile;
         private System.Windows.Forms.ToolStripMenuItem updatePartToolStripMenuItem;
-        private Syncfusion.Windows.Forms.Tools.DoubleTextBox mtxtPartPrice;
+        private QuoteSwift.Controls.NumericTextBox mtxtPartPrice;
     }
 }

--- a/frmAddPump.Designer.cs
+++ b/frmAddPump.Designer.cs
@@ -54,7 +54,7 @@ namespace QuoteSwift
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnAddPump = new System.Windows.Forms.Button();
             this.gbxPartInformation = new System.Windows.Forms.GroupBox();
-            this.mtxtNewPumpPrice = new Syncfusion.Windows.Forms.Tools.DoubleTextBox();
+            this.mtxtNewPumpPrice = new QuoteSwift.Controls.NumericTextBox();
             this.mtxtPumpDescription = new System.Windows.Forms.MaskedTextBox();
             this.mtxtPumpName = new System.Windows.Forms.MaskedTextBox();
             this.lblNewPumpPrice = new System.Windows.Forms.Label();
@@ -64,7 +64,6 @@ namespace QuoteSwift
             ((System.ComponentModel.ISupportInitialize)(this.dgvMandatoryPartView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvNonMandatoryPartView)).BeginInit();
             this.gbxPartInformation.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mtxtNewPumpPrice)).BeginInit();
             this.SuspendLayout();
             // 
             // msAddPumpControls
@@ -313,12 +312,11 @@ namespace QuoteSwift
             // 
             // mtxtNewPumpPrice
             // 
-            this.mtxtNewPumpPrice.BeforeTouchSize = new System.Drawing.Size(148, 24);
-            this.mtxtNewPumpPrice.DoubleValue = 0D;
+            this.mtxtNewPumpPrice.Value = 0M;
             this.mtxtNewPumpPrice.Location = new System.Drawing.Point(174, 90);
             this.mtxtNewPumpPrice.Margin = new System.Windows.Forms.Padding(4);
-            this.mtxtNewPumpPrice.MaxValue = 5000000D;
-            this.mtxtNewPumpPrice.MinValue = 0D;
+            this.mtxtNewPumpPrice.MaxValue = 5000000M;
+            this.mtxtNewPumpPrice.MinValue = 0M;
             this.mtxtNewPumpPrice.Name = "mtxtNewPumpPrice";
             this.mtxtNewPumpPrice.Size = new System.Drawing.Size(139, 24);
             this.mtxtNewPumpPrice.TabIndex = 2;
@@ -396,7 +394,6 @@ namespace QuoteSwift
             ((System.ComponentModel.ISupportInitialize)(this.dgvNonMandatoryPartView)).EndInit();
             this.gbxPartInformation.ResumeLayout(false);
             this.gbxPartInformation.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mtxtNewPumpPrice)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -433,6 +430,6 @@ namespace QuoteSwift
         private System.Windows.Forms.DataGridViewCheckBoxColumn ClmNonMandatoryPartSelection;
         private System.Windows.Forms.DataGridViewTextBoxColumn clmNMPartQuantity;
         private System.Windows.Forms.ToolStripMenuItem updatePumpToolStripMenuItem;
-        private Syncfusion.Windows.Forms.Tools.DoubleTextBox mtxtNewPumpPrice;
+        private QuoteSwift.Controls.NumericTextBox mtxtNewPumpPrice;
     }
 }

--- a/frmCreateQuote.Designer.cs
+++ b/frmCreateQuote.Designer.cs
@@ -120,7 +120,7 @@ namespace QuoteSwift
             this.ClmRepairDevider = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.cbxPumpSelection = new System.Windows.Forms.ComboBox();
             this.panel6 = new System.Windows.Forms.Panel();
-            this.mtxtRebate = new Syncfusion.Windows.Forms.Tools.DoubleTextBox();
+            this.mtxtRebate = new QuoteSwift.Controls.NumericTextBox();
             this.BtnCalculateRebate = new System.Windows.Forms.Button();
             this.lblRebateTestInput = new System.Windows.Forms.Label();
             this.panel10 = new System.Windows.Forms.Panel();
@@ -156,7 +156,6 @@ namespace QuoteSwift
             ((System.ComponentModel.ISupportInitialize)(this.DgvNonMandatoryPartReplacement)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvMandatoryPartReplacement)).BeginInit();
             this.panel6.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mtxtRebate)).BeginInit();
             this.panel10.SuspendLayout();
             this.panel9.SuspendLayout();
             this.panel8.SuspendLayout();
@@ -1080,12 +1079,11 @@ namespace QuoteSwift
             // 
             // mtxtRebate
             // 
-            this.mtxtRebate.BeforeTouchSize = new System.Drawing.Size(148, 24);
-            this.mtxtRebate.DoubleValue = 1D;
+            this.mtxtRebate.Value = 1M;
             this.mtxtRebate.Location = new System.Drawing.Point(71, 8);
             this.mtxtRebate.Margin = new System.Windows.Forms.Padding(4);
-            this.mtxtRebate.MaxValue = 5000000D;
-            this.mtxtRebate.MinValue = 0D;
+            this.mtxtRebate.MaxValue = 5000000M;
+            this.mtxtRebate.MinValue = 0M;
             this.mtxtRebate.Name = "mtxtRebate";
             this.mtxtRebate.Size = new System.Drawing.Size(148, 24);
             this.mtxtRebate.TabIndex = 21;
@@ -1335,7 +1333,6 @@ namespace QuoteSwift
             ((System.ComponentModel.ISupportInitialize)(this.dgvMandatoryPartReplacement)).EndInit();
             this.panel6.ResumeLayout(false);
             this.panel6.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mtxtRebate)).EndInit();
             this.panel10.ResumeLayout(false);
             this.panel10.PerformLayout();
             this.panel9.ResumeLayout(false);
@@ -1451,7 +1448,7 @@ namespace QuoteSwift
         private System.Windows.Forms.DataGridViewTextBoxColumn clmUnitPrice;
         private System.Windows.Forms.DataGridViewTextBoxColumn clmTotal;
         private System.Windows.Forms.DataGridViewTextBoxColumn ClmRepairDevider;
-        private Syncfusion.Windows.Forms.Tools.DoubleTextBox mtxtRebate;
+        private QuoteSwift.Controls.NumericTextBox mtxtRebate;
         private System.Windows.Forms.Label lblCustomerSelection;
         private System.Windows.Forms.Label lblCustomerDeliveryAddress;
         private System.Windows.Forms.SaveFileDialog sfdSaveExport;

--- a/frmViewQuotes.Designer.cs
+++ b/frmViewQuotes.Designer.cs
@@ -47,7 +47,7 @@ namespace QuoteSwift
             this.btnCreateNewQuote = new System.Windows.Forms.Button();
             this.btnViewSelectedQuote = new System.Windows.Forms.Button();
             this.btnCreateNewQuoteOnSelection = new System.Windows.Forms.Button();
-            this.dgvPreviousQuotes = new Syncfusion.WinForms.DataGrid.SfDataGrid();
+            this.dgvPreviousQuotes = new System.Windows.Forms.DataGridView();
             this.msQuoteControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgvPreviousQuotes)).BeginInit();
             this.SuspendLayout();
@@ -219,13 +219,14 @@ namespace QuoteSwift
             this.dgvPreviousQuotes.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.dgvPreviousQuotes.AutoSizeColumnsMode = Syncfusion.WinForms.DataGrid.Enums.AutoSizeColumnsMode.AllCells;
+            this.dgvPreviousQuotes.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             this.dgvPreviousQuotes.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
             this.dgvPreviousQuotes.Location = new System.Drawing.Point(12, 84);
             this.dgvPreviousQuotes.Name = "dgvPreviousQuotes";
             this.dgvPreviousQuotes.Size = new System.Drawing.Size(659, 368);
-            this.dgvPreviousQuotes.Style.AddNewRowStyle.Font.Size = 11F;
-            this.dgvPreviousQuotes.SummaryCalculationUnit = Syncfusion.Data.SummaryCalculationUnit.SelectedRows;
+            this.dgvPreviousQuotes.AllowUserToAddRows = false;
+            this.dgvPreviousQuotes.AllowUserToDeleteRows = false;
+            this.dgvPreviousQuotes.ReadOnly = true;
             this.dgvPreviousQuotes.TabIndex = 6;
             this.dgvPreviousQuotes.Text = "Previous Quotes";
             // 
@@ -274,7 +275,7 @@ namespace QuoteSwift
         private System.Windows.Forms.ToolStripMenuItem managePumpPartsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem addNewPartToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem viewAllPartsToolStripMenuItem;
-        private Syncfusion.WinForms.DataGrid.SfDataGrid dgvPreviousQuotes;
+        private System.Windows.Forms.DataGridView dgvPreviousQuotes;
     }
 }
 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -152,10 +152,10 @@ namespace QuoteSwift
 
         private void BtnViewSelectedQuote_Click(object sender, EventArgs e)
         {
-            if (passed != null && passed.PassQuoteMap != null && dgvPreviousQuotes.SelectedItem as Quote != null)
+            if (passed != null && passed.PassQuoteMap != null && dgvPreviousQuotes.SelectedRows.Count > 0)
             {
                 Hide();
-                passed.QuoteTOChange = dgvPreviousQuotes.SelectedItem as Quote;
+                passed.QuoteTOChange = dgvPreviousQuotes.SelectedRows[0].DataBoundItem as Quote;
                 passed.ChangeSpecificObject = false;
                 QuoteSwiftMainCode.CreateNewQuote(ref passed);
                 passed.QuoteTOChange = null;
@@ -166,10 +166,10 @@ namespace QuoteSwift
 
         private void BtnCreateNewQuoteOnSelection_Click(object sender, EventArgs e)
         {
-            if (passed != null && passed.PassQuoteMap != null && dgvPreviousQuotes.SelectedItem as Quote != null)
+            if (passed != null && passed.PassQuoteMap != null && dgvPreviousQuotes.SelectedRows.Count > 0)
             {
                 this.Hide();
-                passed.QuoteTOChange = dgvPreviousQuotes.SelectedItem as Quote;
+                passed.QuoteTOChange = dgvPreviousQuotes.SelectedRows[0].DataBoundItem as Quote;
                 passed.ChangeSpecificObject = true;
                 QuoteSwiftMainCode.CreateNewQuote(ref passed);
                 passed.QuoteTOChange = null;
@@ -274,82 +274,66 @@ namespace QuoteSwift
 
 
                 dgvPreviousQuotes.Columns["QuoteNumber"].HeaderText = "Quote Number";
-                dgvPreviousQuotes.Columns["QuoteNumber"].HeaderStyle.Font.Size = 11;
-                dgvPreviousQuotes.Columns["QuoteNumber"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteNumber"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["QuoteCreationDate"].HeaderText = "Quote Creation Date";
-                dgvPreviousQuotes.Columns["QuoteCreationDate"].HeaderStyle.Font.Size = 11;
-                dgvPreviousQuotes.Columns["QuoteCreationDate"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteCreationDate"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["QuoteExpireyDate"].HeaderText = "Quote Expiry Date";
-                dgvPreviousQuotes.Columns["QuoteExpireyDate"].HeaderStyle.Font.Size = 11;
-                dgvPreviousQuotes.Columns["QuoteExpireyDate"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteExpireyDate"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["QuoteReference"].HeaderText = "Quote Reference";
-                dgvPreviousQuotes.Columns["QuoteReference"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuoteReference"].Visible = false;
 
                 dgvPreviousQuotes.Columns["QuoteJobNumber"].HeaderText = "Quote Job-Number";
-                dgvPreviousQuotes.Columns["QuoteJobNumber"].HeaderStyle.Font.Size = 11;
-                dgvPreviousQuotes.Columns["QuoteJobNumber"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteJobNumber"].ReadOnly = true;
 
 
                 dgvPreviousQuotes.Columns["QuotePRNumber"].HeaderText = "Quote PR-Number";
-                dgvPreviousQuotes.Columns["QuotePRNumber"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuotePRNumber"].Visible = false;
-                dgvPreviousQuotes.Columns["QuotePRNumber"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuotePRNumber"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["QuotePaymentTerm"].HeaderText = "Quote Payment Term";
-                dgvPreviousQuotes.Columns["QuotePaymentTerm"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuotePaymentTerm"].Visible = false;
-                dgvPreviousQuotes.Columns["QuotePaymentTerm"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuotePaymentTerm"].ReadOnly = true;
 
 
                 dgvPreviousQuotes.Columns["QuoteLineNumber"].HeaderText = "Quote Line Number";
-                dgvPreviousQuotes.Columns["QuoteLineNumber"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuoteLineNumber"].Visible = false;
-                dgvPreviousQuotes.Columns["QuoteLineNumber"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteLineNumber"].ReadOnly = true;
 
 
                 dgvPreviousQuotes.Columns["QuoteNewUnitPrice"].HeaderText = "New Pump Unit Price";
-                dgvPreviousQuotes.Columns["QuoteNewUnitPrice"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuoteNewUnitPrice"].Visible = false;
-                dgvPreviousQuotes.Columns["QuoteNewUnitPrice"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteNewUnitPrice"].ReadOnly = true;
 
 
                 dgvPreviousQuotes.Columns["QuoteRepairPercentage"].HeaderText = "Repair Percentage";
-                dgvPreviousQuotes.Columns["QuoteRepairPercentage"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuoteRepairPercentage"].Visible = false;
-                dgvPreviousQuotes.Columns["QuoteRepairPercentage"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["QuoteRepairPercentage"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["QuoteDeliveryAddress"].HeaderText = "Delivery Address";
-                dgvPreviousQuotes.Columns["QuoteDeliveryAddress"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["QuoteDeliveryAddress"].Visible = false;
 
                 dgvPreviousQuotes.Columns["Telefone"].HeaderText = "Telephone";
-                dgvPreviousQuotes.Columns["Telefone"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["Telefone"].Visible = false;
-                dgvPreviousQuotes.Columns["Telefone"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["Telefone"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["Cellphone"].HeaderText = "Cellphone";
-                dgvPreviousQuotes.Columns["Cellphone"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["Cellphone"].Visible = false;
-                dgvPreviousQuotes.Columns["Cellphone"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["Cellphone"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["Email"].HeaderText = "Email";
-                dgvPreviousQuotes.Columns["Email"].HeaderStyle.Font.Size = 11;
-                dgvPreviousQuotes.Columns["Email"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["Email"].ReadOnly = true;
                 dgvPreviousQuotes.Columns["Email"].Visible = false;
 
                 dgvPreviousQuotes.Columns["NetDays"].HeaderText = "Quote Creation Date";
-                dgvPreviousQuotes.Columns["NetDays"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["NetDays"].Visible = false;
-                dgvPreviousQuotes.Columns["NetDays"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["NetDays"].ReadOnly = true;
 
                 dgvPreviousQuotes.Columns["PumpName"].HeaderText = "Quote Number";
-                dgvPreviousQuotes.Columns["PumpName"].HeaderStyle.Font.Size = 11;
                 dgvPreviousQuotes.Columns["PumpName"].Visible = false;
-                dgvPreviousQuotes.Columns["PumpName"].AllowEditing = false;
+                dgvPreviousQuotes.Columns["PumpName"].ReadOnly = true;
 
             }
 


### PR DESCRIPTION
## Summary
- add lightweight `NumericTextBox` control
- switch designer files to use `NumericTextBox`
- replace SfDataGrid with standard `DataGridView`
- adjust logic to use new controls
- include new control in project file

## Testing
- `dotnet build QuoteSwift.sln` *(fails: command not found)*
- `msbuild QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714023e0488325992343112cde6eeb