### PR TITLE
Normalize pump name comparison on part import

### DIFF
--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -234,7 +234,7 @@ namespace QuoteSwift
                             Pump OldPump = null;
                             foreach (var pump in passed.PassPumpList)
                             {
-                                if (pump.PumpName == NewPump.PumpName)
+                                if (StringUtil.NormalizeKey(pump.PumpName) == StringUtil.NormalizeKey(NewPump.PumpName))
                                 {
                                     FoundPump = true;
                                     OldPump = pump;


### PR DESCRIPTION
## Summary
- compare pump names using `StringUtil.NormalizeKey` when bulk importing parts

## Testing
- `xbuild QuoteSwift.sln /t:Rebuild /p:Configuration=Release` *(fails: default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68741f9d56a48325977952b51a152858