### PR TITLE
Consolidate shutdown logic

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -62,7 +62,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private bool ValidInput()
@@ -136,7 +136,7 @@ namespace QuoteSwift
 
         private void FrmEditBusinessAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
     }
 }

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -59,13 +59,13 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"), ref passed);
+            MainProgramCode.CloseApplication(MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"), ref passed);
         }
 
         private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -75,7 +75,7 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
     }
 }

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -53,7 +53,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -63,7 +63,7 @@ namespace QuoteSwift
 
         private void FrmEditPhoneNumber_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
     }
 }

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void FrmViewBusinessAddresses_Load(object sender, EventArgs e)
@@ -190,7 +190,7 @@ namespace QuoteSwift
 
         private void FrmViewBusinessAddresses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
 

--- a/MainProgramLibrary/MainProgramCode.cs
+++ b/MainProgramLibrary/MainProgramCode.cs
@@ -379,22 +379,30 @@ namespace QuoteSwift
 
 
         //Procedure Handling The Closing Of The Application
-        public static void CloseApplication(bool b , ref Pass passed)
+        public static void CloseApplication(bool exitApp, ref Pass passed)
         {
-
-            MainProgramCode.SerializeMandatoryPartList(ref passed);
-
-            MainProgramCode.SerializeNonMandatoryPartList(ref passed);
-
-            MainProgramCode.SerializePumpList(ref passed);
-
-            MainProgramCode.SerializeBusinessList(ref passed);
-
-            MainProgramCode.SerializeQuoteList(ref passed);
-
-            if (b)
+            if (exitApp)
             {
-                Application.Exit();
+                try
+                {
+                    SerializeMandatoryPartList(ref passed);
+                    SerializeNonMandatoryPartList(ref passed);
+                    SerializePumpList(ref passed);
+                    SerializeBusinessList(ref passed);
+                    SerializeQuoteList(ref passed);
+                }
+                catch (Exception ex)
+                {
+                    while (ex != null)
+                    {
+                        ShowError(ex.Message, "ERROR Occurred");
+                        ex = ex.InnerException;
+                    }
+                }
+                finally
+                {
+                    Application.Exit();
+                }
             }
         }
 

--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -68,40 +68,7 @@ namespace QuoteSwift
 
 
         //Procedure Handling The Closing Of The Application
-        public static void CloseApplication(bool b, ref Pass passed)
-        {
-            if (b)
-            {
-                try
-                {
-
-                    MainProgramCode.SerializeMandatoryPartList(ref passed);
-
-                    MainProgramCode.SerializeNonMandatoryPartList(ref passed);
-
-                    MainProgramCode.SerializePumpList(ref passed);
-
-                    MainProgramCode.SerializeBusinessList(ref passed);
-
-                    MainProgramCode.SerializeQuoteList(ref passed);
-
-                }
-                catch (Exception Ex)
-                {
-
-                    while (Ex != null)
-                    {
-                        MainProgramCode.ShowError(Ex.Message, "ERROR Occurred");
-                        Ex = Ex.InnerException;
-                    }
-
-                }
-                finally
-                {
-                    Application.Exit();
-                }
-            }
-        }
+        // Removed - use MainProgramCode.CloseApplication instead.
 
         /** Parse String Inputs: */
 

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -24,7 +24,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnAddBusiness_Click(object sender, EventArgs e)
@@ -273,7 +273,7 @@ namespace QuoteSwift
 
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -26,7 +26,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnAddCustomer_Click(object sender, EventArgs e)
@@ -297,7 +297,7 @@ namespace QuoteSwift
 
         private void FrmAddCustomer_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -22,7 +22,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
@@ -500,7 +500,7 @@ namespace QuoteSwift
 
         private void FrmAddPart_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /*********************************************************************************/

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnAddPump_Click(object sender, EventArgs e)
@@ -410,7 +410,7 @@ namespace QuoteSwift
 
         private void FrmAddPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /*********************************************************************************/

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -78,7 +78,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void CbxPumpSelection_SelectedIndexChanged(object sender, EventArgs e)
@@ -986,7 +986,7 @@ namespace QuoteSwift
 
         private void FrmCreateQuote_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
     }
 

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void FrmManageAllEmails_Load(object sender, EventArgs e)
@@ -160,7 +160,7 @@ namespace QuoteSwift
 
         private void FrmManageAllEmails_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
     }
 

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -23,7 +23,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnChangePhoneNumberInfo_Click(object sender, EventArgs e)
@@ -254,7 +254,7 @@ namespace QuoteSwift
 
         private void FrmManagingPhoneNumbers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
     }
 }

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -22,7 +22,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnUpdateBusiness_Click(object sender, EventArgs e)
@@ -161,7 +161,7 @@ namespace QuoteSwift
 
         private void FrmViewAllBusinesses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /**********************************************************************************/

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -20,7 +20,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e)
@@ -225,7 +225,7 @@ namespace QuoteSwift
 
         private void FrmViewCustomers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /**********************************************************************************/

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnRemoveAddress_Click(object sender, EventArgs e)
@@ -191,7 +191,7 @@ namespace QuoteSwift
 
         private void FrmViewPOBoxAddresses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /**********************************************************************************/

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
@@ -183,7 +183,7 @@ namespace QuoteSwift
 
         private void FrmViewParts_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /*********************************************************************************/

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift // Repair Quote Swift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void BtnUpdateSelectedPump_Click(object sender, EventArgs e)
@@ -121,7 +121,7 @@ namespace QuoteSwift // Repair Quote Swift
 
         private void FrmViewPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         /*********************************************************************************/

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -48,7 +48,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                QuoteSwiftMainCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true, ref passed);
         }
 
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -257,7 +257,7 @@ namespace QuoteSwift
         readonly int count = 0;
         private void FrmViewQuotes_FormClosing(object sender, FormClosingEventArgs e)
         {
-            QuoteSwiftMainCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true, ref passed);
         }
 
         void LoadDataGrid()


### PR DESCRIPTION
## Summary
- remove duplicate `CloseApplication` in `QuoteSwiftMainCode`
- move unified shutdown logic to `MainProgramCode`
- update all forms to invoke `MainProgramCode.CloseApplication`

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace must be MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_6874102bec0483258a3a69cdab43e374