### PR TITLE
Fix P.O. box list initialization

### DIFF
--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -96,6 +96,8 @@ namespace QuoteSwift
                                               "", txtPOBoxSuburb.Text, txtPOBoxCity.Text, QuoteSwiftMainCode.ParseInt(mtxtPOBoxAreaCode.Text));
                 if (!POBoxAddressExisting(address))
                 {
+                    if (Business.BusinessPOBoxAddressList == null)
+                        Business.BusinessPOBoxAddressList = new BindingList<Address>();
                     Business.BusinessPOBoxAddressList.Add(address);
                     MainProgramCode.ShowInformation("Successfully added the business P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
 


### PR DESCRIPTION
## Summary
- ensure `BusinessPOBoxAddressList` is initialized when adding a PO box address
- run `msbuild QuoteSwift.sln` *(fails: command not found)*

## Testing
- `msbuild QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740627aed88325ba0272fcfee7105a