### PR TITLE
Remove obsolete Pass fields from forms

### DIFF
--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -8,13 +8,6 @@ namespace QuoteSwift
 
         readonly ManageEmailsViewModel viewModel;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
-        public ref Pass Passed { get => ref passed; }
 
         public FrmEditEmailAddress(ManageEmailsViewModel viewModel)
         {
@@ -26,12 +19,12 @@ namespace QuoteSwift
         {
             if (mtxtEmail.Text.Length > 3 && mtxtEmail.Text.Contains("@"))
             {
-                string oldEmail = passed.EmailToChange;
-                passed.EmailToChange = mtxtEmail.Text;
-                if (passed != null && passed.BusinessToChange != null)
+                string oldEmail = viewModel.Pass.EmailToChange;
+                viewModel.Pass.EmailToChange = mtxtEmail.Text;
+                if (viewModel.Pass != null && viewModel.Pass.BusinessToChange != null)
                 {
                     var vm = new AddBusinessViewModel(viewModel.DataService);
-                    vm.UpdatePass(passed);
+                    vm.UpdatePass(viewModel.Pass);
                     vm.LoadData();
                     FrmAddBusiness frmAddBusiness = new FrmAddBusiness(vm);
                     if (!frmAddBusiness.EmailAddressExisting(mtxtEmail.Text))
@@ -39,12 +32,12 @@ namespace QuoteSwift
                         MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
                         Close();
                     }
-                    else passed.EmailToChange = oldEmail;
+                    else viewModel.Pass.EmailToChange = oldEmail;
                 }
-                else if (passed != null && passed.CustomerToChange != null)
+                else if (viewModel.Pass != null && viewModel.Pass.CustomerToChange != null)
                 {
                     var vm = new AddCustomerViewModel(viewModel.DataService);
-                    vm.UpdatePass(passed);
+                    vm.UpdatePass(viewModel.Pass);
                     vm.LoadData();
                     FrmAddCustomer frmAddCustomer = new FrmAddCustomer(vm);
                     if (!frmAddCustomer.EmailAddressExisting(mtxtEmail.Text))
@@ -52,7 +45,7 @@ namespace QuoteSwift
                         MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
                         Close();
                     }
-                    else passed.EmailToChange = oldEmail;
+                    else viewModel.Pass.EmailToChange = oldEmail;
                 }
             }
             else MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
@@ -60,7 +53,7 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_Load(object sender, EventArgs e)
         {
-            mtxtEmail.Text = passed.EmailToChange;
+            mtxtEmail.Text = viewModel.Pass.EmailToChange;
 
         }
 
@@ -71,13 +64,19 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            MainProgramCode.CloseApplication(MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"), ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"), ref p);
+            viewModel.UpdatePass(p);
         }
 
         private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p2 = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p2);
+                viewModel.UpdatePass(p2);
+            }
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -87,7 +86,9 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p3 = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p3);
+            viewModel.UpdatePass(p3);
         }
     }
 }

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -11,12 +11,6 @@ namespace QuoteSwift
         readonly AddBusinessViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
         public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null)
         {
             InitializeComponent();
@@ -24,17 +18,20 @@ namespace QuoteSwift
             this.navigation = navigation;
         }
 
-        public ref Pass Passed { get => ref passed; }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnAddBusiness_Click(object sender, EventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
             {
                 if (viewModel.AddBusiness())
                 {
@@ -104,18 +101,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentBusiness.BusinessEmailAddressList != null)
             {
-                passed.BusinessToChange = viewModel.CurrentBusiness;
-                passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.BusinessToChange = viewModel.CurrentBusiness;
+                viewModel.Pass.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesEmailAddresses();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentBusiness = passed.BusinessToChange;
-                passed.BusinessToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentBusiness = viewModel.Pass.BusinessToChange;
+                viewModel.Pass.BusinessToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
 
             }
             else MainProgramCode.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Email Addresses");
@@ -125,18 +121,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentBusiness.BusinessAddressList != null)
             {
-                passed.BusinessToChange = viewModel.CurrentBusiness;
-                passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.BusinessToChange = viewModel.CurrentBusiness;
+                viewModel.Pass.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesAddresses();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentBusiness = passed.BusinessToChange;
-                passed.BusinessToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentBusiness = viewModel.Pass.BusinessToChange;
+                viewModel.Pass.BusinessToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
             }
             else MainProgramCode.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Addresses");
         }
@@ -145,18 +140,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentBusiness.BusinessPOBoxAddressList != null)
             {
-                passed.BusinessToChange = viewModel.CurrentBusiness;
-                passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.BusinessToChange = viewModel.CurrentBusiness;
+                viewModel.Pass.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesPOBoxAddresses();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentBusiness = passed.BusinessToChange;
-                passed.BusinessToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentBusiness = viewModel.Pass.BusinessToChange;
+                viewModel.Pass.BusinessToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
             }
             else MainProgramCode.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business P.O.Box Addresses");
         }
@@ -165,18 +159,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentBusiness.BusinessTelephoneNumberList != null || viewModel.CurrentBusiness.BusinessCellphoneNumberList != null)
             {
-                passed.BusinessToChange = viewModel.CurrentBusiness;
-                passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.BusinessToChange = viewModel.CurrentBusiness;
+                viewModel.Pass.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesPhoneNumbers();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentBusiness = passed.BusinessToChange;
-                passed.BusinessToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentBusiness = viewModel.Pass.BusinessToChange;
+                viewModel.Pass.BusinessToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
             }
             else MainProgramCode.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Business Phone Numbers");
         }
@@ -184,16 +177,16 @@ namespace QuoteSwift
         private void FrmAddBusiness_Load(object sender, EventArgs e)
         {
             viewModel.LoadData();
-            if (passed.BusinessToChange != null && passed.ChangeSpecificObject) // Change Existing Business Info
+            if (viewModel.Pass.BusinessToChange != null && viewModel.Pass.ChangeSpecificObject) // Change Existing Business Info
             {
-                viewModel.CurrentBusiness = passed.BusinessToChange;
+                viewModel.CurrentBusiness = viewModel.Pass.BusinessToChange;
             }
-            else if (passed.BusinessToChange != null && !passed.ChangeSpecificObject) // View Existing Business Info
+            else if (viewModel.Pass.BusinessToChange != null && !viewModel.Pass.ChangeSpecificObject) // View Existing Business Info
             {
-                viewModel.CurrentBusiness = passed.BusinessToChange;
+                viewModel.CurrentBusiness = viewModel.Pass.BusinessToChange;
                 ConvertToViewOnly();
             }
-            else if (passed.BusinessToChange == null && !passed.ChangeSpecificObject) // Add New Business Info
+            else if (viewModel.Pass.BusinessToChange == null && !viewModel.Pass.ChangeSpecificObject) // Add New Business Info
             {
                 viewModel.CurrentBusiness = new Business();
             }
@@ -210,13 +203,15 @@ namespace QuoteSwift
 
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ConvertToEdit();
-            passed.ChangeSpecificObject = true;
+            viewModel.Pass.ChangeSpecificObject = true;
         private void ConvertToViewOnly()
         {
             QuoteSwiftMainCode.ReadOnlyComponents(gbxBusinessAddress.Controls);
@@ -232,7 +227,7 @@ namespace QuoteSwift
             btnViewEmailAddresses.Enabled = true;
 
             btnAddBusiness.Visible = false;
-            Text = Text.Replace("Add Business", "Viewing " + passed.BusinessToChange.BusinessName);
+            Text = Text.Replace("Add Business", "Viewing " + viewModel.Pass.BusinessToChange.BusinessName);
             updateBusinessInformationToolStripMenuItem.Enabled = true;
         }
 

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -13,12 +13,6 @@ namespace QuoteSwift
 
         Business Container;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
         public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null)
         {
             InitializeComponent();
@@ -34,15 +28,15 @@ namespace QuoteSwift
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                var p = passed;
+                var p = viewModel.Pass;
                 MainProgramCode.CloseApplication(true, ref p);
-                passed = p;
+                viewModel.UpdatePass(p);
             }
         }
 
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
-            if (ValidBusiness() && !passed.ChangeSpecificObject)
+            if (ValidBusiness() && !viewModel.Pass.ChangeSpecificObject)
             {
                 Business linkBusiness = GetSelectedBusiness();
                 viewModel.CurrentCustomer.CustomerName = string.Empty;
@@ -55,9 +49,9 @@ namespace QuoteSwift
                     ResetScreenInput();
                 }
             }
