### PR TITLE
Fix address duplication checks

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -108,19 +108,24 @@ namespace QuoteSwift
 
         private bool AddressExists(Address a)
         {
-            if (passed != null && passed.BusinessToChange != null && passed.BusinessToChange.BusinessPOBoxAddressList != null)
-                if (passed.BusinessToChange.BusinessPOBoxAddressList != null && a != null)
-                    foreach (var address in passed.BusinessToChange.BusinessPOBoxAddressList)
-                    {
-                        if (address.AddressDescription == a.AddressDescription && address.AddressDescription != passed.AddressToChange.AddressDescription) return false;
-                    }
+            if (a == null) return false;
 
-            if (passed != null && passed.CustomerToChange != null && passed.CustomerToChange.CustomerPOBoxAddress != null)
-                if (passed.CustomerToChange.CustomerPOBoxAddress != null && a != null)
-                    foreach (var address in passed.CustomerToChange.CustomerPOBoxAddress)
-                    {
-                        if (address.AddressDescription == a.AddressDescription && address.AddressDescription != passed.AddressToChange.AddressDescription) return false;
-                    }
+            string key = StringUtil.NormalizeKey(a.AddressDescription);
+
+            if (passed?.BusinessToChange != null &&
+                passed.BusinessToChange.AddressMap.TryGetValue(key, out Address existingB))
+            {
+                if (!ReferenceEquals(existingB, passed.AddressToChange))
+                    return true;
+            }
+
+            if (passed?.CustomerToChange != null &&
+                passed.CustomerToChange.DeliveryAddressMap.TryGetValue(key, out Address existingC))
+            {
+                if (!ReferenceEquals(existingC, passed.AddressToChange))
+                    return true;
+            }
+
             return false;
         }
 

--- a/MainProgramLibrary/Business.cs
+++ b/MainProgramLibrary/Business.cs
@@ -84,12 +84,12 @@ namespace QuoteSwift
             mAddressMap = new Dictionary<string, Address>();
             if (mBusinessAddressList != null)
                 foreach (var a in mBusinessAddressList)
-                    mAddressMap[a.AddressDescription] = a;
+                    mAddressMap[StringUtil.NormalizeKey(a.AddressDescription)] = a;
 
             mPOBoxMap = new Dictionary<string, Address>();
             if (mBusinessPOBoxAddressList != null)
                 foreach (var a in mBusinessPOBoxAddressList)
-                    mPOBoxMap[a.AddressDescription] = a;
+                    mPOBoxMap[StringUtil.NormalizeKey(a.AddressDescription)] = a;
 
             mTelephoneNumbers = new HashSet<string>(mBusinessTelephoneNumberList ?? new BindingList<string>());
             mCellphoneNumbers = new HashSet<string>(mBusinessCellphoneNumberList ?? new BindingList<string>());
@@ -112,7 +112,7 @@ namespace QuoteSwift
                 mAddressMap?.Clear();
                 if (mBusinessAddressList != null)
                     foreach (var a in mBusinessAddressList)
-                        mAddressMap[a.AddressDescription] = a;
+                        mAddressMap[StringUtil.NormalizeKey(a.AddressDescription)] = a;
             }
         }
         public BindingList<Address> BusinessPOBoxAddressList
@@ -124,7 +124,7 @@ namespace QuoteSwift
                 mPOBoxMap?.Clear();
                 if (mBusinessPOBoxAddressList != null)
                     foreach (var a in mBusinessPOBoxAddressList)
-                        mPOBoxMap[a.AddressDescription] = a;
+                        mPOBoxMap[StringUtil.NormalizeKey(a.AddressDescription)] = a;
             }
         }
         public Legal BusinessLegalDetails { get => mBusinessLegalDetails; set => mBusinessLegalDetails = value; }

--- a/MainProgramLibrary/Customer.cs
+++ b/MainProgramLibrary/Customer.cs
@@ -77,7 +77,7 @@ namespace QuoteSwift
                 mPOBoxMap?.Clear();
                 if (mCustomerPOBoxAddress != null)
                     foreach (var a in mCustomerPOBoxAddress)
-                        mPOBoxMap[a.AddressDescription] = a;
+                        mPOBoxMap[StringUtil.NormalizeKey(a.AddressDescription)] = a;
             }
         }
         public BindingList<Address> CustomerDeliveryAddressList
@@ -89,7 +89,7 @@ namespace QuoteSwift
                 mDeliveryAddressMap?.Clear();
                 if (mCustomerDeliveryAddressList != null)
                     foreach (var a in mCustomerDeliveryAddressList)
-                        mDeliveryAddressMap[a.AddressDescription] = a;
+                        mDeliveryAddressMap[StringUtil.NormalizeKey(a.AddressDescription)] = a;
             }
         }
         public Legal CustomerLegalDetails { get => mCustomerLegalDetails; set => mCustomerLegalDetails = value; }

