### PR TITLE
Remove navigation pass property

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -76,9 +76,7 @@ namespace QuoteSwift
             passed.AddressToChange = address;
             passed.ChangeSpecificObject = false;
 
-            navigation.Pass = passed;
-            navigation.EditBusinessAddress();
-            passed = navigation.Pass;
+            navigation.EditBusinessAddress(passed);
 
             if (!ReplacePOBoxAddress(address, passed.AddressToChange)) MainProgramCode.ShowError("An error occurred during the updating procedure of the Address.\nUpdated address will not be stored.", "ERROR - Address Not Updated");
 

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -4,24 +4,22 @@ namespace QuoteSwift
 {
     public interface INavigationService
     {
-        Pass Pass { get; set; }
-
-        void CreateNewQuote();
-        void ViewAllQuotes();
-        void ViewAllPumps();
-        void CreateNewPump();
-        void ViewAllParts();
-        void AddNewPart();
-        void AddCustomer();
-        void ViewCustomers();
-        void AddBusiness();
-        void ViewBusinesses();
-        void ViewBusinessesAddresses();
-        void ViewBusinessesPOBoxAddresses();
-        void ViewBusinessesEmailAddresses();
-        void ViewBusinessesPhoneNumbers();
-        void EditBusinessAddress();
-        void EditBusinessEmailAddress();
-        void EditPhoneNumber();
+        void CreateNewQuote(Pass pass);
+        void ViewAllQuotes(Pass pass);
+        void ViewAllPumps(Pass pass);
+        void CreateNewPump(Pass pass);
+        void ViewAllParts(Pass pass);
+        void AddNewPart(Pass pass);
+        void AddCustomer(Pass pass);
+        void ViewCustomers(Pass pass);
+        void AddBusiness(Pass pass);
+        void ViewBusinesses(Pass pass);
+        void ViewBusinessesAddresses(Pass pass);
+        void ViewBusinessesPOBoxAddresses(Pass pass);
+        void ViewBusinessesEmailAddresses(Pass pass);
+        void ViewBusinessesPhoneNumbers(Pass pass);
+        void EditBusinessAddress(Pass pass);
+        void EditBusinessEmailAddress(Pass pass);
+        void EditPhoneNumber(Pass pass);
     }
 }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -5,217 +5,229 @@ namespace QuoteSwift
     public class NavigationService : INavigationService
     {
         readonly IDataService dataService;
+        SortedDictionary<string, Quote> quoteMap;
+        BindingList<Business> businessList;
+        BindingList<Pump> pumpList;
+        Dictionary<string, Part> partMap;
 
         public NavigationService(IDataService service)
         {
             dataService = service;
-            Pass = new Pass(null, null, null, null);
+            quoteMap = dataService.LoadQuoteMap();
+            businessList = dataService.LoadBusinessList();
+            pumpList = dataService.LoadPumpList();
+            partMap = dataService.LoadPartList();
         }
 
-        public Pass Pass { get; set; }
-
-        public void CreateNewQuote()
+        void AssignCollections(Pass pass)
         {
+            if (pass == null) return;
+            pass.PassQuoteMap = quoteMap;
+            pass.PassBusinessList = businessList;
+            pass.PassPumpList = pumpList;
+            pass.PassPartList = partMap;
+        }
+
+        public void CreateNewQuote(Pass pass)
+        {
+            AssignCollections(pass);
             var vm = new CreateQuoteViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmCreateQuote(vm))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            quoteMap = vm.Pass.PassQuoteMap;
+            businessList = vm.Pass.PassBusinessList;
+            pumpList = vm.Pass.PassPumpList;
+            partMap = vm.Pass.PassPartList;
         }
 