-            else if (ValidBusiness() && passed.ChangeSpecificObject)
+            else if (ValidBusiness() && viewModel.Pass.ChangeSpecificObject)
             {
-                string oldName = passed.CustomerToChange.CustomerCompanyName;
+                string oldName = viewModel.Pass.CustomerToChange.CustomerCompanyName;
                 viewModel.CurrentCustomer.CustomerName = string.Empty;
                 viewModel.CurrentCustomer.CustomerLegalDetails = new Legal(mtxtRegistrationNumber.Text, mtxtVATNumber.Text);
                 viewModel.CurrentCustomer.VendorNumber = mtxtVendorNumber.Text;
@@ -84,18 +78,18 @@ namespace QuoteSwift
                 cbBusinessSelection.ValueMember = "BusinessName";
             }
 
-            if (passed.CustomerToChange != null && passed.ChangeSpecificObject) // Change Existing Customer Info
+            if (viewModel.Pass.CustomerToChange != null && viewModel.Pass.ChangeSpecificObject) // Change Existing Customer Info
             {
-                viewModel.CurrentCustomer = passed.CustomerToChange;
+                viewModel.CurrentCustomer = viewModel.Pass.CustomerToChange;
             }
-            else if (passed.CustomerToChange != null && !passed.ChangeSpecificObject) // View Existing Customer Info
+            else if (viewModel.Pass.CustomerToChange != null && !viewModel.Pass.ChangeSpecificObject) // View Existing Customer Info
             {
-                viewModel.CurrentCustomer = passed.CustomerToChange;
+                viewModel.CurrentCustomer = viewModel.Pass.CustomerToChange;
                 ConvertToViewOnly();
                 LoadInformation();
 
             }
-            else if (passed.CustomerToChange == null && !passed.ChangeSpecificObject) // Add New Business Info
+            else if (viewModel.Pass.CustomerToChange == null && !viewModel.Pass.ChangeSpecificObject) // Add New Business Info
             {
                 viewModel.CurrentCustomer = new Customer();
             }
@@ -152,18 +146,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentCustomer.CustomerCellphoneNumberList != null || viewModel.CurrentCustomer.CustomerTelephoneNumberList != null)
             {
-                passed.CustomerToChange = viewModel.CurrentCustomer;
-                passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.CustomerToChange = viewModel.CurrentCustomer;
+                viewModel.Pass.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesPhoneNumbers();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentCustomer = passed.CustomerToChange;
-                passed.CustomerToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentCustomer = viewModel.Pass.CustomerToChange;
+                viewModel.Pass.CustomerToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
             }
             else MainProgramCode.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Customer Phone Numbers");
         }
@@ -172,18 +165,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentCustomer.CustomerPOBoxAddress != null)
             {
-                passed.CustomerToChange = viewModel.CurrentCustomer;
-                passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.CustomerToChange = viewModel.CurrentCustomer;
+                viewModel.Pass.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesPOBoxAddresses();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentCustomer = passed.CustomerToChange;
-                passed.CustomerToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentCustomer = viewModel.Pass.CustomerToChange;
+                viewModel.Pass.CustomerToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
             }
             else MainProgramCode.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer P.O.Box Addresses");
         }
@@ -192,18 +184,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentCustomer.CustomerEmailList != null)
             {
-                passed.CustomerToChange = viewModel.CurrentCustomer;
-                passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.CustomerToChange = viewModel.CurrentCustomer;
+                viewModel.Pass.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesEmailAddresses();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentCustomer = passed.CustomerToChange;
-                passed.CustomerToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentCustomer = viewModel.Pass.CustomerToChange;
+                viewModel.Pass.CustomerToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
 
             }
             else MainProgramCode.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Email Addresses");
@@ -213,18 +204,17 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentCustomer != null)
             {
-                passed.CustomerToChange = viewModel.CurrentCustomer;
-                passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
+                viewModel.Pass.CustomerToChange = viewModel.CurrentCustomer;
+                viewModel.Pass.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.ViewBusinessesAddresses();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                viewModel.CurrentCustomer = passed.CustomerToChange;
-                passed.CustomerToChange = null;
-                passed.ChangeSpecificObject = false;
+                viewModel.CurrentCustomer = viewModel.Pass.CustomerToChange;
+                viewModel.Pass.CustomerToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
             }
             else MainProgramCode.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Addresses");
         }
@@ -232,7 +222,7 @@ namespace QuoteSwift
         private void UpdatedCustomerInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ConvertToEdit();
-            passed.ChangeSpecificObject = true;
+            viewModel.Pass.ChangeSpecificObject = true;
             updatedCustomerInformationToolStripMenuItem.Enabled = false;
         }
 
@@ -247,9 +237,9 @@ namespace QuoteSwift
 
         private void FrmAddCustomer_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var p = passed;
+            var p = viewModel.Pass;
             MainProgramCode.CloseApplication(true, ref p);
