### PR TITLE
Fix duplicate manifest

### DIFF
--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -299,7 +299,6 @@
     <Content Include="NonMandatoryParts.json" />
     <None Include="app.manifest" />
     <None Include="packages.config" />
-    <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>


### PR DESCRIPTION
## Summary
- remove duplicate `app.manifest` item that made MSBuild receive two manifests

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace not MSBuild 2003)*

------
https://chatgpt.com/codex/tasks/task_e_6873addc4e048325bd8c9e051fb0f2b1