### PR TITLE
Ensure shared IDataService across view models

### DIFF
--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -30,8 +30,9 @@ namespace QuoteSwift
                 passed.EmailToChange = mtxtEmail.Text;
                 if (passed != null && passed.BusinessToChange != null)
                 {
-                    var vm = new AddBusinessViewModel(new FileDataService());
+                    var vm = new AddBusinessViewModel(viewModel.DataService);
                     vm.UpdatePass(passed);
+                    vm.LoadData();
                     FrmAddBusiness frmAddBusiness = new FrmAddBusiness(vm);
                     if (!frmAddBusiness.EmailAddressExisting(mtxtEmail.Text))
                     {
@@ -42,8 +43,9 @@ namespace QuoteSwift
                 }
                 else if (passed != null && passed.CustomerToChange != null)
                 {
-                    var vm = new AddCustomerViewModel(new FileDataService());
+                    var vm = new AddCustomerViewModel(viewModel.DataService);
                     vm.UpdatePass(passed);
+                    vm.LoadData();
                     FrmAddCustomer frmAddCustomer = new FrmAddCustomer(vm);
                     if (!frmAddCustomer.EmailAddressExisting(mtxtEmail.Text))
                     {

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -31,8 +31,9 @@ namespace QuoteSwift
         {
             if (passed != null && passed.BusinessToChange != null)
             {
-                var vm = new AddBusinessViewModel(new FileDataService());
+                var vm = new AddBusinessViewModel(viewModel.DataService);
                 vm.UpdatePass(passed);
+                vm.LoadData();
                 FrmAddBusiness frmAddBusiness = new FrmAddBusiness(vm);
                 if (!frmAddBusiness.PhoneNumberExisting(txtPhoneNumber.Text))
                 {
@@ -43,8 +44,9 @@ namespace QuoteSwift
             }
             else if (passed != null && passed.CustomerToChange != null)
             {
-                var vm = new AddCustomerViewModel(new FileDataService());
+                var vm = new AddCustomerViewModel(viewModel.DataService);
                 vm.UpdatePass(passed);
+                vm.LoadData();
                 FrmAddCustomer frmAddCustomer = new FrmAddCustomer(vm);
                 if (!frmAddCustomer.PhoneNumberExisting(txtPhoneNumber.Text))
                 {

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -18,6 +18,7 @@ namespace QuoteSwift
         {
             var vm = new CreateQuoteViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmCreateQuote(vm))
             {
                 form.ShowDialog();
@@ -29,6 +30,7 @@ namespace QuoteSwift
         {
             var vm = new QuotesViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewQuotes(vm, this))
             {
                 form.ShowDialog();
@@ -40,6 +42,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPumpViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewPump(vm, this))
             {
                 form.ShowDialog();
@@ -51,6 +54,7 @@ namespace QuoteSwift
         {
             var vm = new AddPumpViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmAddPump(vm, this))
             {
                 form.ShowDialog();
@@ -62,6 +66,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPartsViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewParts(vm, this))
             {
                 form.ShowDialog();
@@ -73,6 +78,7 @@ namespace QuoteSwift
         {
             var vm = new AddPartViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmAddPart(vm, this))
             {
                 form.ShowDialog();
@@ -84,6 +90,7 @@ namespace QuoteSwift
         {
             var vm = new AddCustomerViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmAddCustomer(vm, this))
             {
                 form.ShowDialog();
@@ -95,6 +102,7 @@ namespace QuoteSwift
         {
             var vm = new ViewCustomersViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewCustomers(vm, this))
             {
                 form.ShowDialog();
@@ -106,6 +114,7 @@ namespace QuoteSwift
         {
             var vm = new AddBusinessViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmAddBusiness(vm, this))
             {
                 form.ShowDialog();
@@ -117,6 +126,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessesViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewAllBusinesses(vm, this))
             {
                 form.ShowDialog();
@@ -128,6 +138,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewBusinessAddresses(vm, this))
             {
                 form.ShowDialog();
@@ -139,6 +150,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPOBoxAddressesViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmViewPOBoxAddresses(vm, this))
             {
                 form.ShowDialog();
@@ -150,6 +162,7 @@ namespace QuoteSwift
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmManageAllEmails(vm, this))
             {
                 form.ShowDialog();
@@ -161,6 +174,7 @@ namespace QuoteSwift
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmManagingPhoneNumbers(vm, this))
             {
                 form.ShowDialog();
@@ -172,6 +186,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmEditBusinessAddress(vm))
             {
                 form.ShowDialog();
@@ -183,6 +198,7 @@ namespace QuoteSwift
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmEditEmailAddress(vm))
             {
                 form.ShowDialog();
@@ -194,6 +210,7 @@ namespace QuoteSwift
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.UpdatePass(Pass);
+            vm.LoadData();
             using (var form = new FrmEditPhoneNumber(vm))
             {
                 form.ShowDialog();

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -382,7 +382,7 @@ namespace QuoteSwift
 
         private void LoadComboBoxes()
         {
-            ViewCustomersViewModel vm = new ViewCustomersViewModel(new FileDataService());
+            ViewCustomersViewModel vm = new ViewCustomersViewModel(viewModel.DataService);
             vm.UpdatePass(passed);
             vm.LoadData();
             if (vm.Pass != null && vm.Pass.PassBusinessList != null)


### PR DESCRIPTION
## Summary
- reuse a single `IDataService` instance through navigation service
- update edit forms to use the shared service
- load data for each view model when navigating
- use the existing service inside `frmCreateQuote`

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Release` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_687537f9764c8325a1fc0d2356f4463e