-            passed = p;
+            viewModel.UpdatePass(p);
         }
 
         /** Form Specific Functions And Procedures: 
@@ -416,8 +406,8 @@ namespace QuoteSwift
         {
             if (viewModel.CurrentCustomer != null)
             {
-                Container = passed.BusinessToChange;
-                passed.BusinessToChange = null;
+                Container = viewModel.Pass.BusinessToChange;
+                viewModel.Pass.BusinessToChange = null;
 
                 txtCustomerCompanyName.Text = viewModel.CurrentCustomer.CustomerCompanyName;
                 cbBusinessSelection.Text = Container.BusinessName;
@@ -457,16 +447,16 @@ namespace QuoteSwift
 
             btnAddCustomer.Visible = true;
             btnAddCustomer.Text = "Update Customer";
-            if (passed != null && passed.BusinessToChange != null)
-                Text = Text.Replace("Viewing " + passed.BusinessToChange.BusinessName, "Updating " + passed.BusinessToChange.BusinessName);
-            if (passed != null && passed.CustomerToChange != null)
-                Text = Text.Replace("Viewing " + passed.CustomerToChange.CustomerName, "Updating " + passed.CustomerToChange.CustomerName);
+            if (viewModel.Pass != null && viewModel.Pass.BusinessToChange != null)
+                Text = Text.Replace("Viewing " + viewModel.Pass.BusinessToChange.BusinessName, "Updating " + viewModel.Pass.BusinessToChange.BusinessName);
+            if (viewModel.Pass != null && viewModel.Pass.CustomerToChange != null)
+                Text = Text.Replace("Viewing " + viewModel.Pass.CustomerToChange.CustomerName, "Updating " + viewModel.Pass.CustomerToChange.CustomerName);
             updatedCustomerInformationToolStripMenuItem.Enabled = false;
         }
 
         private Business GetSelectedBusiness()
         {
-            if (cbBusinessSelection.Text.Length > 0 && passed.BusinessLookup.TryGetValue(cbBusinessSelection.Text, out Business business))
+            if (cbBusinessSelection.Text.Length > 0 && viewModel.Pass.BusinessLookup.TryGetValue(cbBusinessSelection.Text, out Business business))
             {
                 return business;
             }

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -10,13 +10,6 @@ namespace QuoteSwift
         readonly AddPartViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
-        public ref Pass Passed { get => ref passed; }
 
         public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null)
         {
@@ -46,7 +39,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
@@ -55,7 +52,7 @@ namespace QuoteSwift
             if (!ValidInput())
                 return;
 
-            bool updating = passed.ChangeSpecificObject;
+            bool updating = viewModel.Pass.ChangeSpecificObject;
 
             if (!viewModel.AddOrUpdatePart())
             {
@@ -66,7 +63,7 @@ namespace QuoteSwift
             if (updating)
             {
                 MainProgramCode.ShowInformation("Successfully updated the part", "CONFIRMATION - Update Successful");
-                passed.ChangeSpecificObject = false;
+                viewModel.Pass.ChangeSpecificObject = false;
                 Close();
             }
             else
@@ -144,13 +141,13 @@ namespace QuoteSwift
 
         private void FrmAddPart_Load(object sender, EventArgs e)
         {
-            if (passed.ChangeSpecificObject && passed.PartToChange != null)
+            if (viewModel.Pass.ChangeSpecificObject && viewModel.Pass.PartToChange != null)
             {
                 ReadWriteComponents();
                 btnAddPart.Text = "Update";
                 updatePartToolStripMenuItem.Enabled = false;
             }
-            else if (!passed.ChangeSpecificObject && passed.PartToChange != null)
+            else if (!viewModel.Pass.ChangeSpecificObject && viewModel.Pass.PartToChange != null)
             {
                 btnAddPart.Visible = false;
                 Read_OnlyComponents();
@@ -244,12 +241,12 @@ namespace QuoteSwift
 
         private void UpdatePartToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
-                if (MainProgramCode.RequestConfirmation("You are currently only viewing " + passed.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
+            if (!viewModel.Pass.ChangeSpecificObject)
+                if (MainProgramCode.RequestConfirmation("You are currently only viewing " + viewModel.Pass.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
                 {
                     ReadWriteComponents();
                     updatePartToolStripMenuItem.Enabled = false;
-                    passed.ChangeSpecificObject = true;
+                    viewModel.Pass.ChangeSpecificObject = true;
                 }
         }
 
@@ -260,7 +257,9 @@ namespace QuoteSwift
 
         private void FrmAddPart_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
 
 

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -11,13 +11,6 @@ namespace QuoteSwift
         readonly AddPumpViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
-        public ref Pass Passed { get => ref passed; }
 
         public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null)
         {
@@ -29,7 +22,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnAddPump_Click(object sender, EventArgs e)
@@ -48,13 +45,13 @@ namespace QuoteSwift
             viewModel.CurrentPump = new Pump(mtxtPumpName.Text, mtxtPumpDescription.Text, QuoteSwiftMainCode.ParseDecimal(mtxtNewPumpPrice.Text), ref newPumpParts);
 
             bool result;
-            if (passed.ChangeSpecificObject)
+            if (viewModel.Pass.ChangeSpecificObject)
             {
                 result = viewModel.UpdatePump();
                 if (result)
                 {
-                    MainProgramCode.ShowInformation(passed.PumpToChange.PumpName + " has been updated in the list of pumps", "INFORMATION - Pump Update Successfully");
-                    passed.ChangeSpecificObject = false;
+                    MainProgramCode.ShowInformation(viewModel.Pass.PumpToChange.PumpName + " has been updated in the list of pumps", "INFORMATION - Pump Update Successfully");
+                    viewModel.Pass.ChangeSpecificObject = false;
                     ConvertToViewForm();
                     updatePumpToolStripMenuItem.Enabled = true;
                 }
@@ -80,31 +77,31 @@ namespace QuoteSwift
 
         private void MtxtPumpName_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
                 ChangeViewToEdit();
         }
 
         private void MtxtPumpDescription_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
                 ChangeViewToEdit();
         }
 
         private void MtxtNewPumpPrice_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
                 ChangeViewToEdit();
         }
 
         private void DgvMandatoryPartView_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
                 ChangeViewToEdit();
         }
 
         private void DgvNonMandatoryPartView_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
                 ChangeViewToEdit();
         }
 
@@ -113,19 +110,19 @@ namespace QuoteSwift
             LoadMandatoryParts();
             LoadNonMandatoryParts();
 
-            if (passed != null && passed.PumpToChange != null && passed.ChangeSpecificObject == true) //Determine if Edit
+            if (viewModel.Pass != null && viewModel.Pass.PumpToChange != null && viewModel.Pass.ChangeSpecificObject == true) //Determine if Edit
             {
                 ConvertToEditForm();
                 Read_OnlyMainComponents();
                 PopulateFormWithPassedPump();
             }
-            else if (passed != null && passed.PumpToChange != null && passed.ChangeSpecificObject == false) //Determine if View
+            else if (viewModel.Pass != null && viewModel.Pass.PumpToChange != null && viewModel.Pass.ChangeSpecificObject == false) //Determine if View
             {
                 ConvertToViewForm();
                 Read_OnlyMainComponents();
                 PopulateFormWithPassedPump();
             }
-            else if (passed != null && passed.PumpToChange == null && passed.ChangeSpecificObject == false) // Determine if Add New
+            else if (viewModel.Pass != null && viewModel.Pass.PumpToChange == null && viewModel.Pass.ChangeSpecificObject == false) // Determine if Add New
             {
                 mtxtPumpName.Focus();
             }
@@ -179,7 +176,7 @@ namespace QuoteSwift
         void ConvertToEditForm()
         {
             ReadWriteMainComponents();
-            Text = "Updating " + passed.PumpToChange.PumpName + " Pump";
+            Text = "Updating " + viewModel.Pass.PumpToChange.PumpName + " Pump";
             btnAddPump.Text = "Update Pump";
             btnAddPump.Visible = true;
             updatePumpToolStripMenuItem.Enabled = true;
@@ -189,24 +186,24 @@ namespace QuoteSwift
 
         void ConvertToViewForm()
         {
-            Text = "Viewing " + passed.PumpToChange.PumpName + " Pump";
+            Text = "Viewing " + viewModel.Pass.PumpToChange.PumpName + " Pump";
             btnAddPump.Visible = false;
             Read_OnlyMainComponents();
             updatePumpToolStripMenuItem.Enabled = false;
         }
 
-        //Populates the form with the passed Pump object and checks the check boxes in the data grid view where parts are being used.
+        //Populates the form with the viewModel.Pass Pump object and checks the check boxes in the data grid view where parts are being used.
 
         void PopulateFormWithPassedPump()
         {
-            mtxtNewPumpPrice.Text = passed.PumpToChange.NewPumpPrice.ToString();
-            mtxtPumpDescription.Text = passed.PumpToChange.PumpDescription;
-            mtxtPumpName.Text = passed.PumpToChange.PumpName;
+            mtxtNewPumpPrice.Text = viewModel.Pass.PumpToChange.NewPumpPrice.ToString();
+            mtxtPumpDescription.Text = viewModel.Pass.PumpToChange.PumpDescription;
+            mtxtPumpName.Text = viewModel.Pass.PumpToChange.PumpName;
 
             int mIndex = 0;
-            foreach (var part in passed.MandatoryParts)
+            foreach (var part in viewModel.Pass.MandatoryParts)
             {
-                foreach (var pumpPart in passed.PumpToChange.PartList)
+                foreach (var pumpPart in viewModel.Pass.PumpToChange.PartList)
                 {
                     if (part.OriginalItemPartNumber == pumpPart.PumpPart.OriginalItemPartNumber)
                     {
@@ -219,9 +216,9 @@ namespace QuoteSwift
             }
 
             int nmIndex = 0;
-            foreach (var part in passed.NonMandatoryParts)
+            foreach (var part in viewModel.Pass.NonMandatoryParts)
             {
-                foreach (var pumpPart in passed.PumpToChange.PartList)
+                foreach (var pumpPart in viewModel.Pass.PumpToChange.PartList)
                 {
                     if (part.OriginalItemPartNumber == pumpPart.PumpPart.OriginalItemPartNumber)
                     {
@@ -278,7 +275,7 @@ namespace QuoteSwift
                         try
                         {
                             string oKey = row.Cells["clmOriginalPartNumber"].Value?.ToString();
-                            if (passed.PassPartList.TryGetValue(StringUtil.NormalizeKey(oKey), out var part))
+                            if (viewModel.Pass.PassPartList.TryGetValue(StringUtil.NormalizeKey(oKey), out var part))
                                 newPart = new Pump_Part(part,
                                     QuoteSwiftMainCode.ParseInt(row.Cells["clmMPartQuantity"].Value.ToString()));
                             else
@@ -312,7 +309,7 @@ namespace QuoteSwift
                         try
                         {
                             string oKey = row.Cells["clmOriginalPartNumber"].Value?.ToString();
-                            if (passed.PassPartList.TryGetValue(StringUtil.NormalizeKey(oKey), out var part))
+                            if (viewModel.Pass.PassPartList.TryGetValue(StringUtil.NormalizeKey(oKey), out var part))
                                 newPart = new Pump_Part(part,
                                     QuoteSwiftMainCode.ParseInt(row.Cells["clmNMPartQuantity"].Value.ToString()));
                             else
@@ -340,23 +337,23 @@ namespace QuoteSwift
 
         void ChangeViewToEdit()
         {
-            if (passed != null && passed.PumpToChange != null && passed.ChangeSpecificObject == false)
-                if (MainProgramCode.RequestConfirmation("You are currently viewing " + passed.PumpToChange.PumpName + " pump, would you like to edit it instead?", "REQUEST - View To Edit REQUEST"))
+            if (viewModel.Pass != null && viewModel.Pass.PumpToChange != null && viewModel.Pass.ChangeSpecificObject == false)
+                if (MainProgramCode.RequestConfirmation("You are currently viewing " + viewModel.Pass.PumpToChange.PumpName + " pump, would you like to edit it instead?", "REQUEST - View To Edit REQUEST"))
                 {
                     ConvertToEditForm();
-                    passed.ChangeSpecificObject = true;
+                    viewModel.Pass.ChangeSpecificObject = true;
                 }
         }
 
         void RecordNewInformation()
         {
-            if (mtxtPumpName.Text != passed.PumpToChange.PumpName) passed.PumpToChange.PumpName = mtxtPumpName.Text;
+            if (mtxtPumpName.Text != viewModel.Pass.PumpToChange.PumpName) viewModel.Pass.PumpToChange.PumpName = mtxtPumpName.Text;
 
-            if (mtxtPumpDescription.Text != passed.PumpToChange.PumpDescription) passed.PumpToChange.PumpDescription = mtxtPumpDescription.Text;
+            if (mtxtPumpDescription.Text != viewModel.Pass.PumpToChange.PumpDescription) viewModel.Pass.PumpToChange.PumpDescription = mtxtPumpDescription.Text;
 
-            if (NewPumpValueInput() != passed.PumpToChange.NewPumpPrice) passed.PumpToChange.NewPumpPrice = NewPumpValueInput();
+            if (NewPumpValueInput() != viewModel.Pass.PumpToChange.NewPumpPrice) viewModel.Pass.PumpToChange.NewPumpPrice = NewPumpValueInput();
 
-            passed.PumpToChange.PartList = RetreivePumpPartList();
+            viewModel.Pass.PumpToChange.PartList = RetreivePumpPartList();
         }
 
         decimal NewPumpValueInput()
@@ -369,11 +366,11 @@ namespace QuoteSwift
 
         void LoadMandatoryParts()
         {
-            if (passed.PassPartList != null)
+            if (viewModel.Pass.PassPartList != null)
             {
                 dgvMandatoryPartView.Rows.Clear();
 
-                foreach (var part in passed.MandatoryParts)
+                foreach (var part in viewModel.Pass.MandatoryParts)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvMandatoryPartView.Rows.Add(part.PartName,
@@ -389,11 +386,11 @@ namespace QuoteSwift
 
         void LoadNonMandatoryParts()
         {
-            if (passed.PassPartList != null)
+            if (viewModel.Pass.PassPartList != null)
             {
                 dgvNonMandatoryPartView.Rows.Clear();
 
-                foreach (var part in passed.NonMandatoryParts)
+                foreach (var part in viewModel.Pass.NonMandatoryParts)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvNonMandatoryPartView.Rows.Add(part.PartName,
@@ -414,7 +411,7 @@ namespace QuoteSwift
 
         private void UpdatePumpToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
+            if (!viewModel.Pass.ChangeSpecificObject)
                 ChangeViewToEdit();
             updatePumpToolStripMenuItem.Enabled = false;
         }
@@ -426,7 +423,9 @@ namespace QuoteSwift
 
         private void FrmAddPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
 
         /*********************************************************************************/

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -14,11 +14,6 @@ namespace QuoteSwift
     {
         readonly CreateQuoteViewModel viewModel;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
 
         public Quote NewQuote;
 
@@ -30,13 +25,12 @@ namespace QuoteSwift
             this.viewModel = viewModel;
         }
 