-        public void ViewAllQuotes()
+        public void ViewAllQuotes(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new QuotesViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewQuotes(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            quoteMap = vm.Pass.PassQuoteMap;
+            businessList = vm.Pass.PassBusinessList;
+            pumpList = vm.Pass.PassPumpList;
+            partMap = vm.Pass.PassPartList;
         }
 
-        public void ViewAllPumps()
+        public void ViewAllPumps(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewPumpViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewPump(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            pumpList = vm.Pass.PassPumpList;
         }
 
-        public void CreateNewPump()
+        public void CreateNewPump(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new AddPumpViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmAddPump(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            pumpList = vm.Pass.PassPumpList;
         }
 
-        public void ViewAllParts()
+        public void ViewAllParts(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewPartsViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewParts(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            partMap = vm.Pass.PassPartList;
         }
 
-        public void AddNewPart()
+        public void AddNewPart(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new AddPartViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmAddPart(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            partMap = vm.Pass.PassPartList;
         }
 
-        public void AddCustomer()
+        public void AddCustomer(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new AddCustomerViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmAddCustomer(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            businessList = vm.Pass.PassBusinessList;
+            quoteMap = vm.Pass.PassQuoteMap;
         }
 
-        public void ViewCustomers()
+        public void ViewCustomers(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewCustomersViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewCustomers(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void AddBusiness()
+        public void AddBusiness(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new AddBusinessViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmAddBusiness(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
+            businessList = vm.Pass.PassBusinessList;
         }
 
-        public void ViewBusinesses()
+        public void ViewBusinesses(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewBusinessesViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewAllBusinesses(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void ViewBusinessesAddresses()
+        public void ViewBusinessesAddresses(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewBusinessAddressesViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewBusinessAddresses(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void ViewBusinessesPOBoxAddresses()
+        public void ViewBusinessesPOBoxAddresses(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewPOBoxAddressesViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmViewPOBoxAddresses(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void ViewBusinessesEmailAddresses()
+        public void ViewBusinessesEmailAddresses(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ManageEmailsViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmManageAllEmails(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void ViewBusinessesPhoneNumbers()
+        public void ViewBusinessesPhoneNumbers(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ManagePhoneNumbersViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmManagingPhoneNumbers(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void EditBusinessAddress()
+        public void EditBusinessAddress(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ViewBusinessAddressesViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmEditBusinessAddress(vm))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void EditBusinessEmailAddress()
+        public void EditBusinessEmailAddress(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ManageEmailsViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmEditEmailAddress(vm))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
 
-        public void EditPhoneNumber()
+        public void EditPhoneNumber(Pass pass)
         {
+            AssignCollections(pass);
             var vm = new ManagePhoneNumbersViewModel(dataService);
-            vm.UpdatePass(Pass);
-            vm.LoadData();
+            vm.UpdatePass(pass);
             using (var form = new FrmEditPhoneNumber(vm))
             {
                 form.ShowDialog();
             }
-            Pass = vm.Pass;
         }
     }
 }

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -108,9 +108,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesEmailAddresses();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesEmailAddresses(passed);
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;
@@ -129,9 +127,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesAddresses();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesAddresses(passed);
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;
@@ -149,9 +145,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPOBoxAddresses();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesPOBoxAddresses(passed);
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;
@@ -169,9 +163,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPhoneNumbers();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesPhoneNumbers(passed);
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -156,9 +156,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPhoneNumbers();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesPhoneNumbers(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;
@@ -176,9 +174,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPOBoxAddresses();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesPOBoxAddresses(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;
@@ -196,9 +192,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesEmailAddresses();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesEmailAddresses(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;
@@ -217,9 +211,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesAddresses();
-                passed = navigation.Pass;
+                navigation.ViewBusinessesAddresses(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -101,9 +101,7 @@ namespace QuoteSwift
             string email = GetEmailSelection();
             passed.EmailToChange = email;
             passed.ChangeSpecificObject = true;
-            navigation.Pass = passed;
-            navigation.EditBusinessEmailAddress();
-            passed = navigation.Pass;
+            navigation.EditBusinessEmailAddress(passed);
 
             if (passed.BusinessToChange != null && passed.BusinessToChange.BusinessEmailAddressList != null)
             {

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -42,9 +42,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                navigation.EditPhoneNumber(passed);
                 passed.BusinessToChange.UpdateCellphoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";
@@ -56,9 +54,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                navigation.EditPhoneNumber(passed);
                 passed.CustomerToChange.UpdateCellphoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";
@@ -76,9 +72,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                navigation.EditPhoneNumber(passed);
                 passed.BusinessToChange.UpdateTelephoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";
@@ -90,9 +84,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                navigation.EditPhoneNumber(passed);
                 passed.CustomerToChange.UpdateTelephoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -45,9 +45,7 @@ namespace QuoteSwift
 
             passed.BusinessToChange = Business;
             passed.ChangeSpecificObject = false;
-            navigation.Pass = passed;
-            navigation.AddBusiness();
-            passed = navigation.Pass;
+            navigation.AddBusiness(passed);
 
             if (!ReplaceBusiness(Business, passed.BusinessToChange) && passed.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Business will not be stored.", "ERROR - Business Not Updated");
 
@@ -61,9 +59,7 @@ namespace QuoteSwift
         private void BtnAddBusiness_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.AddBusiness();
-            passed = navigation.Pass;
+            navigation.AddBusiness(passed);
             Show();
 
             LoadInformation();

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -45,9 +45,7 @@ namespace QuoteSwift
             passed.ChangeSpecificObject = false;
             passed.BusinessToChange = container;
 
-            navigation.Pass = passed;
-            navigation.AddCustomer();
-            passed = navigation.Pass;
+            navigation.AddCustomer(passed);
 
             if (!ReplaceCustomer(customer, passed.CustomerToChange, container) && passed.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Customer will not be stored.", "ERROR - Customer Not Updated");
 
@@ -63,9 +61,7 @@ namespace QuoteSwift
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.AddCustomer();
-            passed = navigation.Pass;
+            navigation.AddCustomer(passed);
             Show();
 
             LoadInformation();

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -77,9 +77,7 @@ namespace QuoteSwift
             passed.ChangeSpecificObject = false;
             passed.AddressToChange = address;
 
-            navigation.Pass = passed;
-            navigation.EditBusinessAddress();
-            passed = navigation.Pass;
+            navigation.EditBusinessAddress(passed);
 
             if (!ReplacePOBoxAddress(address, passed.AddressToChange)) MainProgramCode.ShowError("An error occurred during the updating procedure of the P.O.Box Address.\nUpdated P.O.Box address will not be stored.", "ERROR - P.O.Box Address Not Updated");
 

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -35,9 +35,7 @@ namespace QuoteSwift
         private void BtnAddPart_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.AddNewPart();
-            passed = navigation.Pass;
+            navigation.AddNewPart(passed);
             Show();
         }
 
@@ -51,9 +49,7 @@ namespace QuoteSwift
                 passed.PartToChange = objPartSelection;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.AddNewPart();
-                passed = navigation.Pass;
+                navigation.AddNewPart(passed);
                 Show();
 
                 passed.ChangeSpecificObject = false;

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -45,9 +45,7 @@ namespace QuoteSwift // Repair Quote Swift
                 passed.ChangeSpecificObject = false;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.CreateNewPump();
-                passed = navigation.Pass;
+                navigation.CreateNewPump(passed);
                 Show();
 
                 passed.ChangeSpecificObject = false;
@@ -64,9 +62,7 @@ namespace QuoteSwift // Repair Quote Swift
         private void BtnAddPump_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.CreateNewPump();
-            passed = navigation.Pass;
+            navigation.CreateNewPump(passed);
             Show();
         }
 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -24,9 +24,7 @@ namespace QuoteSwift
             if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null && viewModel.Pass.PassPumpList != null && viewModel.Pass.PassBusinessList[0].BusinessCustomerList != null)
             {
                 Hide();
-                navigation.Pass = viewModel.Pass;
-                navigation.CreateNewQuote();
-                viewModel.UpdatePass(navigation.Pass);
+                navigation.CreateNewQuote(viewModel.Pass);
                 try
                 {
                     Show();
@@ -58,9 +56,7 @@ namespace QuoteSwift
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.ViewAllPumps();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.ViewAllPumps(viewModel.Pass);
             try
             {
                 Show();
@@ -74,9 +70,7 @@ namespace QuoteSwift
         private void CreateNewPumpToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.CreateNewPump();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.CreateNewPump(viewModel.Pass);
             try
             {
                 Show();
@@ -95,9 +89,7 @@ namespace QuoteSwift
         private void AddNewCustomerToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.AddCustomer();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.AddCustomer(viewModel.Pass);
             try
             {
                 Show();
@@ -111,9 +103,7 @@ namespace QuoteSwift
         private void ViewAllCustomersToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.ViewCustomers();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.ViewCustomers(viewModel.Pass);
             try
             {
                 Show();
@@ -132,9 +122,7 @@ namespace QuoteSwift
         private void AddNewBusinessToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.AddBusiness();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.AddBusiness(viewModel.Pass);
             try
             {
                 Show();
@@ -148,9 +136,7 @@ namespace QuoteSwift
         private void ViewAllBusinessesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.ViewBusinesses();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.ViewBusinesses(viewModel.Pass);
             try
             {
                 Show();
@@ -186,13 +172,11 @@ namespace QuoteSwift
                 if (selected != null)
                 {
                     Hide();
-                    navigation.Pass = viewModel.Pass;
-                    navigation.Pass.QuoteTOChange = selected;
-                    navigation.Pass.ChangeSpecificObject = false;
-                    navigation.CreateNewQuote();
-                    navigation.Pass.QuoteTOChange = null;
-                    navigation.Pass.ChangeSpecificObject = false;
-                    viewModel.UpdatePass(navigation.Pass);
+                    viewModel.Pass.QuoteTOChange = selected;
+                    viewModel.Pass.ChangeSpecificObject = false;
+                    navigation.CreateNewQuote(viewModel.Pass);
+                    viewModel.Pass.QuoteTOChange = null;
+                    viewModel.Pass.ChangeSpecificObject = false;
                     Show();
                 }
             }
@@ -206,13 +190,11 @@ namespace QuoteSwift
                 if (selected != null)
                 {
                     this.Hide();
-                    navigation.Pass = viewModel.Pass;
-                    navigation.Pass.QuoteTOChange = selected;
-                    navigation.Pass.ChangeSpecificObject = true;
-                    navigation.CreateNewQuote();
-                    navigation.Pass.QuoteTOChange = null;
-                    navigation.Pass.ChangeSpecificObject = false;
-                    viewModel.UpdatePass(navigation.Pass);
+                    viewModel.Pass.QuoteTOChange = selected;
+                    viewModel.Pass.ChangeSpecificObject = true;
+                    navigation.CreateNewQuote(viewModel.Pass);
+                    viewModel.Pass.QuoteTOChange = null;
+                    viewModel.Pass.ChangeSpecificObject = false;
                     this.Show();
                 }
             }
@@ -221,9 +203,7 @@ namespace QuoteSwift
         private void ViewAllPartsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.ViewAllParts();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.ViewAllParts(viewModel.Pass);
             try
             {
                 Show();
@@ -242,9 +222,7 @@ namespace QuoteSwift
         private void AddNewPartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = viewModel.Pass;
-            navigation.AddNewPart();
-            viewModel.UpdatePass(navigation.Pass);
+            navigation.AddNewPart(viewModel.Pass);
             try
             {
                 Show();


### PR DESCRIPTION
## Summary
- stop storing a `Pass` in navigation service
- supply shared lists directly to view models
- update all navigation calls in forms
- adjust `INavigationService` method signatures

## Testing
- `dotnet build QuoteSwift.sln` *(fails: The type or namespace name 'Forms' does not exist)*
- `xbuild QuoteSwift.sln` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_68755c5482fc83259089f728a6f7a573