### PR TITLE
Refactor QuotesViewModel data access

### DIFF
--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -141,7 +141,7 @@ namespace QuoteSwift
             vm.UpdatePass(passed);
             FrmViewQuotes frmViewQuotes = new FrmViewQuotes(vm, null);
             frmViewQuotes.ShowDialog();
-            passed = vm.Pass;
+            passed = new Pass(vm.QuoteMap, vm.BusinessList, vm.PumpList, vm.PartMap);
             return ref passed;
         }
 

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -35,7 +35,7 @@ namespace QuoteSwift
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            Pass = new Pass(vm.QuoteMap, vm.BusinessList, vm.PumpList, vm.PartMap);
         }
 
         public void ViewAllPumps()

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -8,32 +8,21 @@ namespace QuoteSwift
     public class QuotesViewModel : INotifyPropertyChanged
     {
         readonly IDataService dataService;
-        readonly Pass pass;
         BindingList<Quote> quotes;
         Quote selectedQuote;
+
+        SortedDictionary<string, Quote> quoteMap;
+        BindingList<Business> businessList;
+        BindingList<Pump> pumpList;
+        Dictionary<string, Part> partMap;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public QuotesViewModel(IDataService service)
         {
             dataService = service;
-            pass = new Pass(null, null, null, null);
         }
 
-        public Pass Pass
-        {
-            get => pass;
-            private set
-            {
-                if (value != null)
-                {
-                    pass.PassQuoteMap = value.PassQuoteMap;
-                    pass.PassBusinessList = value.PassBusinessList;
-                    pass.PassPartList = value.PassPartList;
-                    pass.PassPumpList = value.PassPumpList;
-                }
-            }
-        }
 
         public BindingList<Quote> Quotes
         {
@@ -55,24 +44,64 @@ namespace QuoteSwift
             }
         }
 
+        public SortedDictionary<string, Quote> QuoteMap
+        {
+            get => quoteMap;
+            private set
+            {
+                quoteMap = value;
+                OnPropertyChanged(nameof(QuoteMap));
+            }
+        }
+
+        public BindingList<Business> BusinessList
+        {
+            get => businessList;
+            private set
+            {
+                businessList = value;
+                OnPropertyChanged(nameof(BusinessList));
+            }
+        }
+
+        public BindingList<Pump> PumpList
+        {
+            get => pumpList;
+            private set
+            {
+                pumpList = value;
+                OnPropertyChanged(nameof(PumpList));
+            }
+        }
+
+        public Dictionary<string, Part> PartMap
+        {
+            get => partMap;
+            private set
+            {
+                partMap = value;
+                OnPropertyChanged(nameof(PartMap));
+            }
+        }
+
         public void LoadData()
         {
-            pass.PassPartList = dataService.LoadPartList();
-            pass.PassPumpList = dataService.LoadPumpList();
-            pass.PassBusinessList = dataService.LoadBusinessList();
-            pass.PassQuoteMap = dataService.LoadQuoteMap();
+            PartMap = dataService.LoadPartList();
+            PumpList = dataService.LoadPumpList();
+            BusinessList = dataService.LoadBusinessList();
+            QuoteMap = dataService.LoadQuoteMap();
 
-            Quotes = new BindingList<Quote>(pass.PassQuoteMap.Values.ToList());
+            Quotes = new BindingList<Quote>(QuoteMap.Values.ToList());
         }
 
         public void UpdatePass(Pass newPass)
         {
             if (newPass == null) return;
-            pass.PassQuoteMap = newPass.PassQuoteMap;
-            pass.PassBusinessList = newPass.PassBusinessList;
-            pass.PassPartList = newPass.PassPartList;
-            pass.PassPumpList = newPass.PassPumpList;
-            Quotes = new BindingList<Quote>(pass.PassQuoteMap.Values.ToList());
+            QuoteMap = newPass.PassQuoteMap;
+            BusinessList = newPass.PassBusinessList;
+            PartMap = newPass.PassPartList;
+            PumpList = newPass.PassPumpList;
+            Quotes = new BindingList<Quote>(QuoteMap?.Values.ToList() ?? new List<Quote>());
         }
 
         protected void OnPropertyChanged(string propertyName)

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -21,10 +21,10 @@ namespace QuoteSwift
 
         private void BtnCreateNewQuote_Click(object sender, EventArgs e)
         {
-            if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null && viewModel.Pass.PassPumpList != null && viewModel.Pass.PassBusinessList[0].BusinessCustomerList != null)
+            if (viewModel.BusinessList != null && viewModel.BusinessList.Count > 0 && viewModel.PumpList != null && viewModel.BusinessList[0].BusinessCustomerList != null)
             {
                 Hide();
-                navigation.Pass = viewModel.Pass;
+                navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
                 navigation.CreateNewQuote();
                 viewModel.UpdatePass(navigation.Pass);
                 try
@@ -49,7 +49,7 @@ namespace QuoteSwift
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                var p = viewModel.Pass;
+                var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
                 MainProgramCode.CloseApplication(true, ref p);
                 viewModel.UpdatePass(p);
             }
