### PR TITLE
Initialize address list when adding

### DIFF
--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -116,6 +116,8 @@ namespace QuoteSwift
                                               txtStreetName.Text, txtSuburb.Text, txtCity.Text, QuoteSwiftMainCode.ParseInt(mtxtAreaCode.Text));
                 if (!AddressExisting(address))
                 {
+                    if (Business.BusinessAddressList == null)
+                        Business.BusinessAddressList = new BindingList<Address>();
                     Business.BusinessAddressList.Add(address);
                     Business.AddressMap[StringUtil.NormalizeKey(address.AddressDescription)] = address;
                     MainProgramCode.ShowInformation("Successfully added the business address", "INFORMATION - Business Address Added Successfully");


### PR DESCRIPTION
## Summary
- fix BtnAddAddress_Click to initialize BusinessAddressList when it's null

## Testing
- `xbuild QuoteSwift.sln` *(fails: MSBuild XML namespace error)*
- `msbuild QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742de352b88325892f9b2b3d52590a