### PR TITLE
Remove Pass property from INavigationService

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly ViewBusinessAddressesViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -19,7 +19,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null)
+        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -4,7 +4,6 @@ namespace QuoteSwift
 {
     public interface INavigationService
     {
-        Pass Pass { get; set; }
 
         void CreateNewQuote();
         void ViewAllQuotes();

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly AddBusinessViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -17,7 +17,7 @@ namespace QuoteSwift
             set => viewModel.UpdatePass(value);
         }
 
-        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null)
+        public FrmAddBusiness(AddBusinessViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly AddCustomerViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Business Container;
 
@@ -19,7 +19,7 @@ namespace QuoteSwift
             set => viewModel.UpdatePass(value);
         }
 
-        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null)
+        public FrmAddCustomer(AddCustomerViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -8,7 +8,7 @@ namespace QuoteSwift
     {
 
         readonly AddPartViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -18,7 +18,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null)
+        public FrmAddPart(AddPartViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     public partial class FrmAddPump : Form
     {
         readonly AddPumpViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -19,7 +19,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null)
+        public FrmAddPump(AddPumpViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly ManageEmailsViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -19,7 +19,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null)
+        public FrmManageAllEmails(ManageEmailsViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -11,7 +11,7 @@ namespace QuoteSwift
     {
 
         readonly ManagePhoneNumbersViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -21,7 +21,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, INavigationService navigation = null)
+        public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly ViewBusinessesViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -19,7 +19,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, INavigationService navigation = null)
+        public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -8,7 +8,7 @@ namespace QuoteSwift
     public partial class FrmViewCustomers : Form
     {
         readonly ViewCustomersViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -16,7 +16,7 @@ namespace QuoteSwift
             set => viewModel.UpdatePass(value);
         }
 
-        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null)
+        public FrmViewCustomers(ViewCustomersViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly ViewPOBoxAddressesViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -19,7 +19,7 @@ namespace QuoteSwift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null)
+        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     {
 
         readonly ViewPartsViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -17,7 +17,7 @@ namespace QuoteSwift
             set => viewModel.UpdatePass(value);
         }
 
-        public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null)
+        public FrmViewParts(ViewPartsViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -10,7 +10,7 @@ namespace QuoteSwift // Repair Quote Swift
     {
 
         readonly ViewPumpViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
         Pass passed
         {
@@ -20,7 +20,7 @@ namespace QuoteSwift // Repair Quote Swift
 
         public ref Pass Passed { get => ref passed; }
 
-        public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null)
+        public FrmViewPump(ViewPumpViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -10,9 +10,9 @@ namespace QuoteSwift
     {
 
         readonly QuotesViewModel viewModel;
-        readonly INavigationService navigation;
+        readonly NavigationService navigation;
 
-        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null)
+        public FrmViewQuotes(QuotesViewModel viewModel, NavigationService navigation = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;


### PR DESCRIPTION
## Summary
- drop Pass from `INavigationService`
- use `NavigationService` directly in forms

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace must be MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_68755c575c008325afc265387213ce1e