-        public ref Pass Passed { get => ref passed; }
 
         private void BtnComplete_Click(object sender, EventArgs e)
         {
-            if (passed != null && !passed.ChangeSpecificObject && passed.QuoteTOChange != null)
+            if (viewModel.Pass != null && !viewModel.Pass.ChangeSpecificObject && viewModel.Pass.QuoteTOChange != null)
             {
-                NewQuote = passed.QuoteTOChange;
+                NewQuote = viewModel.Pass.QuoteTOChange;
                 ExportQuoteToTemplate();
                 NewQuote = null;
             }
@@ -54,12 +48,12 @@ namespace QuoteSwift
                     }
 
 
-                    if (passed.PassQuoteMap != null)
+                    if (viewModel.Pass.PassQuoteMap != null)
                     {
-                        passed.PassQuoteMap[NewQuote.QuoteNumber] = NewQuote;
+                        viewModel.Pass.PassQuoteMap[NewQuote.QuoteNumber] = NewQuote;
                     }
                     else
-                        passed.PassQuoteMap = new SortedDictionary<string, Quote> { [NewQuote.QuoteNumber] = NewQuote };
+                        viewModel.Pass.PassQuoteMap = new SortedDictionary<string, Quote> { [NewQuote.QuoteNumber] = NewQuote };
 
                     if (MainProgramCode.RequestConfirmation("The quote was successfully created. Would you like to export the quote an Excel document?", "REQUEST - Export Quote to Excel"))
                     {
@@ -67,7 +61,7 @@ namespace QuoteSwift
                     }
                     else MainProgramCode.ShowInformation("The quote was successfully added to the list of quotes.", "INFORMATION - Quote Added To List");
 
-                    passed.QuoteTOChange = NewQuote;
+                    viewModel.Pass.QuoteTOChange = NewQuote;
                     ConvertToReadOnly();
                     createNewQuoteUsingThisQuoteToolStripMenuItem.Enabled = true;
                 }
