### PR TITLE
Refactor AddPartViewModel data handling

### DIFF
--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -197,10 +197,10 @@ namespace QuoteSwift
         public static ref Pass AddNewPart(ref Pass passed)
         {
             var vm = new AddPartViewModel(new FileDataService());
-            vm.UpdatePass(passed);
+            vm.UpdatePass(passed.PassPartList, passed.PassPumpList, passed.PartToChange, passed.ChangeSpecificObject);
             FrmAddPart frmAddPart = new FrmAddPart(vm, null);
+            frmAddPart.SetPass(passed);
             frmAddPart.ShowDialog();
-            passed = vm.Pass;
             return ref passed;
         }
 

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -77,13 +77,13 @@ namespace QuoteSwift
         public void AddNewPart()
         {
             var vm = new AddPartViewModel(dataService);
-            vm.UpdatePass(Pass);
+            vm.UpdatePass(Pass.PassPartList, Pass.PassPumpList, Pass.PartToChange, Pass.ChangeSpecificObject);
             vm.LoadData();
             using (var form = new FrmAddPart(vm, this))
             {
+                form.SetPass(Pass);
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
         public void AddCustomer()

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -10,13 +10,16 @@ namespace QuoteSwift
         readonly AddPartViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
+        Pass passed;
 
         public ref Pass Passed { get => ref passed; }
+
+        public void SetPass(Pass value)
+        {
+            passed = value;
+            if (value != null)
+                viewModel.UpdatePass(value.PassPartList, value.PassPumpList, value.PartToChange, value.ChangeSpecificObject);
+        }
 
         public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null)
         {


### PR DESCRIPTION
## Summary
- remove Pass field from AddPartViewModel
- expose PartMap, PumpList, PartToChange and ChangeSpecificObject properties
- adjust AddPartViewModel methods to use new fields
- update form, navigation and helper methods for new API

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace issue)*

------
https://chatgpt.com/codex/tasks/task_e_68755c4f03248325a801df7275b86a66