### PR TITLE
Fix property assignments and remove unused references

### DIFF
--- a/MainProgramLibrary/Business.cs
+++ b/MainProgramLibrary/Business.cs
@@ -28,13 +28,13 @@ namespace QuoteSwift
         {
             BusinessName = "";
             BusinessExtraInformation = "";
-            BusinessAddressList = new BindingList<Address>();
-            BusinessPOBoxAddressList = new BindingList<Address>();
+            mBusinessAddressList = new BindingList<Address>();
+            mBusinessPOBoxAddressList = new BindingList<Address>();
             BusinessLegalDetails = null;
-            BusinessTelephoneNumberList = new BindingList<string>();
-            BusinessCellphoneNumberList = new BindingList<string>();
-            BusinessEmailAddressList = new BindingList<string>();
-            BusinessCustomerList = new BindingList<Customer>();
+            mBusinessTelephoneNumberList = new BindingList<string>();
+            mBusinessCellphoneNumberList = new BindingList<string>();
+            mBusinessEmailAddressList = new BindingList<string>();
+            mBusinessCustomerList = new BindingList<Customer>();
 
             mAddressMap = new Dictionary<string, Address>();
             mPOBoxMap = new Dictionary<string, Address>();
@@ -53,24 +53,24 @@ namespace QuoteSwift
 
             if (b.mBusinessAddressList != null)
             {
-                BusinessAddressList = new BindingList<Address>();
+                mBusinessAddressList = new BindingList<Address>();
                 foreach (var a in b.mBusinessAddressList)
-                    BusinessAddressList.Add(new Address(a));
+                    mBusinessAddressList.Add(new Address(a));
             }
             else
             {
-                BusinessAddressList = null;
+                mBusinessAddressList = null;
             }
 
             if (b.mBusinessPOBoxAddressList != null)
             {
-                BusinessPOBoxAddressList = new BindingList<Address>();
+                mBusinessPOBoxAddressList = new BindingList<Address>();
                 foreach (var a in b.mBusinessPOBoxAddressList)
-                    BusinessPOBoxAddressList.Add(new Address(a));
+                    mBusinessPOBoxAddressList.Add(new Address(a));
             }
             else
             {
-                BusinessPOBoxAddressList = null;
+                mBusinessPOBoxAddressList = null;
             }
 
             BusinessLegalDetails = b.mBusinessLegalDetails != null
@@ -79,46 +79,46 @@ namespace QuoteSwift
 
             if (b.mBusinessTelephoneNumberList != null)
             {
-                BusinessTelephoneNumberList = new BindingList<string>();
+                mBusinessTelephoneNumberList = new BindingList<string>();
                 foreach (var n in b.mBusinessTelephoneNumberList)
-                    BusinessTelephoneNumberList.Add(n);
+                    mBusinessTelephoneNumberList.Add(n);
             }
             else
             {
-                BusinessTelephoneNumberList = null;
+                mBusinessTelephoneNumberList = null;
             }
 
             if (b.mBusinessCellphoneNumberList != null)
             {
-                BusinessCellphoneNumberList = new BindingList<string>();
+                mBusinessCellphoneNumberList = new BindingList<string>();
                 foreach (var n in b.mBusinessCellphoneNumberList)
-                    BusinessCellphoneNumberList.Add(n);
+                    mBusinessCellphoneNumberList.Add(n);
             }
             else
             {
-                BusinessCellphoneNumberList = null;
+                mBusinessCellphoneNumberList = null;
             }
 
             if (b.mBusinessEmailAddressList != null)
             {
-                BusinessEmailAddressList = new BindingList<string>();
+                mBusinessEmailAddressList = new BindingList<string>();
                 foreach (var e in b.mBusinessEmailAddressList)
-                    BusinessEmailAddressList.Add(e);
+                    mBusinessEmailAddressList.Add(e);
             }
             else
             {
-                BusinessEmailAddressList = null;
+                mBusinessEmailAddressList = null;
             }
 
             if (b.mBusinessCustomerList != null)
             {
-                BusinessCustomerList = new BindingList<Customer>();
+                mBusinessCustomerList = new BindingList<Customer>();
                 foreach (var c in b.mBusinessCustomerList)
-                    BusinessCustomerList.Add(new Customer(c));
+                    mBusinessCustomerList.Add(new Customer(c));
             }
             else
             {
-                BusinessCustomerList = null;
+                mBusinessCustomerList = null;
             }
 
             mAddressMap = new Dictionary<string, Address>();
@@ -148,13 +148,13 @@ namespace QuoteSwift
         {
             BusinessName = mBusinessName;
             BusinessExtraInformation = mBusinessExtraInformation;
-            BusinessAddressList = mBusinessAddressList;
-            BusinessPOBoxAddressList = mBusinessPOBoxAddressList;
+            this.mBusinessAddressList = mBusinessAddressList;
+            this.mBusinessPOBoxAddressList = mBusinessPOBoxAddressList;
             BusinessLegalDetails = mBusinessLegalDetails;
-            BusinessTelephoneNumberList = mBusinessTelephoneNumberList;
-            BusinessCellphoneNumberList = mBusinessCellphoneNumberList;
-            BusinessEmailAddressList = mBusinessEmailAddressList;
-            BusinessCustomerList = mBusinessCustomerList;
+            this.mBusinessTelephoneNumberList = mBusinessTelephoneNumberList;
+            this.mBusinessCellphoneNumberList = mBusinessCellphoneNumberList;
+            this.mBusinessEmailAddressList = mBusinessEmailAddressList;
+            this.mBusinessCustomerList = mBusinessCustomerList;
 
             mAddressMap = new Dictionary<string, Address>();
             if (mBusinessAddressList != null)

--- a/MainProgramLibrary/Customer.cs
+++ b/MainProgramLibrary/Customer.cs
@@ -27,12 +27,12 @@ namespace QuoteSwift
         {
             CustomerName = "";
             CustomerCompanyName = "";
-            CustomerPOBoxAddress = new BindingList<Address>();
-            CustomerDeliveryAddressList = new BindingList<Address>();
+            mCustomerPOBoxAddress = new BindingList<Address>();
+            mCustomerDeliveryAddressList = new BindingList<Address>();
             CustomerLegalDetails = null;
-            CustomerTelephoneNumberList = new BindingList<string>();
-            CustomerCellphoneNumberList = new BindingList<string>();
-            CustomerEmailList = new BindingList<string>();
+            mCustomerTelephoneNumberList = new BindingList<string>();
+            mCustomerCellphoneNumberList = new BindingList<string>();
+            mCustomerEmailList = new BindingList<string>();
             VendorNumber = "";
 
             mDeliveryAddressMap = new Dictionary<string, Address>();
@@ -50,24 +50,24 @@ namespace QuoteSwift
 
             if (c.mCustomerPOBoxAddress != null)
             {
-                CustomerPOBoxAddress = new BindingList<Address>();
+                mCustomerPOBoxAddress = new BindingList<Address>();
                 foreach (var a in c.mCustomerPOBoxAddress)
-                    CustomerPOBoxAddress.Add(new Address(a));
+                    mCustomerPOBoxAddress.Add(new Address(a));
             }
             else
             {
-                CustomerPOBoxAddress = null;
+                mCustomerPOBoxAddress = null;
             }
 
             if (c.mCustomerDeliveryAddressList != null)
             {
-                CustomerDeliveryAddressList = new BindingList<Address>();
+                mCustomerDeliveryAddressList = new BindingList<Address>();
                 foreach (var a in c.mCustomerDeliveryAddressList)
-                    CustomerDeliveryAddressList.Add(new Address(a));
+                    mCustomerDeliveryAddressList.Add(new Address(a));
             }
             else
             {
-                CustomerDeliveryAddressList = null;
+                mCustomerDeliveryAddressList = null;
             }
 
             CustomerLegalDetails = c.mCustomerLegalDetails != null
@@ -76,35 +76,35 @@ namespace QuoteSwift
 
             if (c.mCustomerTelephoneNumberList != null)
             {
-                CustomerTelephoneNumberList = new BindingList<string>();
+                mCustomerTelephoneNumberList = new BindingList<string>();
                 foreach (var n in c.mCustomerTelephoneNumberList)
-                    CustomerTelephoneNumberList.Add(n);
+                    mCustomerTelephoneNumberList.Add(n);
             }
             else
             {
-                CustomerTelephoneNumberList = null;
+                mCustomerTelephoneNumberList = null;
             }
 
             if (c.mCustomerCellphoneNumberList != null)
             {
-                CustomerCellphoneNumberList = new BindingList<string>();
+                mCustomerCellphoneNumberList = new BindingList<string>();
                 foreach (var n in c.mCustomerCellphoneNumberList)
-                    CustomerCellphoneNumberList.Add(n);
+                    mCustomerCellphoneNumberList.Add(n);
             }
             else
             {
-                CustomerCellphoneNumberList = null;
+                mCustomerCellphoneNumberList = null;
             }
 
             if (c.mCustomerEmailList != null)
             {
-                CustomerEmailList = new BindingList<string>();
+                mCustomerEmailList = new BindingList<string>();
                 foreach (var e in c.mCustomerEmailList)
-                    CustomerEmailList.Add(e);
+                    mCustomerEmailList.Add(e);
             }
             else
             {
-                CustomerEmailList = null;
+                mCustomerEmailList = null;
             }
 
             VendorNumber = c.VendorNumber;

--- a/MainProgramLibrary/MainProgramLibrary.csproj
+++ b/MainProgramLibrary/MainProgramLibrary.csproj
@@ -10,12 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Bogus">
-      <HintPath>..\QuoteSwift\packages\Bogus.33.0.2\lib\net40\Bogus.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Memory">
-      <HintPath>..\QuoteSwift\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Windows.Forms.dll</HintPath>
     </Reference>

--- a/MainProgramLibrary/StringUtil.cs
+++ b/MainProgramLibrary/StringUtil.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
             if (string.IsNullOrWhiteSpace(input))
                 return string.Empty;
             string trimmed = input.Trim();
-            string singleSpaced = Regex.Replace(trimmed, "\s+", " ");
+            string singleSpaced = Regex.Replace(trimmed, @"\s+", " ");
             return singleSpaced.ToUpperInvariant();
         }
     }

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -74,9 +74,6 @@
     <StartupObject>QuoteSwift.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bogus, Version=33.0.2.0, Culture=neutral, PublicKeyToken=fa1bb3f3f218129a, processorArchitecture=MSIL">
-      <HintPath>packages\Bogus.33.0.2\lib\net40\Bogus.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -95,9 +92,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing.Design" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
     </Reference>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bogus" version="33.0.2" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net48" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net48" />
@@ -8,7 +7,6 @@
   <package id="Swashbuckle.Core" version="5.6.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
## Summary
- remove references to Bogus and System.Memory
- keep internal lists writable and expose them as read-only
- clean up parameterized constructors
- fix escape sequence in `StringUtil`

## Testing
- `dotnet build QuoteSwift.sln` *(fails: System.Windows.Forms not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b4358c5483258024010ceddcc782