@@ -83,7 +77,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void CbxPumpSelection_SelectedIndexChanged(object sender, EventArgs e)
@@ -93,13 +91,13 @@ namespace QuoteSwift
 
         private void FrmCreateQuote_Load(object sender, EventArgs e)
         {
-            if (passed != null && !passed.ChangeSpecificObject && passed.QuoteTOChange != null) // View Quote
+            if (viewModel.Pass != null && !viewModel.Pass.ChangeSpecificObject && viewModel.Pass.QuoteTOChange != null) // View Quote
             {
                 LoadFromPassedObject();
                 ConvertToReadOnly();
                 createNewQuoteUsingThisQuoteToolStripMenuItem.Enabled = true;
             }
-            else if (passed != null && passed.ChangeSpecificObject && passed.QuoteTOChange != null)//Create New Quote Using Passed Quote
+            else if (viewModel.Pass != null && viewModel.Pass.ChangeSpecificObject && viewModel.Pass.QuoteTOChange != null)//Create New Quote Using Passed Quote
             {
                 LoadFromPassedObject();
 
@@ -127,7 +125,7 @@ namespace QuoteSwift
                 dtpPaymentTerm.Value = dtpQuoteCreationDate.Value.AddMonths(1);
 
                 Text = Text.Replace("<< Business Name >>", GetBusinessSelection().BusinessName);
-                if (passed.PassQuoteMap == null || passed.PassQuoteMap.Count == 0)
+                if (viewModel.Pass.PassQuoteMap == null || viewModel.Pass.PassQuoteMap.Count == 0)
                 {
                     cbxUseAutomaticNumberingScheme.Checked = false;
                     cbxUseAutomaticNumberingScheme.Enabled = false;
@@ -190,9 +188,9 @@ namespace QuoteSwift
             Business business;
             string SearchName = cbxBusinessSelection.Text;
 
-            if (passed.PassBusinessList != null && SearchName.Length > 1)
+            if (viewModel.Pass.PassBusinessList != null && SearchName.Length > 1)
             {
-                business = passed.PassBusinessList.SingleOrDefault(p => p.BusinessName == SearchName);
+                business = viewModel.Pass.PassBusinessList.SingleOrDefault(p => p.BusinessName == SearchName);
                 return business;
             }
 
@@ -203,7 +201,7 @@ namespace QuoteSwift
         {
             string SearchName = cbxCustomerSelection.Text;
 
-            if (SearchName.Length > 1 && passed.PassBusinessList != null)
+            if (SearchName.Length > 1 && viewModel.Pass.PassBusinessList != null)
             {
                 Business selected = GetBusinessSelection();
                 if (selected != null && selected.BusinessCustomerList != null)
@@ -219,7 +217,7 @@ namespace QuoteSwift
         {
             string SearchName = cbxPumpSelection.Text;
 
-            if (passed.PassPumpList != null) return passed.PassPumpList.SingleOrDefault(p => p.PumpName == SearchName);
+            if (viewModel.Pass.PassPumpList != null) return viewModel.Pass.PassPumpList.SingleOrDefault(p => p.PumpName == SearchName);
 
             return null;
         }
@@ -255,7 +253,7 @@ namespace QuoteSwift
 
         private void LinkBusinessTelephone(Business b, ref ComboBox cb)
         {
-            if (passed != null && passed.PassBusinessList != null && b != null)
+            if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null && b != null)
             {
                 //Created a Binding Source for the Business' Telephone list to link the source
                 //directly to the combo-box's data-source:
@@ -268,7 +266,7 @@ namespace QuoteSwift
 
         private void LinkBusinessCellphone(Business b, ref ComboBox cb)
         {
-            if (passed != null && passed.PassBusinessList != null && b != null)
+            if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null && b != null)
             {
                 //Created a Binding Source for the Business' Cellphone list to link the source
                 //directly to the combo-box's data-source:
@@ -281,7 +279,7 @@ namespace QuoteSwift
 
         private void LinkBusinessEmail(Business b, ref ComboBox cb)
         {
-            if (passed != null && passed.PassBusinessList != null && b != null)
+            if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null && b != null)
             {
                 //Created a Binding Source for the Business' Email list to link the source
                 //directly to the combo-box's data-source:
@@ -344,12 +342,12 @@ namespace QuoteSwift
 
         private void LinkPumpList(ref ComboBox cb)
         {
-            if (passed != null && passed.PassPumpList != null)
+            if (viewModel.Pass != null && viewModel.Pass.PassPumpList != null)
             {
                 //Created a Binding Source for the Pumps list to link the source
                 //directly to the combo-box's data-source:
 
-                BindingSource ComboBoxSource = new BindingSource { DataSource = passed.PassPumpList };
+                BindingSource ComboBoxSource = new BindingSource { DataSource = viewModel.Pass.PassPumpList };
 
                 cb.DataSource = ComboBoxSource.DataSource;
 
@@ -383,7 +381,7 @@ namespace QuoteSwift
         private void LoadComboBoxes()
         {
             ViewCustomersViewModel vm = new ViewCustomersViewModel(viewModel.DataService);
-            vm.UpdatePass(passed);
+            vm.UpdatePass(viewModel.Pass);
             vm.LoadData();
             if (vm.Pass != null && vm.Pass.PassBusinessList != null)
             {
@@ -408,7 +406,7 @@ namespace QuoteSwift
             dgvMandatoryPartReplacement.Rows.Clear();
             DgvNonMandatoryPartReplacement.Rows.Clear();
 
-            if (passed != null && passed.PassPumpList != null && cbxPumpSelection.SelectedIndex > -1)
+            if (viewModel.Pass != null && viewModel.Pass.PassPumpList != null && cbxPumpSelection.SelectedIndex > -1)
             {
                 Pump display = GetPumpSelection();
 
@@ -780,9 +778,9 @@ namespace QuoteSwift
         {
             Quote Provided = q;
 
-            if (passed.PassQuoteMap != null)
+            if (viewModel.Pass.PassQuoteMap != null)
             {
-                foreach (var kv in passed.PassQuoteMap)
+                foreach (var kv in viewModel.Pass.PassQuoteMap)
                 {
                     Quote ql = kv.Value;
                     if (ql.QuoteJobNumber == Provided.QuoteJobNumber || ql.QuoteNumber == Provided.QuoteNumber)
@@ -795,11 +793,11 @@ namespace QuoteSwift
 
         private void GetNewQuotenumber()
         {
-            if (passed != null && passed.PassQuoteMap != null && passed.PassQuoteMap.Count > 0)
+            if (viewModel.Pass != null && viewModel.Pass.PassQuoteMap != null && viewModel.Pass.PassQuoteMap.Count > 0)
             {
-                Quote temp = passed.PassQuoteMap.First().Value;
+                Quote temp = viewModel.Pass.PassQuoteMap.First().Value;
                 int LastQuoteNumber = GetQuoteNumber(ref temp);
-                foreach (var q in passed.PassQuoteMap.Values.Skip(1))
+                foreach (var q in viewModel.Pass.PassQuoteMap.Values.Skip(1))
                 {
                     temp = q;
                     if (LastQuoteNumber < GetQuoteNumber(ref temp)) LastQuoteNumber = GetQuoteNumber(ref temp);
@@ -843,11 +841,11 @@ namespace QuoteSwift
             dgvMandatoryPartReplacement.Rows.Clear();
             DgvNonMandatoryPartReplacement.Rows.Clear();
             //Manually setting the data grid's mandatory rows' values:
-            cbxPumpSelection.Text = passed.QuoteTOChange.PumpName;
+            cbxPumpSelection.Text = viewModel.Pass.QuoteTOChange.PumpName;
 
-            for (int i = 0; i < passed.QuoteTOChange.QuoteMandatoryPartList.Count; i++)
+            for (int i = 0; i < viewModel.Pass.QuoteTOChange.QuoteMandatoryPartList.Count; i++)
             {
-                Quote_Part data = passed.QuoteTOChange.QuoteMandatoryPartList[i];
+                Quote_Part data = viewModel.Pass.QuoteTOChange.QuoteMandatoryPartList[i];
                 if (data != null)
                     dgvMandatoryPartReplacement.Rows.Add(data.PumpPart.PumpPart.NewPartNumber,
                                                          data.PumpPart.PumpPart.PartDescription,
@@ -860,9 +858,9 @@ namespace QuoteSwift
                                                          ((data.UnitPrice * data.New) + (data.Repaired * (data.UnitPrice / data.RepairDevider))),
                                                          data.RepairDevider);
             }
-            for (int i = 0; i < passed.QuoteTOChange.QuoteNewList.Count; i++)
+            for (int i = 0; i < viewModel.Pass.QuoteTOChange.QuoteNewList.Count; i++)
             {
-                Quote_Part data = passed.QuoteTOChange.QuoteNewList[i];
+                Quote_Part data = viewModel.Pass.QuoteTOChange.QuoteNewList[i];
                 if (data != null)
                     DgvNonMandatoryPartReplacement.Rows.Add(data.PumpPart.PumpPart.NewPartNumber,
                                                          data.PumpPart.PumpPart.PartDescription,
@@ -875,58 +873,58 @@ namespace QuoteSwift
                                                          ((data.UnitPrice * data.New) + (data.Repaired * (data.UnitPrice / data.RepairDevider))),
                                                          data.RepairDevider);
             }
-            DgvNonMandatoryPartReplacement.Rows.Add("TS6MACH", "MACHINING", 1, 0, 0, 1, 0, passed.QuoteTOChange.QuoteCost.Machining, 0, 1);
-            DgvNonMandatoryPartReplacement.Rows.Add("TS6LAB", "LABOUR", 1, 0, 0, 1, 0, passed.QuoteTOChange.QuoteCost.Labour, 0, 1);
-            DgvNonMandatoryPartReplacement.Rows.Add("CON TS6", "CONSUMABLES incl COLLECTION & DELIVERY", 1, 0, 0, 1, 0, passed.QuoteTOChange.QuoteCost.Consumables, 0, 1);
+            DgvNonMandatoryPartReplacement.Rows.Add("TS6MACH", "MACHINING", 1, 0, 0, 1, 0, viewModel.Pass.QuoteTOChange.QuoteCost.Machining, 0, 1);
+            DgvNonMandatoryPartReplacement.Rows.Add("TS6LAB", "LABOUR", 1, 0, 0, 1, 0, viewModel.Pass.QuoteTOChange.QuoteCost.Labour, 0, 1);
+            DgvNonMandatoryPartReplacement.Rows.Add("CON TS6", "CONSUMABLES incl COLLECTION & DELIVERY", 1, 0, 0, 1, 0, viewModel.Pass.QuoteTOChange.QuoteCost.Consumables, 0, 1);
 
             //Loading Business Information:
-            Address add = passed.QuoteTOChange.QuoteBusinessPOBox;
-            cbxBusinessSelection.Text = passed.QuoteTOChange.QuoteCompany.BusinessName;
+            Address add = viewModel.Pass.QuoteTOChange.QuoteBusinessPOBox;
+            cbxBusinessSelection.Text = viewModel.Pass.QuoteTOChange.QuoteCompany.BusinessName;
             CbxPOBoxSelection.Text = add.AddressDescription;
             lblBusinessPOBoxNumber.Text = "P.O.Box " + add.AddressStreetNumber;
             lblBusinessPOBoxSuburb.Text = add.AddressSuburb;
             lblBusinessPOBoxCity.Text = add.AddressCity;
             lblBusinessPOBoxAreaCode.Text = add.AddressAreaCode.ToString();
 
-            lblBusinessRegistrationNumber.Text = passed.QuoteTOChange.QuoteCompany.BusinessLegalDetails.RegistrationNumber;
-            lblBusinessVATNumber.Text = passed.QuoteTOChange.QuoteCompany.BusinessLegalDetails.VatNumber;
-            cbxBusinessTelephoneNumberSelection.Text = passed.QuoteTOChange.Telefone;
-            cbxBusinessCellphoneNumberSelection.Text = passed.QuoteTOChange.Cellphone;
-            cbxBusinessEmailAddressSelection.Text = passed.QuoteTOChange.Email;
+            lblBusinessRegistrationNumber.Text = viewModel.Pass.QuoteTOChange.QuoteCompany.BusinessLegalDetails.RegistrationNumber;
+            lblBusinessVATNumber.Text = viewModel.Pass.QuoteTOChange.QuoteCompany.BusinessLegalDetails.VatNumber;
+            cbxBusinessTelephoneNumberSelection.Text = viewModel.Pass.QuoteTOChange.Telefone;
+            cbxBusinessCellphoneNumberSelection.Text = viewModel.Pass.QuoteTOChange.Cellphone;
+            cbxBusinessEmailAddressSelection.Text = viewModel.Pass.QuoteTOChange.Email;
 
             //Loading Customer Section:
-            add = passed.QuoteTOChange.QuoteCustomerPOBox;
-            cbxCustomerSelection.Text = passed.QuoteTOChange.QuoteCustomer.CustomerCompanyName;
+            add = viewModel.Pass.QuoteTOChange.QuoteCustomerPOBox;
+            cbxCustomerSelection.Text = viewModel.Pass.QuoteTOChange.QuoteCustomer.CustomerCompanyName;
             CbxCustomerPOBoxSelection.Text = add.AddressDescription;
             lblCustomerPOBoxStreetName.Text = "Private Bag X" + add.AddressStreetNumber;
             lblCustomerPOBoxSuburb.Text = add.AddressSuburb;
             lblCustomerPOBoxCity.Text = add.AddressCity;
             lblCustomerPOBoxAreaCode.Text = add.AddressAreaCode.ToString();
 
-            cbxCustomerDeliveryAddress.Text = passed.QuoteTOChange.QuoteCustomer.CustomerName;
-            rtxCustomerDeliveryDescripton.Text = passed.QuoteTOChange.QuoteDeliveryAddress;
-            txtCustomerVATNumber.Text = passed.QuoteTOChange.QuoteCustomer.CustomerLegalDetails.VatNumber;
+            cbxCustomerDeliveryAddress.Text = viewModel.Pass.QuoteTOChange.QuoteCustomer.CustomerName;
+            rtxCustomerDeliveryDescripton.Text = viewModel.Pass.QuoteTOChange.QuoteDeliveryAddress;
+            txtCustomerVATNumber.Text = viewModel.Pass.QuoteTOChange.QuoteCustomer.CustomerLegalDetails.VatNumber;
 
             //Loading other Quote Details:
-            txtJobNumber.Text = passed.QuoteTOChange.QuoteJobNumber;
-            txtReferenceNumber.Text = passed.QuoteTOChange.QuoteReference;
-            txtPRNumber.Text = passed.QuoteTOChange.QuotePRNumber;
-            txtLineNumber.Text = passed.QuoteTOChange.QuoteLineNumber;
-            dtpPaymentTerm.Value = passed.QuoteTOChange.QuotePaymentTerm;
+            txtJobNumber.Text = viewModel.Pass.QuoteTOChange.QuoteJobNumber;
+            txtReferenceNumber.Text = viewModel.Pass.QuoteTOChange.QuoteReference;
+            txtPRNumber.Text = viewModel.Pass.QuoteTOChange.QuotePRNumber;
+            txtLineNumber.Text = viewModel.Pass.QuoteTOChange.QuoteLineNumber;
+            dtpPaymentTerm.Value = viewModel.Pass.QuoteTOChange.QuotePaymentTerm;
 
-            txtQuoteNumber.Text = passed.QuoteTOChange.QuoteNumber;
+            txtQuoteNumber.Text = viewModel.Pass.QuoteTOChange.QuoteNumber;
 
-            dtpQuoteCreationDate.Value = passed.QuoteTOChange.QuoteCreationDate;
-            dtpQuoteExpiryDate.Value = passed.QuoteTOChange.QuoteExpireyDate;
+            dtpQuoteCreationDate.Value = viewModel.Pass.QuoteTOChange.QuoteCreationDate;
+            dtpQuoteExpiryDate.Value = viewModel.Pass.QuoteTOChange.QuoteExpireyDate;
 
-            lblNewPumpUnitPrice.Text = "New Pump Price: R " + passed.QuoteTOChange.QuoteCost.PumpPrice.ToString();
-            lblRepairPercentage.Text = passed.QuoteTOChange.QuoteRepairPercentage + "%";
-            lblRebateValue.Text = "R" + passed.QuoteTOChange.QuoteCost.Rebate.ToString();
-            lblSubTotalValue.Text = "R" + passed.QuoteTOChange.QuoteCost.SubTotal.ToString();
-            lblVATValue.Text = "R" + passed.QuoteTOChange.QuoteCost.VAT.ToString();
-            lblTotalDueValue.Text = "R" + passed.QuoteTOChange.QuoteCost.TotalDue.ToString();
+            lblNewPumpUnitPrice.Text = "New Pump Price: R " + viewModel.Pass.QuoteTOChange.QuoteCost.PumpPrice.ToString();
+            lblRepairPercentage.Text = viewModel.Pass.QuoteTOChange.QuoteRepairPercentage + "%";
+            lblRebateValue.Text = "R" + viewModel.Pass.QuoteTOChange.QuoteCost.Rebate.ToString();
+            lblSubTotalValue.Text = "R" + viewModel.Pass.QuoteTOChange.QuoteCost.SubTotal.ToString();
+            lblVATValue.Text = "R" + viewModel.Pass.QuoteTOChange.QuoteCost.VAT.ToString();
+            lblTotalDueValue.Text = "R" + viewModel.Pass.QuoteTOChange.QuoteCost.TotalDue.ToString();
 
-            mtxtRebate.Text = passed.QuoteTOChange.QuoteCost.Rebate.ToString();
+            mtxtRebate.Text = viewModel.Pass.QuoteTOChange.QuoteCost.Rebate.ToString();
         }
 
         private void ConvertToReadOnly()
@@ -946,7 +944,7 @@ namespace QuoteSwift
             btnComplete.Enabled = true;
             btnCancel.Enabled = true;
 
-            Text = Text.Replace("<< Business Name >>", passed.QuoteTOChange.QuoteCompany.BusinessName);
+            Text = Text.Replace("<< Business Name >>", viewModel.Pass.QuoteTOChange.QuoteCompany.BusinessName);
             Text = Text.Replace("Creating New", "Viewing");
         }
 
@@ -954,15 +952,15 @@ namespace QuoteSwift
         {
             QuoteSwiftMainCode.ReadWriteComponents(Controls);
 
-            Text = Text.Replace(passed.QuoteTOChange.QuoteCompany.BusinessName, passed.QuoteTOChange.QuoteCompany.BusinessName);
+            Text = Text.Replace(viewModel.Pass.QuoteTOChange.QuoteCompany.BusinessName, viewModel.Pass.QuoteTOChange.QuoteCompany.BusinessName);
             Text = Text.Replace("Viewing", "Creating New");
 
         }
 
         private void CreateNewQuoteUsingThisQuoteToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (passed.QuoteTOChange == null) passed.QuoteTOChange = NewQuote;
-            passed.ChangeSpecificObject = true;
+            if (viewModel.Pass.QuoteTOChange == null) viewModel.Pass.QuoteTOChange = NewQuote;
+            viewModel.Pass.ChangeSpecificObject = true;
             ConvertToReadWrite();
             GetNewQuotenumber();
             btnComplete.Text = "Complete";
@@ -975,7 +973,9 @@ namespace QuoteSwift
 
         private void FrmCreateQuote_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
     }
 

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -11,13 +11,6 @@ namespace QuoteSwift
         readonly ViewBusinessesViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
-        public ref Pass Passed { get => ref passed; }
 
         public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, INavigationService navigation = null)
         {
@@ -29,7 +22,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnUpdateBusiness_Click(object sender, EventArgs e)
@@ -43,16 +40,15 @@ namespace QuoteSwift
                 return;
             }
 
-            passed.BusinessToChange = Business;
-            passed.ChangeSpecificObject = false;
-            navigation.Pass = passed;
+            viewModel.Pass.BusinessToChange = Business;
+            viewModel.Pass.ChangeSpecificObject = false;
             navigation.AddBusiness();
-            passed = navigation.Pass;
+            viewModel.UpdatePass(navigation.Pass);
 
-            if (!ReplaceBusiness(Business, passed.BusinessToChange) && passed.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Business will not be stored.", "ERROR - Business Not Updated");
+            if (!ReplaceBusiness(Business, viewModel.Pass.BusinessToChange) && viewModel.Pass.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Business will not be stored.", "ERROR - Business Not Updated");
 
-            passed.BusinessToChange = null;
-            passed.ChangeSpecificObject = false;
+            viewModel.Pass.BusinessToChange = null;
+            viewModel.Pass.ChangeSpecificObject = false;
 
             LoadInformation();
 
@@ -61,9 +57,8 @@ namespace QuoteSwift
         private void BtnAddBusiness_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
             navigation.AddBusiness();
-            passed = navigation.Pass;
+            viewModel.UpdatePass(navigation.Pass);
             Show();
 
             LoadInformation();
@@ -71,9 +66,9 @@ namespace QuoteSwift
 
         private void FrmViewAllBusinesses_Load(object sender, EventArgs e)
         {
-            if (passed.PassBusinessList != null)
+            if (viewModel.Pass.PassBusinessList != null)
             {
-                foreach (var business in passed.PassBusinessList)
+                foreach (var business in viewModel.Pass.PassBusinessList)
                     DgvBusinessList.Rows.Add(business.BusinessName);
             }
 
@@ -85,17 +80,17 @@ namespace QuoteSwift
         {
             Business business = GetBusinessSelection();
 
-            if (business != null && passed.PassBusinessList != null)
+            if (business != null && viewModel.Pass.PassBusinessList != null)
             {
                 if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete '" + business.BusinessName + "' from the business list?", "REQUEST - Deletion Request"))
                 {
-                    passed.PassBusinessList.Remove(business);
-                    passed.BusinessLookup.Remove(business.BusinessName);
-                    passed.BusinessVatNumbers.Remove(business.BusinessLegalDetails.VatNumber);
-                    passed.BusinessRegNumbers.Remove(business.BusinessLegalDetails.RegistrationNumber);
+                    viewModel.Pass.PassBusinessList.Remove(business);
+                    viewModel.Pass.BusinessLookup.Remove(business.BusinessName);
+                    viewModel.Pass.BusinessVatNumbers.Remove(business.BusinessLegalDetails.VatNumber);
+                    viewModel.Pass.BusinessRegNumbers.Remove(business.BusinessLegalDetails.RegistrationNumber);
                     MainProgramCode.ShowInformation("Successfully deleted '" + business.BusinessName + "' from the business list", "CONFIRMATION - Deletion Success");
 
-                    if (passed.PassBusinessList.Count == 0) passed.PassBusinessList = null;
+                    if (viewModel.Pass.PassBusinessList.Count == 0) viewModel.Pass.PassBusinessList = null;
 
                     LoadInformation();
                 }
@@ -122,7 +117,7 @@ namespace QuoteSwift
             if (string.IsNullOrEmpty(searchName))
                 return null;
 
-            if (passed.BusinessLookup != null && passed.BusinessLookup.TryGetValue(searchName, out Business business))
+            if (viewModel.Pass.BusinessLookup != null && viewModel.Pass.BusinessLookup.TryGetValue(searchName, out Business business))
             {
                 return business;
             }
@@ -134,8 +129,8 @@ namespace QuoteSwift
         {
             DgvBusinessList.Rows.Clear();
 
-            if (passed.PassBusinessList != null)
-                foreach (var business in passed.PassBusinessList)
+            if (viewModel.Pass.PassBusinessList != null)
+                foreach (var business in viewModel.Pass.PassBusinessList)
                 {
                     DgvBusinessList.Rows.Add(business.BusinessName);
                 }
@@ -143,17 +138,17 @@ namespace QuoteSwift
 
         private bool ReplaceBusiness(Business Original, Business New)
         {
-            if (New != null && Original != null && passed.PassBusinessList != null)
-                for (int i = 0; i < passed.PassBusinessList.Count; i++)
-                    if (passed.PassBusinessList[i] == Original)
+            if (New != null && Original != null && viewModel.Pass.PassBusinessList != null)
+                for (int i = 0; i < viewModel.Pass.PassBusinessList.Count; i++)
+                    if (viewModel.Pass.PassBusinessList[i] == Original)
                     {
-                        passed.PassBusinessList[i] = New;
-                        passed.BusinessLookup.Remove(Original.BusinessName);
-                        passed.BusinessVatNumbers.Remove(Original.BusinessLegalDetails.VatNumber);
-                        passed.BusinessRegNumbers.Remove(Original.BusinessLegalDetails.RegistrationNumber);
-                        passed.BusinessLookup[New.BusinessName] = New;
-                        passed.BusinessVatNumbers.Add(New.BusinessLegalDetails.VatNumber);
-                        passed.BusinessRegNumbers.Add(New.BusinessLegalDetails.RegistrationNumber);
+                        viewModel.Pass.PassBusinessList[i] = New;
+                        viewModel.Pass.BusinessLookup.Remove(Original.BusinessName);
+                        viewModel.Pass.BusinessVatNumbers.Remove(Original.BusinessLegalDetails.VatNumber);
+                        viewModel.Pass.BusinessRegNumbers.Remove(Original.BusinessLegalDetails.RegistrationNumber);
+                        viewModel.Pass.BusinessLookup[New.BusinessName] = New;
+                        viewModel.Pass.BusinessVatNumbers.Add(New.BusinessLegalDetails.VatNumber);
+                        viewModel.Pass.BusinessRegNumbers.Add(New.BusinessLegalDetails.RegistrationNumber);
                         return true;
                     }
 
@@ -172,7 +167,9 @@ namespace QuoteSwift
 
         private void FrmViewAllBusinesses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
 
         /**********************************************************************************/

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -10,24 +10,22 @@ namespace QuoteSwift
         readonly ViewCustomersViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
 
         public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            passed = viewModel.Pass;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e)
@@ -41,19 +39,18 @@ namespace QuoteSwift
                 return;
             }
 
-            passed.CustomerToChange = customer;
-            passed.ChangeSpecificObject = false;
-            passed.BusinessToChange = container;
+            viewModel.Pass.CustomerToChange = customer;
+            viewModel.Pass.ChangeSpecificObject = false;
+            viewModel.Pass.BusinessToChange = container;
 
-            navigation.Pass = passed;
             navigation.AddCustomer();
-            passed = navigation.Pass;
+            viewModel.UpdatePass(navigation.Pass);
 
-            if (!ReplaceCustomer(customer, passed.CustomerToChange, container) && passed.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Customer will not be stored.", "ERROR - Customer Not Updated");
+            if (!ReplaceCustomer(customer, viewModel.Pass.CustomerToChange, container) && viewModel.Pass.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Customer will not be stored.", "ERROR - Customer Not Updated");
 
-            passed.CustomerToChange = null;
-            passed.BusinessToChange = null;
-            passed.ChangeSpecificObject = false;
+            viewModel.Pass.CustomerToChange = null;
+            viewModel.Pass.BusinessToChange = null;
+            viewModel.Pass.ChangeSpecificObject = false;
 
             LoadInformation();
 
@@ -63,9 +60,8 @@ namespace QuoteSwift
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
             navigation.AddCustomer();
-            passed = navigation.Pass;
+            viewModel.UpdatePass(navigation.Pass);
             Show();
 
             LoadInformation();
@@ -110,8 +106,8 @@ namespace QuoteSwift
         {
             DgvCustomerList.Rows.Clear();
 
-            if (passed != null && passed.PassBusinessList != null && cbBusinessSelection.Text.Length > 0)
-                foreach (var business in passed.PassBusinessList)
+            if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null && cbBusinessSelection.Text.Length > 0)
+                foreach (var business in viewModel.Pass.PassBusinessList)
                     if (cbBusinessSelection.Text == business.BusinessName)
                         if (business.BusinessCustomerList != null)
                             foreach (var customer in business.BusinessCustomerList)
@@ -122,12 +118,12 @@ namespace QuoteSwift
 
         private string GetPreviousQuoteDate(Customer c)
         {
-            if (passed.PassQuoteMap != null)
+            if (viewModel.Pass.PassQuoteMap != null)
             {
                 DateTime latest = DateTime.MinValue;
                 bool found = false;
 
-                foreach (var q in passed.PassQuoteMap.Values)
+                foreach (var q in viewModel.Pass.PassQuoteMap.Values)
                 {
                     if (q.QuoteCustomer != null && c != null &&
                         q.QuoteCustomer.CustomerCompanyName == c.CustomerCompanyName)
@@ -190,7 +186,7 @@ namespace QuoteSwift
         {
             string searchName = cbBusinessSelection.Text;
 
-            if (searchName.Length > 1 && passed.BusinessLookup.TryGetValue(searchName, out Business business))
+            if (searchName.Length > 1 && viewModel.Pass.BusinessLookup.TryGetValue(searchName, out Business business))
             {
                 return business;
             }
@@ -200,9 +196,9 @@ namespace QuoteSwift
 
         public void LinkBusinessToSource(ref ComboBox cb)
         {
-            if (passed != null && passed.PassBusinessList != null)
+            if (viewModel.Pass != null && viewModel.Pass.PassBusinessList != null)
             {
-                BindingSource ComboBoxBusinessSource = new BindingSource { DataSource = passed.PassBusinessList };
+                BindingSource ComboBoxBusinessSource = new BindingSource { DataSource = viewModel.Pass.PassBusinessList };
 
                 cb.DataSource = ComboBoxBusinessSource.DataSource;
 
@@ -228,9 +224,9 @@ namespace QuoteSwift
 
         private void FrmViewCustomers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var p = passed;
+            var p = viewModel.Pass;
             MainProgramCode.CloseApplication(true, ref p);
-            passed = p;
+            viewModel.UpdatePass(p);
         }
 
         /**********************************************************************************/

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -11,12 +11,6 @@ namespace QuoteSwift
         readonly ViewPartsViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
         public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null)
         {
             InitializeComponent();
@@ -24,20 +18,22 @@ namespace QuoteSwift
             this.navigation = navigation;
         }
 
-        public ref Pass Passed { get => ref passed; }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
             navigation.AddNewPart();
-            passed = navigation.Pass;
+            viewModel.UpdatePass(navigation.Pass);
             Show();
         }
 
@@ -47,17 +43,16 @@ namespace QuoteSwift
 
             if (objPartSelection != null)
             {
-                passed.ChangeSpecificObject = false;
-                passed.PartToChange = objPartSelection;
+                viewModel.Pass.ChangeSpecificObject = false;
+                viewModel.Pass.PartToChange = objPartSelection;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.AddNewPart();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                passed.ChangeSpecificObject = false;
-                passed.PartToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
+                viewModel.Pass.PartToChange = null;
             }
             else
             {
@@ -67,7 +62,7 @@ namespace QuoteSwift
 
         private void FrmViewParts_Activated(object sender, EventArgs e)
         {
-            if (passed != null)
+            if (viewModel.Pass != null)
             {
                 dgvAllParts.Rows.Clear();
                 LoadMandatoryParts();
@@ -84,7 +79,7 @@ namespace QuoteSwift
                 {
                     if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
                     {
-                        passed.RemovePart(SelectedPart);
+                        viewModel.Pass.RemovePart(SelectedPart);
                         MainProgramCode.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
                     }
                 }
@@ -92,7 +87,7 @@ namespace QuoteSwift
                 {
                     if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
                     {
-                        passed.RemovePart(SelectedPart);
+                        viewModel.Pass.RemovePart(SelectedPart);
                         MainProgramCode.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
                     }
                 }
@@ -113,9 +108,9 @@ namespace QuoteSwift
 
         void LoadMandatoryParts()
         {
-            if (passed.PassPartList != null)
+            if (viewModel.Pass.PassPartList != null)
             {
-                foreach (var part in passed.MandatoryParts)
+                foreach (var part in viewModel.Pass.MandatoryParts)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvAllParts.Rows.Add(part.PartName,
@@ -130,9 +125,9 @@ namespace QuoteSwift
 
         void LoadNonMandatoryParts()
         {
-            if (passed.PassPartList != null)
+            if (viewModel.Pass.PassPartList != null)
             {
-                foreach (var part in passed.NonMandatoryParts)
+                foreach (var part in viewModel.Pass.NonMandatoryParts)
                 {
                     //Manually setting the data grid's rows' values:
                     dgvAllParts.Rows.Add(part.PartName,
@@ -158,18 +153,18 @@ namespace QuoteSwift
             if (string.IsNullOrEmpty(SearchName))
                 return null;
 
-            if (passed.PassPartList != null && passed.PassPartList.Count > 0)
+            if (viewModel.Pass.PassPartList != null && viewModel.Pass.PassPartList.Count > 0)
             {
                 string key = StringUtil.NormalizeKey(SearchName);
                 if ((bool)(dgvAllParts.Rows[iGridSelection].Cells[4].Value) == true)
                 {
                     //Search for part in mandatory
-                    passed.PassPartList.TryGetValue(key, out var part);
+                    viewModel.Pass.PassPartList.TryGetValue(key, out var part);
                     return part;
                 }
                 else // Search in Non-Mandatory
                 {
-                    passed.PassPartList.TryGetValue(key, out var part);
+                    viewModel.Pass.PassPartList.TryGetValue(key, out var part);
                     return part;
                 }
             }
@@ -195,7 +190,9 @@ namespace QuoteSwift
 
         private void FrmViewParts_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
 
         /*********************************************************************************/

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -12,13 +12,6 @@ namespace QuoteSwift // Repair Quote Swift
         readonly ViewPumpViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed
-        {
-            get => viewModel.Pass;
-            set => viewModel.UpdatePass(value);
-        }
-
-        public ref Pass Passed { get => ref passed; }
 
         public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null)
         {
@@ -30,7 +23,11 @@ namespace QuoteSwift // Repair Quote Swift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+            {
+                var p = viewModel.Pass;
+                MainProgramCode.CloseApplication(true, ref p);
+                viewModel.UpdatePass(p);
+            }
         }
 
         private void BtnUpdateSelectedPump_Click(object sender, EventArgs e)
@@ -41,17 +38,16 @@ namespace QuoteSwift // Repair Quote Swift
             {
                 iGridSelection = dgvPumpList.CurrentCell.RowIndex;
 
-                passed.PumpToChange = passed.PassPumpList.ElementAt(iGridSelection);
-                passed.ChangeSpecificObject = false;
+                viewModel.Pass.PumpToChange = viewModel.Pass.PassPumpList.ElementAt(iGridSelection);
+                viewModel.Pass.ChangeSpecificObject = false;
 
                 Hide();
-                navigation.Pass = passed;
                 navigation.CreateNewPump();
-                passed = navigation.Pass;
+                viewModel.UpdatePass(navigation.Pass);
                 Show();
 
-                passed.ChangeSpecificObject = false;
-                passed.PumpToChange = null;
+                viewModel.Pass.ChangeSpecificObject = false;
+                viewModel.Pass.PumpToChange = null;
 
                 LoadInformation();
             }
@@ -64,9 +60,8 @@ namespace QuoteSwift // Repair Quote Swift
         private void BtnAddPump_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
             navigation.CreateNewPump();
-            passed = navigation.Pass;
+            viewModel.UpdatePass(navigation.Pass);
             Show();
         }
 
@@ -76,12 +71,12 @@ namespace QuoteSwift // Repair Quote Swift
             {
                 int iGridSelection = dgvPumpList.CurrentCell.RowIndex;
 
-                Pump objPumpSelection = passed.PassPumpList.ElementAt(iGridSelection);
+                Pump objPumpSelection = viewModel.Pass.PassPumpList.ElementAt(iGridSelection);
 
                 if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + objPumpSelection.PumpName + "pump from the list of pumps?", "REQUEST - Deletion Request"))
                 {
-                    passed.PassPumpList.RemoveAt(iGridSelection);
-                    passed.RepairableItemNames.Remove(StringUtil.NormalizeKey(objPumpSelection.PumpName));
+                    viewModel.Pass.PassPumpList.RemoveAt(iGridSelection);
+                    viewModel.Pass.RepairableItemNames.Remove(StringUtil.NormalizeKey(objPumpSelection.PumpName));
 
                     MainProgramCode.ShowInformation("Successfully deleted " + objPumpSelection.PumpName + " from the pump list", "INFORMATION - Deletion Success");
                 }
@@ -117,9 +112,9 @@ namespace QuoteSwift // Repair Quote Swift
             //Manually Load Pump items:
             dgvPumpList.Rows.Clear();
 
-            if (passed.PassPumpList != null)
+            if (viewModel.Pass.PassPumpList != null)
             {
-                foreach (var pump in passed.PassPumpList)
+                foreach (var pump in viewModel.Pass.PassPumpList)
                 {
                     dgvPumpList.Rows.Add(pump.PumpName,
                                         pump.PumpDescription,
@@ -145,7 +140,7 @@ namespace QuoteSwift // Repair Quote Swift
                 {
                     try
                     {
-                        MainProgramCode.ExportInventory(passed.PassPumpList, sfd.FileName);
+                        MainProgramCode.ExportInventory(viewModel.Pass.PassPumpList, sfd.FileName);
                         MainProgramCode.ShowInformation("Inventory exported successfully.", "INFORMATION - Export Successful");
                     }
                     catch (Exception ex)
@@ -158,7 +153,9 @@ namespace QuoteSwift // Repair Quote Swift
 
         private void FrmViewPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            var p = viewModel.Pass;
+            MainProgramCode.CloseApplication(true, ref p);
+            viewModel.UpdatePass(p);
         }
 
         /*********************************************************************************/


### PR DESCRIPTION
## Summary
- remove local Pass variables from multiple WinForms forms
- update event handlers to access `viewModel.Pass`
- propagate updates via `viewModel.UpdatePass`

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `msbuild QuoteSwift.sln -t:Build -p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755c5599e8832584ea2895933ed898