### PR TITLE
Add duplicate check when updating customer name

### DIFF
--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -68,6 +68,14 @@ namespace QuoteSwift
                 Business container = GetSelectedBusiness();
                 if (container != null)
                 {
+                    if (container.CustomerMap.TryGetValue(passed.CustomerToChange.CustomerCompanyName, out Customer existing)
+                        && existing != passed.CustomerToChange)
+                    {
+                        MainProgramCode.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
+                        passed.CustomerToChange.CustomerCompanyName = oldName;
+                        return;
+                    }
+
                     container.CustomerMap.Remove(oldName);
                     container.CustomerMap[passed.CustomerToChange.CustomerCompanyName] = passed.CustomerToChange;
                 }

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -143,6 +143,13 @@ namespace QuoteSwift
         private bool ReplaceCustomer(Customer Original, Customer New, Business Container)
         {
             if (New != null && Original != null && Container != null && Container.BusinessCustomerList != null)
+            {
+                if (Container.CustomerMap.TryGetValue(New.CustomerCompanyName, out Customer existing) && existing != Original)
+                {
+                    MainProgramCode.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
+                    return false;
+                }
+
                 for (int i = 0; i < Container.BusinessCustomerList.Count; i++)
                     if (Container.BusinessCustomerList[i] == Original)
                     {
@@ -151,6 +158,7 @@ namespace QuoteSwift
                         Container.CustomerMap[New.CustomerCompanyName] = New;
                         return true;
                     }
+            }
 
             return false;
         }


### PR DESCRIPTION
## Summary
- prevent duplicate company names when editing customers in `frmAddCustomer`
- validate uniqueness of customer names during replace in `frmViewCustomers`

## Testing
- `dotnet build QuoteSwift.sln -c Release` *(fails: .NET Framework 4.8 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873fcd875688325a448688bf3702d71