@@ -58,7 +58,7 @@ namespace QuoteSwift
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.ViewAllPumps();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -74,7 +74,7 @@ namespace QuoteSwift
         private void CreateNewPumpToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.CreateNewPump();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -95,7 +95,7 @@ namespace QuoteSwift
         private void AddNewCustomerToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.AddCustomer();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -111,7 +111,7 @@ namespace QuoteSwift
         private void ViewAllCustomersToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.ViewCustomers();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -132,7 +132,7 @@ namespace QuoteSwift
         private void AddNewBusinessToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.AddBusiness();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -148,7 +148,7 @@ namespace QuoteSwift
         private void ViewAllBusinessesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.ViewBusinesses();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -180,13 +180,13 @@ namespace QuoteSwift
 
         private void BtnViewSelectedQuote_Click(object sender, EventArgs e)
         {
-            if (viewModel.Pass != null && viewModel.Pass.PassQuoteMap != null)
+            if (viewModel.QuoteMap != null)
             {
                 Quote selected = GetSelectedQuote();
                 if (selected != null)
                 {
                     Hide();
-                    navigation.Pass = viewModel.Pass;
+                    navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
                     navigation.Pass.QuoteTOChange = selected;
                     navigation.Pass.ChangeSpecificObject = false;
                     navigation.CreateNewQuote();
@@ -200,13 +200,13 @@ namespace QuoteSwift
 
         private void BtnCreateNewQuoteOnSelection_Click(object sender, EventArgs e)
         {
-            if (viewModel.Pass != null && viewModel.Pass.PassQuoteMap != null)
+            if (viewModel.QuoteMap != null)
             {
                 Quote selected = GetSelectedQuote();
                 if (selected != null)
                 {
                     this.Hide();
-                    navigation.Pass = viewModel.Pass;
+                    navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
                     navigation.Pass.QuoteTOChange = selected;
                     navigation.Pass.ChangeSpecificObject = true;
                     navigation.CreateNewQuote();
@@ -221,7 +221,7 @@ namespace QuoteSwift
         private void ViewAllPartsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.ViewAllParts();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -242,7 +242,7 @@ namespace QuoteSwift
         private void AddNewPartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
+            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             navigation.AddNewPart();
             viewModel.UpdatePass(navigation.Pass);
             try
@@ -265,7 +265,7 @@ namespace QuoteSwift
         readonly int count = 0;
         private void FrmViewQuotes_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var p = viewModel.Pass;
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
             MainProgramCode.CloseApplication(true, ref p);
             viewModel.UpdatePass(p);
         }
@@ -275,8 +275,8 @@ namespace QuoteSwift
 
 
             BindingSource PreviousQuotesDatagridBindingSource = null;
-            if (viewModel.Pass != null && viewModel.Pass.PassQuoteMap != null)
-                PreviousQuotesDatagridBindingSource = new BindingSource { DataSource = new BindingList<Quote>(viewModel.Pass.PassQuoteMap.Values.ToList()) };
+            if (viewModel.QuoteMap != null)
+                PreviousQuotesDatagridBindingSource = new BindingSource { DataSource = new BindingList<Quote>(viewModel.QuoteMap.Values.ToList()) };
 
             if (PreviousQuotesDatagridBindingSource != null)
             {


### PR DESCRIPTION
## Summary
- expose QuoteMap, BusinessList, PumpList and PartMap on `QuotesViewModel`
- update `LoadData` and `UpdatePass` to populate those collections
- adapt `frmViewQuotes` to construct `Pass` objects from the new properties
- return a new `Pass` from `NavigationService.ViewAllQuotes`
- update helper in `QuoteSwiftMainCode` for new data access

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68755c5251ac8325907a8281738fb25d