### PR TITLE
Fix non-mandatory part selection

### DIFF
--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -693,7 +693,10 @@ namespace QuoteSwift
 
 
             BindingList<Quote_Part> NonMandatoryPartList = new BindingList<Quote_Part>();
-            for (int i = 0; i < DgvNonMandatoryPartReplacement.Rows.Count - 4; i++)
+            // Exclude only the total row added during calculation.
+            // The data grid contains three cost category rows (Machining,
+            // Labour and Consumables) which must be included in the quote.
+            for (int i = 0; i < DgvNonMandatoryPartReplacement.Rows.Count - 1; i++)
             {
                 if (DgvNonMandatoryPartReplacement.Rows[i].Cells[0].Value.ToString() != "-")
                 {


### PR DESCRIPTION
## Summary
- ensure cost category rows are included when creating quotes
- build attempted with dotnet msbuild and mono xbuild but fails due to missing framework

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln -verbosity:minimal` *(fails: System.Windows.Forms not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e0db57ec83259b733a91b3a78404