### PR TITLE
Switch part lists to dictionaries

### DIFF
--- a/MainProgramLibrary/MainProgramCode.cs
+++ b/MainProgramLibrary/MainProgramCode.cs
@@ -151,12 +151,12 @@ namespace QuoteSwift
 
         //Serialize Part list:
 
-        public static byte[] SerializePartList(BindingList<Part> PartList)
+        public static byte[] SerializePartList(Dictionary<string, Part> PartList)
         {
             byte[] tempByte;
             try
             {
-                tempByte = MainProgramCode.JsonSerialize<BindingList<Part>>(PartList);
+                tempByte = MainProgramCode.JsonSerialize<Dictionary<string, Part>>(PartList);
             }
             catch
             {
@@ -168,11 +168,11 @@ namespace QuoteSwift
 
         //De-serialize Part list:
 
-        public static BindingList<Part> DeserializePartList(byte[] tempByte)
+        public static Dictionary<string, Part> DeserializePartList(byte[] tempByte)
         {
             try
             {
-                return MainProgramCode.JsonDeserialize<BindingList<Part>>(tempByte);
+                return MainProgramCode.JsonDeserialize<Dictionary<string, Part>>(tempByte);
             }
             catch
             {

--- a/MainProgramLibrary/Pass.cs
+++ b/MainProgramLibrary/Pass.cs
@@ -9,8 +9,12 @@ namespace QuoteSwift
         private SortedDictionary<string, Quote> mPassQuoteMap;
         private BindingList<Business> mPassBusinessList;
         private BindingList<Pump> mPassPumpList;
-        private BindingList<Part> mPassMandatoryPartList;
-        private BindingList<Part> mPassNonMandatoryPartList;
+        // dictionaries for parts keyed by original part number
+        private Dictionary<string, Part> mPassMandatoryPartList;
+        private Dictionary<string, Part> mPassNonMandatoryPartList;
+        // lookup dictionaries for part new numbers
+        private Dictionary<string, Part> mMandatoryNewPartMap = new Dictionary<string, Part>();
+        private Dictionary<string, Part> mNonMandatoryNewPartMap = new Dictionary<string, Part>();
 
         // lookup collections for businesses
         private Dictionary<string, Business> mBusinessLookup = new Dictionary<string, Business>();
@@ -29,7 +33,7 @@ namespace QuoteSwift
 
         //Pass All Constructor :
 
-        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, Dictionary<string, Part> mPassMandatoryPartList, Dictionary<string, Part> mPassNonMandatoryPartList)
         {
             PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
@@ -40,7 +44,7 @@ namespace QuoteSwift
 
         //Pass Quote Constructor:
 
-        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Quote mQuoteTOChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, Dictionary<string, Part> mPassMandatoryPartList, Dictionary<string, Part> mPassNonMandatoryPartList, ref Quote mQuoteTOChange, bool mChangeSpecificObject = false)
         {
             PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
@@ -53,7 +57,7 @@ namespace QuoteSwift
 
         //Pass Business Constructor:
 
-        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Business mBusinessToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, Dictionary<string, Part> mPassMandatoryPartList, Dictionary<string, Part> mPassNonMandatoryPartList, ref Business mBusinessToChange, bool mChangeSpecificObject = false)
         {
             PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
@@ -66,7 +70,7 @@ namespace QuoteSwift
 
         //Pass Customer Constructor:
 
-        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Customer mCustomerToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, Dictionary<string, Part> mPassMandatoryPartList, Dictionary<string, Part> mPassNonMandatoryPartList, ref Customer mCustomerToChange, bool mChangeSpecificObject = false)
         {
             PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
@@ -79,7 +83,7 @@ namespace QuoteSwift
 
         //Pass Pump Constructor:
 
-        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Pump mPumpToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, Dictionary<string, Part> mPassMandatoryPartList, Dictionary<string, Part> mPassNonMandatoryPartList, ref Pump mPumpToChange, bool mChangeSpecificObject = false)
         {
             PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
@@ -92,7 +96,7 @@ namespace QuoteSwift
 
         //Pass Part Constructor:
 
-        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, BindingList<Part> mPassMandatoryPartList, BindingList<Part> mPassNonMandatoryPartList, ref Part mPartToChange, bool mChangeSpecificObject = false)
+        public Pass(SortedDictionary<string, Quote> quoteMap, BindingList<Business> mPassBusinessList, BindingList<Pump> mPassPumpList, Dictionary<string, Part> mPassMandatoryPartList, Dictionary<string, Part> mPassNonMandatoryPartList, ref Part mPartToChange, bool mChangeSpecificObject = false)
         {
             PassQuoteMap = quoteMap;
             PassBusinessList = mPassBusinessList;
@@ -121,8 +125,24 @@ namespace QuoteSwift
         public bool ChangeSpecificObject { get => mChangeSpecificObject; set => mChangeSpecificObject = value; }
         public Pump PumpToChange { get => mPumpToChange; set => mPumpToChange = value; }
         public Part PartToChange { get => mPartToChange; set => mPartToChange = value; }
-        public BindingList<Part> PassMandatoryPartList { get => mPassMandatoryPartList; set => mPassMandatoryPartList = value; }
-        public BindingList<Part> PassNonMandatoryPartList { get => mPassNonMandatoryPartList; set => mPassNonMandatoryPartList = value; }
+        public Dictionary<string, Part> PassMandatoryPartList
+        {
+            get => mPassMandatoryPartList;
+            set
+            {
+                mPassMandatoryPartList = value;
+                SyncMandatoryPartLookup();
+            }
+        }
+        public Dictionary<string, Part> PassNonMandatoryPartList
+        {
+            get => mPassNonMandatoryPartList;
+            set
+            {
+                mPassNonMandatoryPartList = value;
+                SyncNonMandatoryPartLookup();
+            }
+        }
         public Address AddressToChange { get => mAddressToChange; set => mAddressToChange = value; }
         public string EmailToChange { get => mEmailToChange; set => mEmailToChange = value; }
         public string PhoneNumberToChange { get => mPhoneNumberToChange; set => mPhoneNumberToChange = value; }
@@ -146,6 +166,68 @@ namespace QuoteSwift
                     mBusinessRegNumbers.Add(b.BusinessLegalDetails?.RegistrationNumber);
                 }
             }
+        }
+
+        private void SyncMandatoryPartLookup()
+        {
+            mMandatoryNewPartMap.Clear();
+            if (mPassMandatoryPartList != null)
+            {
+                foreach (var p in mPassMandatoryPartList.Values)
+                    mMandatoryNewPartMap[StringUtil.NormalizeKey(p.NewPartNumber)] = p;
+            }
+        }
+
+        private void SyncNonMandatoryPartLookup()
+        {
+            mNonMandatoryNewPartMap.Clear();
+            if (mPassNonMandatoryPartList != null)
+            {
+                foreach (var p in mPassNonMandatoryPartList.Values)
+                    mNonMandatoryNewPartMap[StringUtil.NormalizeKey(p.NewPartNumber)] = p;
+            }
+        }
+
+        public void AddMandatoryPart(Part part)
+        {
+            if (part == null) return;
+            if (mPassMandatoryPartList == null) mPassMandatoryPartList = new Dictionary<string, Part>();
+            string origKey = StringUtil.NormalizeKey(part.OriginalItemPartNumber);
+            mPassMandatoryPartList[origKey] = part;
+            mMandatoryNewPartMap[StringUtil.NormalizeKey(part.NewPartNumber)] = part;
+        }
+
+        public void RemoveMandatoryPart(Part part)
+        {
+            if (part == null || mPassMandatoryPartList == null) return;
+            mPassMandatoryPartList.Remove(StringUtil.NormalizeKey(part.OriginalItemPartNumber));
+            mMandatoryNewPartMap.Remove(StringUtil.NormalizeKey(part.NewPartNumber));
+        }
+
+        public bool TryGetMandatoryPartByNew(string newNumber, out Part part)
+        {
+            return mMandatoryNewPartMap.TryGetValue(StringUtil.NormalizeKey(newNumber), out part);
+        }
+
+        public void AddNonMandatoryPart(Part part)
+        {
+            if (part == null) return;
+            if (mPassNonMandatoryPartList == null) mPassNonMandatoryPartList = new Dictionary<string, Part>();
+            string origKey = StringUtil.NormalizeKey(part.OriginalItemPartNumber);
+            mPassNonMandatoryPartList[origKey] = part;
+            mNonMandatoryNewPartMap[StringUtil.NormalizeKey(part.NewPartNumber)] = part;
+        }
+
+        public void RemoveNonMandatoryPart(Part part)
+        {
+            if (part == null || mPassNonMandatoryPartList == null) return;
+            mPassNonMandatoryPartList.Remove(StringUtil.NormalizeKey(part.OriginalItemPartNumber));
+            mNonMandatoryNewPartMap.Remove(StringUtil.NormalizeKey(part.NewPartNumber));
+        }
+
+        public bool TryGetNonMandatoryPartByNew(string newNumber, out Part part)
+        {
+            return mNonMandatoryNewPartMap.TryGetValue(StringUtil.NormalizeKey(newNumber), out part);
         }
     }
 }

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
+using System.Collections.Generic;
 
 namespace QuoteSwift
 {
@@ -187,7 +188,7 @@ namespace QuoteSwift
             mtxtPumpName.Text = passed.PumpToChange.PumpName;
 
             int mIndex = 0;
-            foreach (var part in passed.PassMandatoryPartList)
+            foreach (var part in passed.PassMandatoryPartList.Values)
             {
                 foreach (var pumpPart in passed.PumpToChange.PartList)
                 {
@@ -202,7 +203,7 @@ namespace QuoteSwift
             }
 
             int nmIndex = 0;
-            foreach (var part in passed.PassNonMandatoryPartList)
+            foreach (var part in passed.PassNonMandatoryPartList.Values)
             {
                 foreach (var pumpPart in passed.PumpToChange.PartList)
                 {
@@ -260,8 +261,12 @@ namespace QuoteSwift
                     {
                         try
                         {
-                            newPart = new Pump_Part(passed.PassMandatoryPartList[mPartIndex],
-                                QuoteSwiftMainCode.ParseInt(row.Cells["clmMPartQuantity"].Value.ToString()));
+                            string oKey = row.Cells["clmOriginalPartNumber"].Value?.ToString();
+                            if (passed.PassMandatoryPartList.TryGetValue(StringUtil.NormalizeKey(oKey), out var part))
+                                newPart = new Pump_Part(part,
+                                    QuoteSwiftMainCode.ParseInt(row.Cells["clmMPartQuantity"].Value.ToString()));
+                            else
+                                newPart = null;
                         }
                         catch
                         {
@@ -290,8 +295,12 @@ namespace QuoteSwift
                     {
                         try
                         {
-                            newPart = new Pump_Part(passed.PassNonMandatoryPartList[nmPartIndex],
-                                QuoteSwiftMainCode.ParseInt(row.Cells["clmNMPartQuantity"].Value.ToString()));
+                            string oKey = row.Cells["clmOriginalPartNumber"].Value?.ToString();
+                            if (passed.PassNonMandatoryPartList.TryGetValue(StringUtil.NormalizeKey(oKey), out var part))
+                                newPart = new Pump_Part(part,
+                                    QuoteSwiftMainCode.ParseInt(row.Cells["clmNMPartQuantity"].Value.ToString()));
+                            else
+                                newPart = null;
                         }
                         catch
                         {
@@ -348,7 +357,7 @@ namespace QuoteSwift
             {
                 dgvMandatoryPartView.Rows.Clear();
 
-                foreach (var part in passed.PassMandatoryPartList)
+                foreach (var part in passed.PassMandatoryPartList.Values)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvMandatoryPartView.Rows.Add(part.PartName,
@@ -368,7 +377,7 @@ namespace QuoteSwift
             {
                 dgvNonMandatoryPartView.Rows.Clear();
 
-                foreach (var part in passed.PassNonMandatoryPartList)
+                foreach (var part in passed.PassNonMandatoryPartList.Values)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvNonMandatoryPartView.Rows.Add(part.PartName,

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -72,7 +72,7 @@ namespace QuoteSwift
                 {
                     if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
                     {
-                        passed.PassMandatoryPartList.Remove(SelectedPart);
+                        passed.RemoveMandatoryPart(SelectedPart);
                         MainProgramCode.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
                     }
                 }
@@ -80,7 +80,7 @@ namespace QuoteSwift
                 {
                     if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
                     {
-                        passed.PassNonMandatoryPartList.Remove(SelectedPart);
+                        passed.RemoveNonMandatoryPart(SelectedPart);
                         MainProgramCode.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
                     }
                 }
@@ -103,7 +103,7 @@ namespace QuoteSwift
         {
             if (passed.PassMandatoryPartList != null)
             {
-                foreach (var part in passed.PassMandatoryPartList)
+                foreach (var part in passed.PassMandatoryPartList.Values)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvAllParts.Rows.Add(part.PartName,
@@ -120,7 +120,7 @@ namespace QuoteSwift
         {
             if (passed.PassNonMandatoryPartList != null)
             {
-                foreach (var part in passed.PassNonMandatoryPartList)
+                foreach (var part in passed.PassNonMandatoryPartList.Values)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvAllParts.Rows.Add(part.PartName,
@@ -148,14 +148,17 @@ namespace QuoteSwift
 
             if (passed.PassMandatoryPartList.Count > 0 || passed.PassNonMandatoryPartList.Count > 0 || passed != null || passed.PassMandatoryPartList != null || passed.PassNonMandatoryPartList != null)
             {
+                string key = StringUtil.NormalizeKey(SearchName);
                 if ((bool)(dgvAllParts.Rows[iGridSelection].Cells[4].Value) == true)
                 {
                     //Search for part in mandatory
-                    return passed.PassMandatoryPartList.SingleOrDefault(p => p.OriginalItemPartNumber == SearchName);
+                    passed.PassMandatoryPartList.TryGetValue(key, out var part);
+                    return part;
                 }
                 else // Search in Non-Mandatory
                 {
-                    return passed.PassNonMandatoryPartList.SingleOrDefault(p => p.OriginalItemPartNumber == SearchName);
+                    passed.PassNonMandatoryPartList.TryGetValue(key, out var part);
+                    return part;
                 }
             }
 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -17,7 +17,7 @@ namespace QuoteSwift
         {
             InitializeComponent();
             this.passed = passed;
-            if (this.passed == null) passed = new Pass(new SortedDictionary<string, Quote>(), new BindingList<Business>(), new BindingList<Pump>(), new BindingList<Part>(), new BindingList<Part>());
+            if (this.passed == null) passed = new Pass(new SortedDictionary<string, Quote>(), new BindingList<Business>(), new BindingList<Pump>(), new Dictionary<string, Part>(), new Dictionary<string, Part>());
 
         }
 
@@ -221,11 +221,11 @@ namespace QuoteSwift
 
                     byte[] RetreivedMandatoryPartList = MainProgramCode.RetreiveData("MandatoryParts.json");
 
-                    if (RetreivedMandatoryPartList != null && RetreivedMandatoryPartList.Length > 0) passed.PassMandatoryPartList = new BindingList<Part>(MainProgramCode.DeserializePartList(RetreivedMandatoryPartList));
+                    if (RetreivedMandatoryPartList != null && RetreivedMandatoryPartList.Length > 0) passed.PassMandatoryPartList = MainProgramCode.DeserializePartList(RetreivedMandatoryPartList);
 
                     RetreivedMandatoryPartList = MainProgramCode.RetreiveData("NonMandatoryParts.json");
 
-                    if (RetreivedMandatoryPartList != null && RetreivedMandatoryPartList.Length > 0) passed.PassNonMandatoryPartList = new BindingList<Part>(MainProgramCode.DeserializePartList(RetreivedMandatoryPartList));
+                    if (RetreivedMandatoryPartList != null && RetreivedMandatoryPartList.Length > 0) passed.PassNonMandatoryPartList = MainProgramCode.DeserializePartList(RetreivedMandatoryPartList);
 
                     byte[] RetreivePumpList = MainProgramCode.RetreiveData("PumpList.json");
 


### PR DESCRIPTION
## Summary
- replace part BindingLists with `Dictionary<string, Part>`
- update serialization helpers for new dictionary structure
- refactor add/edit forms to use dictionary lookups
- adjust pumps/parts forms for new structure

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_68740b4e7e688325ad70b38a36209718