### PR TITLE
Refactor navigation service APIs

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -73,9 +73,7 @@ namespace QuoteSwift
             passed.AddressToChange = address;
             passed.ChangeSpecificObject = false;
 
-            navigation.Pass = passed;
-            navigation.EditBusinessAddress();
-            passed = navigation.Pass;
+            passed = navigation.EditBusinessAddress(passed);
 
             if (!ReplacePOBoxAddress(address, passed.AddressToChange)) MainProgramCode.ShowError("An error occurred during the updating procedure of the Address.\nUpdated address will not be stored.", "ERROR - Address Not Updated");
 

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -4,24 +4,22 @@ namespace QuoteSwift
 {
     public interface INavigationService
     {
-        Pass Pass { get; set; }
-
-        void CreateNewQuote();
-        void ViewAllQuotes();
-        void ViewAllPumps();
-        void CreateNewPump();
-        void ViewAllParts();
-        void AddNewPart();
-        void AddCustomer();
-        void ViewCustomers();
-        void AddBusiness();
-        void ViewBusinesses();
-        void ViewBusinessesAddresses();
-        void ViewBusinessesPOBoxAddresses();
-        void ViewBusinessesEmailAddresses();
-        void ViewBusinessesPhoneNumbers();
-        void EditBusinessAddress();
-        void EditBusinessEmailAddress();
-        void EditPhoneNumber();
+        Pass CreateNewQuote(Pass pass);
+        Pass ViewAllQuotes(Pass pass);
+        Pass ViewAllPumps(Pass pass);
+        Pass CreateNewPump(Pass pass);
+        Pass ViewAllParts(Pass pass);
+        Pass AddNewPart(Pass pass);
+        Pass AddCustomer(Pass pass);
+        Pass ViewCustomers(Pass pass);
+        Pass AddBusiness(Pass pass);
+        Pass ViewBusinesses(Pass pass);
+        Pass ViewBusinessesAddresses(Pass pass);
+        Pass ViewBusinessesPOBoxAddresses(Pass pass);
+        Pass ViewBusinessesEmailAddresses(Pass pass);
+        Pass ViewBusinessesPhoneNumbers(Pass pass);
+        Pass EditBusinessAddress(Pass pass);
+        Pass EditBusinessEmailAddress(Pass pass);
+        Pass EditPhoneNumber(Pass pass);
     }
 }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -9,196 +9,210 @@ namespace QuoteSwift
         public NavigationService(IDataService service)
         {
             dataService = service;
-            Pass = new Pass(null, null, null, null);
         }
 
-        public Pass Pass { get; set; }
-
-        public void CreateNewQuote()
+        public Pass CreateNewQuote(Pass pass)
         {
             var vm = new CreateQuoteViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmCreateQuote(vm, Pass))
