### PR TITLE
Remove unused SetNewNumber method

### DIFF
--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -246,41 +246,6 @@ namespace QuoteSwift
             }
         }
 
-        private void SetNewNumber(string OldNumber, string NewNumber, BindingList<string> b)
-        {
-            if (b == null)
-                return;
-
-            // select the lookup collection maintained by the underlying object
-            HashSet<string> lookup = null;
-            if (passed.BusinessToChange != null)
-            {
-                if (ReferenceEquals(b, passed.BusinessToChange.BusinessTelephoneNumberList))
-                    lookup = passed.BusinessToChange.TelephoneNumbers;
-                else if (ReferenceEquals(b, passed.BusinessToChange.BusinessCellphoneNumberList))
-                    lookup = passed.BusinessToChange.CellphoneNumbers;
-            }
-            else if (passed.CustomerToChange != null)
-            {
-                if (ReferenceEquals(b, passed.CustomerToChange.CustomerTelephoneNumberList))
-                    lookup = passed.CustomerToChange.TelephoneNumbers;
-                else if (ReferenceEquals(b, passed.CustomerToChange.CustomerCellphoneNumberList))
-                    lookup = passed.CustomerToChange.CellphoneNumbers;
-            }
-
-            foreach (var number in b.ToList())
-            {
-                if (number == OldNumber)
-                {
-                    int index = b.IndexOf(number);
-                    if (index >= 0)
-                        b[index] = NewNumber;
-                    lookup?.Remove(OldNumber);
-                    lookup?.Add(NewNumber);
-                    break;
-                }
-            }
-        }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- remove the unused `SetNewNumber` helper from *frmManagingPhoneNumbers.cs*

## Testing
- `dotnet msbuild QuoteSwift.sln` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874062c64b08325a4ffcc4d2ceebed9