### PR TITLE
Improve grid selection safety

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -121,27 +121,24 @@ namespace QuoteSwift
 
         Address GetAddressSelection()
         {
-            Address SelectedAddress;
-            string SearchName;
-            int iGridSelection = DgvViewAllBusinessAddresses.CurrentCell.RowIndex;
-            try
-            {
-                SearchName = DgvViewAllBusinessAddresses.Rows[iGridSelection].Cells[0].Value.ToString();
-            }
-            catch
-            {
+            if (DgvViewAllBusinessAddresses.CurrentCell == null || DgvViewAllBusinessAddresses.CurrentRow == null)
                 return null;
-            }
+
+            int iGridSelection = DgvViewAllBusinessAddresses.CurrentCell.RowIndex;
+            if (iGridSelection < 0 || iGridSelection >= DgvViewAllBusinessAddresses.Rows.Count)
+                return null;
+
+            string SearchName = DgvViewAllBusinessAddresses.Rows[iGridSelection].Cells[0].Value?.ToString();
+            if (string.IsNullOrEmpty(SearchName))
+                return null;
 
             if (passed != null && passed.BusinessToChange != null && passed.BusinessToChange.BusinessAddressList != null)
             {
-                SelectedAddress = passed.BusinessToChange.BusinessAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-                return SelectedAddress;
+                return passed.BusinessToChange.BusinessAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
             }
             else if (passed != null && passed.CustomerToChange != null && passed.CustomerToChange.CustomerDeliveryAddressList != null)
             {
-                SelectedAddress = passed.CustomerToChange.CustomerDeliveryAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-                return SelectedAddress;
+                return passed.CustomerToChange.CustomerDeliveryAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
             }
 
             return null;

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -111,29 +111,27 @@ namespace QuoteSwift
 
         string GetEmailSelection()
         {
-            string SearchName;
+            if (DgvEmails.CurrentCell == null || DgvEmails.CurrentRow == null)
+                return string.Empty;
+
             int iGridSelection = DgvEmails.CurrentCell.RowIndex;
-            try
-            {
-                SearchName = DgvEmails.Rows[iGridSelection].Cells[0].Value.ToString();
-            }
-            catch
-            {
-                return "";
-            }
+            if (iGridSelection < 0 || iGridSelection >= DgvEmails.Rows.Count)
+                return string.Empty;
+
+            string SearchName = DgvEmails.Rows[iGridSelection].Cells[0].Value?.ToString();
+            if (string.IsNullOrEmpty(SearchName))
+                return string.Empty;
 
             if (passed.BusinessToChange != null && passed.BusinessToChange.BusinessEmailAddressList != null)
             {
-                SearchName = passed.BusinessToChange.BusinessEmailAddressList.SingleOrDefault(p => p == SearchName);
-                return SearchName;
+                return passed.BusinessToChange.BusinessEmailAddressList.SingleOrDefault(p => p == SearchName) ?? string.Empty;
             }
             else if (passed.CustomerToChange != null && passed.CustomerToChange.CustomerEmailList != null)
             {
-                SearchName = passed.CustomerToChange.CustomerEmailList.SingleOrDefault(p => p == SearchName);
-                return SearchName;
+                return passed.CustomerToChange.CustomerEmailList.SingleOrDefault(p => p == SearchName) ?? string.Empty;
             }
 
-            return "";
+            return string.Empty;
         }
 
         private void LoadInformation()

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -188,24 +188,23 @@ namespace QuoteSwift
 
         string GetNumberSelection(BindingList<string> b, ref DataGridView d)
         {
-            string SearchName;
+            if (d == null || d.CurrentCell == null || d.CurrentRow == null)
+                return string.Empty;
+
             int iGridSelection = d.CurrentCell.RowIndex;
-            try
-            {
-                SearchName = d.Rows[iGridSelection].Cells[0].Value.ToString();
-            }
-            catch
-            {
-                return "";
-            }
+            if (iGridSelection < 0 || iGridSelection >= d.Rows.Count)
+                return string.Empty;
+
+            string SearchName = d.Rows[iGridSelection].Cells[0].Value?.ToString();
+            if (string.IsNullOrEmpty(SearchName))
+                return string.Empty;
 
             if (b != null)
             {
-                SearchName = b.SingleOrDefault(p => p == SearchName);
-                return SearchName;
+                return b.SingleOrDefault(p => p == SearchName) ?? string.Empty;
             }
 
-            return "";
+            return SearchName;
         }
 
         private void LoadInformation()

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -100,19 +100,18 @@ namespace QuoteSwift
 
         private Business GetBusinessSelection()
         {
-            string searchName;
-            int iGridSelection;
-            try
-            {
-                iGridSelection = DgvBusinessList.CurrentCell.RowIndex;
-                searchName = DgvBusinessList.Rows[iGridSelection].Cells[0].Value.ToString();
-            }
-            catch
-            {
+            if (DgvBusinessList.CurrentCell == null || DgvBusinessList.CurrentRow == null)
                 return null;
-            }
 
-            if (passed.BusinessLookup.TryGetValue(searchName, out Business business))
+            int iGridSelection = DgvBusinessList.CurrentCell.RowIndex;
+            if (iGridSelection < 0 || iGridSelection >= DgvBusinessList.Rows.Count)
+                return null;
+
+            string searchName = DgvBusinessList.Rows[iGridSelection].Cells[0].Value?.ToString();
+            if (string.IsNullOrEmpty(searchName))
+                return null;
+
+            if (passed.BusinessLookup != null && passed.BusinessLookup.TryGetValue(searchName, out Business business))
             {
                 return business;
             }

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -157,24 +157,20 @@ namespace QuoteSwift
 
         private Customer GetCustomerSelection()
         {
-            Customer customer;
-            string SearchName;
-            int iGridSelection;
-            try
-            {
-                iGridSelection = DgvCustomerList.CurrentCell.RowIndex;
-                SearchName = DgvCustomerList.Rows[iGridSelection].Cells[0].Value.ToString();
-            }
-            catch
-            {
+            if (DgvCustomerList.CurrentCell == null || DgvCustomerList.CurrentRow == null)
                 return null;
-            }
 
-            if (GetSelectedBusiness() != null)
-            {
-                if (GetSelectedBusiness().CustomerMap.TryGetValue(SearchName, out customer))
-                    return customer;
-            }
+            int iGridSelection = DgvCustomerList.CurrentCell.RowIndex;
+            if (iGridSelection < 0 || iGridSelection >= DgvCustomerList.Rows.Count)
+                return null;
+
+            string SearchName = DgvCustomerList.Rows[iGridSelection].Cells[0].Value?.ToString();
+            if (string.IsNullOrEmpty(SearchName))
+                return null;
+
+            Business selected = GetSelectedBusiness();
+            if (selected != null && selected.CustomerMap != null && selected.CustomerMap.TryGetValue(SearchName, out Customer customer))
+                return customer;
 
             return null;
         }

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -122,27 +122,24 @@ namespace QuoteSwift
 
         Address GetAddressSelection()
         {
-            Address SelectedAddress;
-            string SearchName;
-            int iGridSelection = dgvPOBoxAddresses.CurrentCell.RowIndex;
-            try
-            {
-                SearchName = dgvPOBoxAddresses.Rows[iGridSelection].Cells[0].Value.ToString();
-            }
-            catch
-            {
+            if (dgvPOBoxAddresses.CurrentCell == null || dgvPOBoxAddresses.CurrentRow == null)
                 return null;
-            }
+
+            int iGridSelection = dgvPOBoxAddresses.CurrentCell.RowIndex;
+            if (iGridSelection < 0 || iGridSelection >= dgvPOBoxAddresses.Rows.Count)
+                return null;
+
+            string SearchName = dgvPOBoxAddresses.Rows[iGridSelection].Cells[0].Value?.ToString();
+            if (string.IsNullOrEmpty(SearchName))
+                return null;
 
             if (passed != null && passed.BusinessToChange != null && passed.BusinessToChange.BusinessPOBoxAddressList != null)
             {
-                SelectedAddress = passed.BusinessToChange.BusinessPOBoxAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-                return SelectedAddress;
+                return passed.BusinessToChange.BusinessPOBoxAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
             }
             else if (passed != null && passed.CustomerToChange != null && passed.CustomerToChange.CustomerPOBoxAddress != null)
             {
-                SelectedAddress = passed.CustomerToChange.CustomerPOBoxAddress.SingleOrDefault(p => p.AddressDescription == SearchName);
-                return SelectedAddress;
+                return passed.CustomerToChange.CustomerPOBoxAddress.SingleOrDefault(p => p.AddressDescription == SearchName);
             }
 
             return null;

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -135,35 +135,27 @@ namespace QuoteSwift
 
         Part GetSelectedPart()
         {
-            Part SelectedPart;
-            string SearchName;
-            int iGridSelection = 0;
-            try
-            {
-                iGridSelection = dgvAllParts.CurrentCell.RowIndex;
-                SearchName = dgvAllParts.Rows[iGridSelection].Cells[2].Value.ToString();
-            }
-            catch (NullReferenceException)
-            {
+            if (dgvAllParts.CurrentCell == null || dgvAllParts.CurrentRow == null)
                 return null;
-            }
 
+            int iGridSelection = dgvAllParts.CurrentCell.RowIndex;
+            if (iGridSelection < 0 || iGridSelection >= dgvAllParts.Rows.Count)
+                return null;
+
+            string SearchName = dgvAllParts.Rows[iGridSelection].Cells[2].Value?.ToString();
+            if (string.IsNullOrEmpty(SearchName))
+                return null;
 
             if (passed.PassMandatoryPartList.Count > 0 || passed.PassNonMandatoryPartList.Count > 0 || passed != null || passed.PassMandatoryPartList != null || passed.PassNonMandatoryPartList != null)
             {
-
                 if ((bool)(dgvAllParts.Rows[iGridSelection].Cells[4].Value) == true)
                 {
                     //Search for part in mandatory
-
-                    SelectedPart = passed.PassMandatoryPartList.SingleOrDefault(p => p.OriginalItemPartNumber == SearchName);
-                    return SelectedPart;
-
+                    return passed.PassMandatoryPartList.SingleOrDefault(p => p.OriginalItemPartNumber == SearchName);
                 }
                 else // Search in Non-Mandatory
                 {
-                    SelectedPart = passed.PassNonMandatoryPartList.SingleOrDefault(p => p.OriginalItemPartNumber == SearchName);
-                    return SelectedPart;
+                    return passed.PassNonMandatoryPartList.SingleOrDefault(p => p.OriginalItemPartNumber == SearchName);
                 }
             }
 


### PR DESCRIPTION
## Summary
- check grid CurrentCell and row index in selection helpers
- return null/empty when no valid grid selection

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fca2c8c48325b2403082b1f66ce4