### PR TITLE
Fix null check when adding PO box address

### DIFF
--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -152,6 +152,8 @@ namespace QuoteSwift
                                               "", txtPOBoxSuburb.Text, txtPOBoxCity.Text, QuoteSwiftMainCode.ParseInt(mtxtPOBoxAreaCode.Text));
                 if (!POBoxAddressExisting(address))
                 {
+                    if (Customer.CustomerPOBoxAddress == null)
+                        Customer.CustomerPOBoxAddress = new BindingList<Address>();
                     Customer.CustomerPOBoxAddress.Add(address);
                     Customer.POBoxMap[StringUtil.NormalizeKey(address.AddressDescription)] = address;
                     MainProgramCode.ShowInformation("Successfully added the customer P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");


### PR DESCRIPTION
## Summary
- ensure `Customer.CustomerPOBoxAddress` is initialised before adding an address

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: could not resolve references)*

------
https://chatgpt.com/codex/tasks/task_e_68740623d57c8325b4ac9696bf9ed0d9