### PR TITLE
Add repairable item name deduping

### DIFF
--- a/MainProgramLibrary/Pass.cs
+++ b/MainProgramLibrary/Pass.cs
@@ -20,6 +20,7 @@ namespace QuoteSwift
         private Dictionary<string, Business> mBusinessLookup = new Dictionary<string, Business>();
         private HashSet<string> mBusinessVatNumbers = new HashSet<string>();
         private HashSet<string> mBusinessRegNumbers = new HashSet<string>();
+        private HashSet<string> mRepairableItemNames = new HashSet<string>();
         private Business mBusinessToChange = null; //In the event that a Business' information needs to be changed
         private Customer mCustomerToChange = null; //In the event that a Customer's information needs to be changed
         private Quote mQuoteTOChange = null; //In the event that a Quote's information needs to be changed
@@ -118,7 +119,15 @@ namespace QuoteSwift
                 SyncBusinessLookup();
             }
         }
-        public BindingList<Pump> PassPumpList { get => mPassPumpList; set => mPassPumpList = value; }
+        public BindingList<Pump> PassPumpList
+        {
+            get => mPassPumpList;
+            set
+            {
+                mPassPumpList = value;
+                SyncRepairableItemLookup();
+            }
+        }
         public Business BusinessToChange { get => mBusinessToChange; set => mBusinessToChange = value; }
         public Customer CustomerToChange { get => mCustomerToChange; set => mCustomerToChange = value; }
         public Quote QuoteTOChange { get => mQuoteTOChange; set => mQuoteTOChange = value; }
@@ -150,6 +159,7 @@ namespace QuoteSwift
         public Dictionary<string, Business> BusinessLookup => mBusinessLookup;
         public HashSet<string> BusinessVatNumbers => mBusinessVatNumbers;
         public HashSet<string> BusinessRegNumbers => mBusinessRegNumbers;
+        public HashSet<string> RepairableItemNames => mRepairableItemNames;
 
         private void SyncBusinessLookup()
         {
@@ -164,6 +174,18 @@ namespace QuoteSwift
                         mBusinessLookup[b.BusinessName] = b;
                     mBusinessVatNumbers.Add(b.BusinessLegalDetails?.VatNumber);
                     mBusinessRegNumbers.Add(b.BusinessLegalDetails?.RegistrationNumber);
+                }
+            }
+        }
+
+        private void SyncRepairableItemLookup()
+        {
+            mRepairableItemNames.Clear();
+            if (mPassPumpList != null)
+            {
+                foreach (var p in mPassPumpList)
+                {
+                    mRepairableItemNames.Add(StringUtil.NormalizeKey(p.PumpName));
                 }
             }
         }
@@ -228,6 +250,21 @@ namespace QuoteSwift
         public bool TryGetNonMandatoryPartByNew(string newNumber, out Part part)
         {
             return mNonMandatoryNewPartMap.TryGetValue(StringUtil.NormalizeKey(newNumber), out part);
+        }
+
+        public void AddRepairableItem(Pump pump)
+        {
+            if (pump == null) return;
+            if (mPassPumpList == null) mPassPumpList = new BindingList<Pump>();
+            mPassPumpList.Add(pump);
+            mRepairableItemNames.Add(StringUtil.NormalizeKey(pump.PumpName));
+        }
+
+        public void RemoveRepairableItem(Pump pump)
+        {
+            if (pump == null || mPassPumpList == null) return;
+            mPassPumpList.Remove(pump);
+            mRepairableItemNames.Remove(StringUtil.NormalizeKey(pump.PumpName));
         }
     }
 }

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -39,9 +39,20 @@ namespace QuoteSwift
                     return;
                 }
 
+                string normalizedName = StringUtil.NormalizeKey(mtxtPumpName.Text);
+
                 if (passed.ChangeSpecificObject) // Update Part List if true
                 {
+                    string oldName = StringUtil.NormalizeKey(passed.PumpToChange.PumpName);
+                    if (passed.RepairableItemNames.Contains(normalizedName) && normalizedName != oldName)
+                    {
+                        MainProgramCode.ShowError("This item name is already in use.", "ERROR - Duplicate Item Name");
+                        return;
+                    }
+
                     RecordNewInformation();
+                    passed.RepairableItemNames.Remove(oldName);
+                    passed.RepairableItemNames.Add(normalizedName);
                     MainProgramCode.ShowInformation(passed.PumpToChange.PumpName + " has been updated in the list of pumps", "INFORMATION - Pump Update Successfully");
 
                     //Set ChangeSpecificObject to false and convert to View
@@ -54,8 +65,15 @@ namespace QuoteSwift
                 }
                 else //Create New Pump And Add To Pump List
                 {
+                    if (passed.RepairableItemNames.Contains(normalizedName))
+                    {
+                        MainProgramCode.ShowError("This item name is already in use.", "ERROR - Duplicate Item Name");
+                        return;
+                    }
+
                     Pump newPump = new Pump(mtxtPumpName.Text, mtxtPumpDescription.Text, QuoteSwiftMainCode.ParseDecimal(mtxtNewPumpPrice.Text), ref NewPumpParts);
                     if (passed.PassPumpList == null) passed.PassPumpList = new BindingList<Pump> { newPump }; else passed.PassPumpList.Add(newPump);
+                    passed.RepairableItemNames.Add(normalizedName);
                     MainProgramCode.ShowInformation(newPump.PumpName + " has been added to the list of pumps", "INFORMATION - Pump Added Successfully");
                 }
             }

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -68,6 +68,7 @@ namespace QuoteSwift // Repair Quote Swift
                 if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + objPumpSelection.PumpName + "pump from the list of pumps?", "REQUEST - Deletion Request"))
                 {
                     passed.PassPumpList.RemoveAt(iGridSelection);
+                    passed.RepairableItemNames.Remove(StringUtil.NormalizeKey(objPumpSelection.PumpName));
 
                     MainProgramCode.ShowInformation("Successfully deleted " + objPumpSelection.PumpName + " from the pump list", "INFORMATION - Deletion Success");
                 }


### PR DESCRIPTION
## Summary
- track repairable item names in `Pass`
- validate repairable item names when adding/updating pumps
- remove names from lookup when deleting pumps

## Testing
- `xbuild QuoteSwift.sln` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68740fbf4a0c83258161cbdde3387eeb