### PR TITLE
Remove unused CustomerVendorNumber field

### DIFF
--- a/MainProgramLibrary/Customer.cs
+++ b/MainProgramLibrary/Customer.cs
@@ -10,7 +10,6 @@ namespace QuoteSwift
         private BindingList<Address> mCustomerPOBoxAddress;
         private BindingList<Address> mCustomerDeliveryAddressList;
         private Legal mCustomerLegalDetails;
-        private string mCustomerVendorNumber;
         private BindingList<string> mCustomerTelephoneNumberList;
         private BindingList<string> mCustomerCellphoneNumberList;
         private BindingList<string> mCustomerEmailList;
@@ -31,7 +30,6 @@ namespace QuoteSwift
             CustomerPOBoxAddress = new BindingList<Address>();
             CustomerDeliveryAddressList = new BindingList<Address>();
             CustomerLegalDetails = null;
-            CustomerVendorNumber = "";
             CustomerTelephoneNumberList = new BindingList<string>();
             CustomerCellphoneNumberList = new BindingList<string>();
             CustomerEmailList = new BindingList<string>();
@@ -52,7 +50,6 @@ namespace QuoteSwift
             CustomerPOBoxAddress = c.CustomerPOBoxAddress;
             CustomerDeliveryAddressList = c.CustomerDeliveryAddressList;
             CustomerLegalDetails = c.CustomerLegalDetails;
-            CustomerVendorNumber = c.CustomerVendorNumber;
             CustomerTelephoneNumberList = c.CustomerTelephoneNumberList;
             CustomerCellphoneNumberList = c.CustomerCellphoneNumberList;
             CustomerEmailList = c.CustomerEmailList;
@@ -93,7 +90,6 @@ namespace QuoteSwift
             }
         }
         public Legal CustomerLegalDetails { get => mCustomerLegalDetails; set => mCustomerLegalDetails = value; }
-        public string CustomerVendorNumber { get => mCustomerVendorNumber; set => mCustomerVendorNumber = value; }
         public BindingList<string> CustomerTelephoneNumberList
         {
             get => mCustomerTelephoneNumberList;


### PR DESCRIPTION
## Summary
- drop `mCustomerVendorNumber` field and related property
- ensure constructors only use `VendorNumber`
- verified JSON serialization/deserialization still succeeds

## Testing
- `dotnet build` *(fails: reference assemblies for .NETFramework v4.8 not found)*
- compiled Customer class in a temporary .NET project and ran a small serialization test

------
https://chatgpt.com/codex/tasks/task_e_6873fcee13cc8325adb36f01401aea24