+            using (var form = new FrmCreateQuote(vm, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void ViewAllQuotes()
+        public Pass ViewAllQuotes(Pass pass)
         {
             var vm = new QuotesViewModel(dataService);
-            vm.UpdateData(Pass.PassQuoteMap, Pass.PassBusinessList, Pass.PassPumpList, Pass.PassPartList);
+            vm.UpdateData(pass.PassQuoteMap, pass.PassBusinessList, pass.PassPumpList, pass.PassPartList);
             vm.LoadData();
             using (var form = new FrmViewQuotes(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass = new Pass(vm.QuoteMap, vm.BusinessList, vm.PumpList, vm.PartMap);
+            pass = new Pass(vm.QuoteMap, vm.BusinessList, vm.PumpList, vm.PartMap);
+            return pass;
         }
 
-        public void ViewAllPumps()
+        public Pass ViewAllPumps(Pass pass)
         {
             var vm = new ViewPumpViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewPump(vm, this, Pass))
+            using (var form = new FrmViewPump(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void CreateNewPump()
+        public Pass CreateNewPump(Pass pass)
         {
             var vm = new AddPumpViewModel(dataService);
-            vm.UpdateData(Pass.PassPumpList, Pass.PassPartList, Pass.PumpToChange, Pass.ChangeSpecificObject, Pass.RepairableItemNames);
+            vm.UpdateData(pass.PassPumpList, pass.PassPartList, pass.PumpToChange, pass.ChangeSpecificObject, pass.RepairableItemNames);
             vm.LoadData();
             using (var form = new FrmAddPump(vm, this))
             {
-                form.SetPass(Pass);
+                form.SetPass(pass);
                 form.ShowDialog();
             }
-            Pass.PassPumpList = vm.PumpList;
-            Pass.PassPartList = vm.PartMap;
+            pass.PassPumpList = vm.PumpList;
+            pass.PassPartList = vm.PartMap;
+            return pass;
         }
 
-        public void ViewAllParts()
+        public Pass ViewAllParts(Pass pass)
         {
             var vm = new ViewPartsViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewParts(vm, this, Pass))
+            using (var form = new FrmViewParts(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void AddNewPart()
+        public Pass AddNewPart(Pass pass)
         {
             var vm = new AddPartViewModel(dataService);
-            vm.UpdatePass(Pass.PassPartList, Pass.PassPumpList, Pass.PartToChange, Pass.ChangeSpecificObject);
+            vm.UpdatePass(pass.PassPartList, pass.PassPumpList, pass.PartToChange, pass.ChangeSpecificObject);
             vm.LoadData();
             using (var form = new FrmAddPart(vm, this))
             {
-                form.SetPass(Pass);
+                form.SetPass(pass);
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void AddCustomer()
+        public Pass AddCustomer(Pass pass)
         {
             var vm = new AddCustomerViewModel(dataService);
-            vm.UpdateData(Pass.PassBusinessList, Pass.CustomerToChange, Pass.ChangeSpecificObject);
+            vm.UpdateData(pass.PassBusinessList, pass.CustomerToChange, pass.ChangeSpecificObject);
             vm.LoadData();
             using (var form = new FrmAddCustomer(vm, this))
             {
                 form.ShowDialog();
             }
-            Pass.PassBusinessList = vm.BusinessList;
-            Pass.CustomerToChange = vm.CustomerToChange;
-            Pass.ChangeSpecificObject = vm.ChangeSpecificObject;
+            pass.PassBusinessList = vm.BusinessList;
+            pass.CustomerToChange = vm.CustomerToChange;
+            pass.ChangeSpecificObject = vm.ChangeSpecificObject;
+            return pass;
         }
 
-        public void ViewCustomers()
+        public Pass ViewCustomers(Pass pass)
         {
             var vm = new ViewCustomersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewCustomers(vm, this, Pass))
+            using (var form = new FrmViewCustomers(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void AddBusiness()
+        public Pass AddBusiness(Pass pass)
         {
             var vm = new AddBusinessViewModel(dataService);
-            vm.UpdateData(Pass.PassBusinessList, Pass.BusinessToChange, Pass.ChangeSpecificObject);
+            vm.UpdateData(pass.PassBusinessList, pass.BusinessToChange, pass.ChangeSpecificObject);
             vm.LoadData();
             using (var form = new FrmAddBusiness(vm, this))
             {
-                form.SetPass(Pass);
+                form.SetPass(pass);
                 form.ShowDialog();
             }
-            Pass.PassBusinessList = vm.BusinessList;
-            Pass.BusinessToChange = vm.BusinessToChange;
-            Pass.ChangeSpecificObject = vm.ChangeSpecificObject;
+            pass.PassBusinessList = vm.BusinessList;
+            pass.BusinessToChange = vm.BusinessToChange;
+            pass.ChangeSpecificObject = vm.ChangeSpecificObject;
+            return pass;
         }
 
-        public void ViewBusinesses()
+        public Pass ViewBusinesses(Pass pass)
         {
             var vm = new ViewBusinessesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewAllBusinesses(vm, this, Pass))
+            using (var form = new FrmViewAllBusinesses(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void ViewBusinessesAddresses()
+        public Pass ViewBusinessesAddresses(Pass pass)
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewBusinessAddresses(vm, this, Pass))
+            using (var form = new FrmViewBusinessAddresses(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void ViewBusinessesPOBoxAddresses()
+        public Pass ViewBusinessesPOBoxAddresses(Pass pass)
         {
             var vm = new ViewPOBoxAddressesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewPOBoxAddresses(vm, this, Pass))
+            using (var form = new FrmViewPOBoxAddresses(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void ViewBusinessesEmailAddresses()
+        public Pass ViewBusinessesEmailAddresses(Pass pass)
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmManageAllEmails(vm, this, Pass))
+            using (var form = new FrmManageAllEmails(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void ViewBusinessesPhoneNumbers()
+        public Pass ViewBusinessesPhoneNumbers(Pass pass)
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmManagingPhoneNumbers(vm, this, Pass))
+            using (var form = new FrmManagingPhoneNumbers(vm, this, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void EditBusinessAddress()
+        public Pass EditBusinessAddress(Pass pass)
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmEditBusinessAddress(vm, Pass))
+            using (var form = new FrmEditBusinessAddress(vm, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void EditBusinessEmailAddress()
+        public Pass EditBusinessEmailAddress(Pass pass)
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmEditEmailAddress(vm, Pass))
+            using (var form = new FrmEditEmailAddress(vm, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
 
-        public void EditPhoneNumber()
+        public Pass EditPhoneNumber(Pass pass)
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmEditPhoneNumber(vm, Pass))
+            using (var form = new FrmEditPhoneNumber(vm, pass))
             {
                 form.ShowDialog();
             }
+            return pass;
         }
     }
 }

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -110,9 +110,8 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesEmailAddresses();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesEmailAddresses(passed);
+                Show();
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;
@@ -131,9 +130,8 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesAddresses();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesAddresses(passed);
+                Show();
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;
@@ -151,9 +149,8 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPOBoxAddresses();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesPOBoxAddresses(passed);
+                Show();
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;
@@ -171,9 +168,8 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updateBusinessInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPhoneNumbers();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesPhoneNumbers(passed);
+                Show();
                 Show();
 
                 viewModel.CurrentBusiness = passed.BusinessToChange;

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -158,9 +158,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPhoneNumbers();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesPhoneNumbers(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;
@@ -178,9 +176,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesPOBoxAddresses();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesPOBoxAddresses(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;
@@ -198,9 +194,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesEmailAddresses();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesEmailAddresses(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;
@@ -219,9 +213,7 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = !updatedCustomerInformationToolStripMenuItem.Enabled;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.ViewBusinessesAddresses();
-                passed = navigation.Pass;
+                passed = navigation.ViewBusinessesAddresses(passed);
                 Show();
 
                 viewModel.CurrentCustomer = passed.CustomerToChange;

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -98,9 +98,7 @@ namespace QuoteSwift
             string email = GetEmailSelection();
             passed.EmailToChange = email;
             passed.ChangeSpecificObject = true;
-            navigation.Pass = passed;
-            navigation.EditBusinessEmailAddress();
-            passed = navigation.Pass;
+            passed = navigation.EditBusinessEmailAddress(passed);
 
             if (passed.BusinessToChange != null && passed.BusinessToChange.BusinessEmailAddressList != null)
             {

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -39,9 +39,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                passed = navigation.EditPhoneNumber(passed);
                 passed.BusinessToChange.UpdateCellphoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";
@@ -53,9 +51,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                passed = navigation.EditPhoneNumber(passed);
                 passed.CustomerToChange.UpdateCellphoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";
@@ -73,9 +69,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                passed = navigation.EditPhoneNumber(passed);
                 passed.BusinessToChange.UpdateTelephoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";
@@ -87,9 +81,7 @@ namespace QuoteSwift
                 passed.PhoneNumberToChange = OldNumber;
                 passed.ChangeSpecificObject = true;
 
-                navigation.Pass = passed;
-                navigation.EditPhoneNumber();
-                passed = navigation.Pass;
+                passed = navigation.EditPhoneNumber(passed);
                 passed.CustomerToChange.UpdateTelephoneNumber(OldNumber, passed.PhoneNumberToChange);
 
                 passed.PhoneNumberToChange = "";

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -42,9 +42,7 @@ namespace QuoteSwift
 
             passed.BusinessToChange = Business;
             passed.ChangeSpecificObject = false;
-            navigation.Pass = passed;
-            navigation.AddBusiness();
-            passed = navigation.Pass;
+            passed = navigation.AddBusiness(passed);
 
             if (!ReplaceBusiness(Business, passed.BusinessToChange) && passed.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Business will not be stored.", "ERROR - Business Not Updated");
 
@@ -58,9 +56,7 @@ namespace QuoteSwift
         private void BtnAddBusiness_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.AddBusiness();
-            passed = navigation.Pass;
+            passed = navigation.AddBusiness(passed);
             Show();
 
             LoadInformation();

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -41,9 +41,7 @@ namespace QuoteSwift
             passed.ChangeSpecificObject = false;
             passed.BusinessToChange = container;
 
-            navigation.Pass = passed;
-            navigation.AddCustomer();
-            passed = navigation.Pass;
+            passed = navigation.AddCustomer(passed);
 
             if (!ReplaceCustomer(customer, passed.CustomerToChange, container) && passed.ChangeSpecificObject) MainProgramCode.ShowError("An error occurred during the updating procedure.\nUpdated Customer will not be stored.", "ERROR - Customer Not Updated");
 
@@ -59,9 +57,7 @@ namespace QuoteSwift
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.AddCustomer();
-            passed = navigation.Pass;
+            passed = navigation.AddCustomer(passed);
             Show();
 
             LoadInformation();

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -74,9 +74,7 @@ namespace QuoteSwift
             passed.ChangeSpecificObject = false;
             passed.AddressToChange = address;
 
-            navigation.Pass = passed;
-            navigation.EditBusinessAddress();
-            passed = navigation.Pass;
+            passed = navigation.EditBusinessAddress(passed);
 
             if (!ReplacePOBoxAddress(address, passed.AddressToChange)) MainProgramCode.ShowError("An error occurred during the updating procedure of the P.O.Box Address.\nUpdated P.O.Box address will not be stored.", "ERROR - P.O.Box Address Not Updated");
 

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -32,9 +32,7 @@ namespace QuoteSwift
         private void BtnAddPart_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.AddNewPart();
-            passed = navigation.Pass;
+            passed = navigation.AddNewPart(passed);
             Show();
         }
 
@@ -48,9 +46,7 @@ namespace QuoteSwift
                 passed.PartToChange = objPartSelection;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.AddNewPart();
-                passed = navigation.Pass;
+                passed = navigation.AddNewPart(passed);
                 Show();
 
                 passed.ChangeSpecificObject = false;

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -42,9 +42,7 @@ namespace QuoteSwift // Repair Quote Swift
                 passed.ChangeSpecificObject = false;
 
                 Hide();
-                navigation.Pass = passed;
-                navigation.CreateNewPump();
-                passed = navigation.Pass;
+                passed = navigation.CreateNewPump(passed);
                 Show();
 
                 passed.ChangeSpecificObject = false;
@@ -61,9 +59,7 @@ namespace QuoteSwift // Repair Quote Swift
         private void BtnAddPump_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = passed;
-            navigation.CreateNewPump();
-            passed = navigation.Pass;
+            passed = navigation.CreateNewPump(passed);
             Show();
         }
 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -24,9 +24,9 @@ namespace QuoteSwift
             if (viewModel.BusinessList != null && viewModel.BusinessList.Count > 0 && viewModel.PumpList != null && viewModel.BusinessList[0].BusinessCustomerList != null)
             {
                 Hide();
-                navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-                navigation.CreateNewQuote();
-                viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+                var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+                p = navigation.CreateNewQuote(p);
+                viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
                 try
                 {
                     Show();
@@ -58,9 +58,9 @@ namespace QuoteSwift
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.ViewAllPumps();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.ViewAllPumps(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -74,9 +74,9 @@ namespace QuoteSwift
         private void CreateNewPumpToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.CreateNewPump();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.CreateNewPump(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -95,9 +95,9 @@ namespace QuoteSwift
         private void AddNewCustomerToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.AddCustomer();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.AddCustomer(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -111,9 +111,9 @@ namespace QuoteSwift
         private void ViewAllCustomersToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.ViewCustomers();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.ViewCustomers(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -132,9 +132,9 @@ namespace QuoteSwift
         private void AddNewBusinessToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.AddBusiness();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.AddBusiness(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -148,9 +148,9 @@ namespace QuoteSwift
         private void ViewAllBusinessesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.ViewBusinesses();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.ViewBusinesses(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -186,13 +186,13 @@ namespace QuoteSwift
                 if (selected != null)
                 {
                     Hide();
-                    navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-                    navigation.Pass.QuoteTOChange = selected;
-                    navigation.Pass.ChangeSpecificObject = false;
-                    navigation.CreateNewQuote();
-                    navigation.Pass.QuoteTOChange = null;
-                    navigation.Pass.ChangeSpecificObject = false;
-                    viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+                    var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+                    p.QuoteTOChange = selected;
+                    p.ChangeSpecificObject = false;
+                    p = navigation.CreateNewQuote(p);
+                    p.QuoteTOChange = null;
+                    p.ChangeSpecificObject = false;
+                    viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
                     Show();
                 }
             }
@@ -206,13 +206,13 @@ namespace QuoteSwift
                 if (selected != null)
                 {
                     this.Hide();
-                    navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-                    navigation.Pass.QuoteTOChange = selected;
-                    navigation.Pass.ChangeSpecificObject = true;
-                    navigation.CreateNewQuote();
-                    navigation.Pass.QuoteTOChange = null;
-                    navigation.Pass.ChangeSpecificObject = false;
-                    viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+                    var p2 = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+                    p2.QuoteTOChange = selected;
+                    p2.ChangeSpecificObject = true;
+                    p2 = navigation.CreateNewQuote(p2);
+                    p2.QuoteTOChange = null;
+                    p2.ChangeSpecificObject = false;
+                    viewModel.UpdateData(p2.PassQuoteMap, p2.PassBusinessList, p2.PassPumpList, p2.PassPartList);
                     this.Show();
                 }
             }
@@ -221,9 +221,9 @@ namespace QuoteSwift
         private void ViewAllPartsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.ViewAllParts();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.ViewAllParts(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();
@@ -242,9 +242,9 @@ namespace QuoteSwift
         private void AddNewPartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.Pass = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            navigation.AddNewPart();
-            viewModel.UpdateData(navigation.Pass.PassQuoteMap, navigation.Pass.PassBusinessList, navigation.Pass.PassPumpList, navigation.Pass.PassPartList);
+            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
+            p = navigation.AddNewPart(p);
+            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
             try
             {
                 Show();


### PR DESCRIPTION
## Summary
- remove the `Pass` property from `INavigationService`
- adapt `NavigationService` to pass `Pass` objects via parameters and return the updated data
- update all forms to call the new parameter-based navigation methods

## Testing
- `xbuild QuoteSwift.sln /t:Rebuild /p:Configuration=Debug` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_68758707ee8483258ebe291fc7c2fe3c