### PR TITLE
Remove leftover Syncfusion references

### DIFF
--- a/MainProgramLibrary/MainProgramLibrary.csproj
+++ b/MainProgramLibrary/MainProgramLibrary.csproj
@@ -9,36 +9,6 @@
     <Reference Include="Bogus">
       <HintPath>..\QuoteSwift\packages\Bogus.33.0.2\lib\net40\Bogus.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base">
-      <HintPath>..\QuoteSwift\packages\Syncfusion.Compression.Base.18.4.0.43\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.Core.WinForms">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.Core.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.Data.WinForms">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.Data.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.GridCommon.WinForms">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.GridCommon.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.Licensing">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.Licensing.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.SfDataGrid.WinForms">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.SfDataGrid.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.SfInput.WinForms">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.SfInput.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.SfListView.WinForms">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.SfListView.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.Shared.Base">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.Shared.Base.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.XlsIO.Base">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Syncfusion\Essential Studio\Windows\18.4.0.30\Assemblies\4.6\Syncfusion.XlsIO.Base.dll</HintPath>
-    </Reference>
     <Reference Include="System.Memory">
       <HintPath>..\QuoteSwift\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -97,22 +97,6 @@
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
       <HintPath>packages\Swashbuckle.Core.5.6.0\lib\net40\Swashbuckle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Compression.Base, Version=18.4460.0.43, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Compression.Base.18.4.0.43\lib\net46\Syncfusion.Compression.Base.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.Core.WinForms, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.Data.WinForms, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.GridCommon.WinForms, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.Licensing, Version=18.4460.0.43, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.Licensing.18.4.0.43\lib\net46\Syncfusion.Licensing.dll</HintPath>
-    </Reference>
-    <Reference Include="Syncfusion.SfDataGrid.WinForms, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL" />
-    <Reference Include="Syncfusion.SfInput.WinForms, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.SfListView.WinForms, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89" />
-    <Reference Include="Syncfusion.Shared.Base, Version=18.4460.0.30, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL" />
-    <Reference Include="Syncfusion.XlsIO.Base, Version=18.4460.0.43, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>packages\Syncfusion.XlsIO.WinForms.18.4.0.43\lib\net46\Syncfusion.XlsIO.Base.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>


### PR DESCRIPTION
## Summary
- drop Syncfusion references from QuoteSwift.csproj
- drop Syncfusion references from MainProgramLibrary.csproj

## Testing
- `dotnet build QuoteSwift.sln` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687283555e908325aec3e0cfc3f236e7