### PR TITLE
Add default Pump constructor and null-safe part list

### DIFF
--- a/MainProgramLibrary/Pump.cs
+++ b/MainProgramLibrary/Pump.cs
@@ -10,11 +10,19 @@ namespace QuoteSwift
         private BindingList<Pump_Part> mPartList;
         private decimal mNewPumpPrice;
 
+        public Pump()
+        {
+            PumpName = "";
+            PumpDescription = "";
+            PartList = new BindingList<Pump_Part>();
+            NewPumpPrice = 0m;
+        }
+
         public Pump(string mPumpName, string mPumpDescription, decimal mNewPumpPrice, ref BindingList<Pump_Part> mPartList)
         {
             PumpName = mPumpName;
             PumpDescription = mPumpDescription;
-            PartList = mPartList;
+            PartList = mPartList ?? new BindingList<Pump_Part>();
             NewPumpPrice = mNewPumpPrice;
         }
 


### PR DESCRIPTION
## Summary
- ensure `Pump` initializes `PartList` when null
- provide parameterless `Pump` constructor

## Testing
- `dotnet build QuoteSwift.sln` *(fails: reference assemblies for .NETFramework v4.8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874a314a5308325ae46567dded605b8