### PR TITLE
Fix null-check for business legal details

### DIFF
--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -507,8 +507,12 @@ namespace QuoteSwift
             {
                 txtBusinessName.Text = Business.BusinessName;
                 rtxtExtraInformation.Text = Business.BusinessExtraInformation;
-                mtxtVATNumber.Text = Business.BusinessLegalDetails.VatNumber;
-                mtxtRegistrationNumber.Text = Business.BusinessLegalDetails.RegistrationNumber;
+
+                if (Business.BusinessLegalDetails != null)
+                {
+                    mtxtVATNumber.Text = Business.BusinessLegalDetails.VatNumber;
+                    mtxtRegistrationNumber.Text = Business.BusinessLegalDetails.RegistrationNumber;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- check `BusinessLegalDetails` for null in `LoadInformation`

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68742e1f82a8832592407df9a550eb97