--- a/MainProgramLibrary/StringUtil.cs
+++ b/MainProgramLibrary/StringUtil.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+
+namespace QuoteSwift
+{
+    public static class StringUtil
+    {
+        public static string NormalizeKey(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return string.Empty;
+            string trimmed = input.Trim();
+            string singleSpaced = Regex.Replace(trimmed, "\s+", " ");
+            return singleSpaced.ToUpperInvariant();
+        }
+    }
+}

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -99,7 +99,7 @@ namespace QuoteSwift
                     Business.BusinessPOBoxAddressList.Add(address);
                     MainProgramCode.ShowInformation("Successfully added the business P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
 
-                    Business.POBoxMap[address.AddressDescription] = address;
+                    Business.POBoxMap[StringUtil.NormalizeKey(address.AddressDescription)] = address;
 
                     ClearPOBoxAddressInput();
                 }
@@ -115,7 +115,7 @@ namespace QuoteSwift
                 if (!AddressExisting(address))
                 {
                     Business.BusinessAddressList.Add(address);
-                    Business.AddressMap[address.AddressDescription] = address;
+                    Business.AddressMap[StringUtil.NormalizeKey(address.AddressDescription)] = address;
                     MainProgramCode.ShowInformation("Successfully added the business address", "INFORMATION - Business Address Added Successfully");
 
                     ClearBusinessAddressInput();
@@ -455,7 +455,8 @@ namespace QuoteSwift
 
         public bool AddressExisting(Address a)
         {
-            if (Business.AddressMap.ContainsKey(a.AddressDescription))
+            string key = StringUtil.NormalizeKey(a.AddressDescription);
+            if (Business.AddressMap.ContainsKey(key))
             {
                 MainProgramCode.ShowError("This address has already been added previously.\nHINT: Description should be unique", "ERROR - Address Already Added");
                 return true;
@@ -466,7 +467,8 @@ namespace QuoteSwift
 
         private bool POBoxAddressExisting(Address a)
         {
-            if (Business.POBoxMap.ContainsKey(a.AddressDescription))
+            string key = StringUtil.NormalizeKey(a.AddressDescription);
+            if (Business.POBoxMap.ContainsKey(key))
             {
                 MainProgramCode.ShowError("This P.O.Box address has already been added previously.\nHINT: Description should be unique", "ERROR - P.O.Box Address Already Added");
                 return true;

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -120,7 +120,7 @@ namespace QuoteSwift
                     {
                         Customer.CustomerDeliveryAddressList.Add(address);
                     }
-                    Customer.DeliveryAddressMap[address.AddressDescription] = address;
+                    Customer.DeliveryAddressMap[StringUtil.NormalizeKey(address.AddressDescription)] = address;
                     MainProgramCode.ShowInformation("Successfully added the customer address", "INFORMATION - Customer Address Added Successfully");
 
                     ClearCustomerAddressInput();
@@ -137,7 +137,7 @@ namespace QuoteSwift
                 if (!POBoxAddressExisting(address))
                 {
                     Customer.CustomerPOBoxAddress.Add(address);
-                    Customer.POBoxMap[address.AddressDescription] = address;
+                    Customer.POBoxMap[StringUtil.NormalizeKey(address.AddressDescription)] = address;
                     MainProgramCode.ShowInformation("Successfully added the customer P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
 
                     ClearPOBoxAddressInput();
@@ -442,7 +442,8 @@ namespace QuoteSwift
 
         public bool AddressExisting(Address a)
         {
-            if (Customer.DeliveryAddressMap.ContainsKey(a.AddressDescription))
+            string key = StringUtil.NormalizeKey(a.AddressDescription);
+            if (Customer.DeliveryAddressMap.ContainsKey(key))
             {
                 MainProgramCode.ShowError("This address has already been added previously.\nHINT: Description should be unique", "ERROR - Address Already Added");
                 return true;
@@ -453,7 +454,8 @@ namespace QuoteSwift
 
         private bool POBoxAddressExisting(Address a)
         {
-            if (Customer.POBoxMap.ContainsKey(a.AddressDescription))
+            string key = StringUtil.NormalizeKey(a.AddressDescription);
+            if (Customer.POBoxMap.ContainsKey(key))
             {
                 MainProgramCode.ShowError("This P.O.Box address has already been added previously.\nHINT: Description should be unique", "ERROR - P.O.Box Address Already Added");
                 return true;


### PR DESCRIPTION
## Summary
- normalize strings via `StringUtil.NormalizeKey`
- store address keys in dictionaries using normalized descriptions
- detect duplicates correctly in `AddressExists`
- use normalized keys when adding/updating addresses

## Testing
- `dotnet build QuoteSwift.sln` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc7cb4a88325bc2320e601df42f6