### PR TITLE
Refactor CloseApplication and serialization helpers

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -65,7 +65,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private bool ValidInput()
@@ -139,7 +143,11 @@ namespace QuoteSwift
 
         private void FrmEditBusinessAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
     }
 }

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -70,13 +70,22 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            MainProgramCode.CloseApplication(MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"), ref passed);
+            MainProgramCode.CloseApplication(
+                MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"),
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -86,7 +95,11 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
     }
 }

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -64,7 +64,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -74,7 +78,11 @@ namespace QuoteSwift
 
         private void FrmEditPhoneNumber_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
     }
 }

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -26,7 +26,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void FrmViewBusinessAddresses_Load(object sender, EventArgs e)
@@ -187,7 +191,11 @@ namespace QuoteSwift
 
         private void FrmViewBusinessAddresses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
 

--- a/MainProgramLibrary/MainProgramCode.cs
+++ b/MainProgramLibrary/MainProgramCode.cs
@@ -152,7 +152,7 @@ namespace QuoteSwift
 
         //Serialize Part list:
 
-        public static byte[] SerializePartList(Dictionary<string, Part> PartList)
+        public static byte[] SerializePartListData(Dictionary<string, Part> PartList)
         {
             byte[] tempByte;
             try
@@ -181,20 +181,20 @@ namespace QuoteSwift
             }
         }
 
-        // Serialize Part List Method
+        // Serialize and store Part List
 
-        public static void SerializePartList(ref Pass passed)
+        public static void SerializePartList(Dictionary<string, Part> partList)
         {
-            if (passed != null && passed.PassPartList != null && passed.PassPartList.Count > 0)
+            if (partList != null && partList.Count > 0)
             {
-                byte[] ToStore = MainProgramCode.SerializePartList(passed.PassPartList);
+                byte[] ToStore = MainProgramCode.SerializePartListData(partList);
                 MainProgramCode.SaveData("Parts.json", ToStore);
             }
         }
 
         // Serialize Pump List Method
 
-        public static byte[] SerializePumpList(BindingList<Pump> PumpPartList)
+        public static byte[] SerializePumpListData(BindingList<Pump> PumpPartList)
         {
             byte[] tempByte;
             try
@@ -223,15 +223,13 @@ namespace QuoteSwift
             }
         }
 
-        // Serialize and Store Pump List Method
+        // Serialize and store Pump List
 
-        public static void SerializePumpList(ref Pass passed)
+        public static void SerializePumpList(BindingList<Pump> pumpList)
         {
-            //Determine if Pump List exist:
-
-            if (passed != null && passed.PassPumpList != null && passed.PassPumpList.Count > 0)
+            if (pumpList != null && pumpList.Count > 0)
             {
-                byte[] ToStore = MainProgramCode.SerializePumpList(passed.PassPumpList);
+                byte[] ToStore = MainProgramCode.SerializePumpListData(pumpList);
                 MainProgramCode.SaveData("PumpList.json", ToStore);
             }
         }
@@ -239,7 +237,7 @@ namespace QuoteSwift
 
         // Serialize Business List Method
 
-        public static byte[] SerializeBusinessList(BindingList<Business> BusinessList)
+        public static byte[] SerializeBusinessListData(BindingList<Business> BusinessList)
         {
             byte[] tempByte;
             try
@@ -268,22 +266,20 @@ namespace QuoteSwift
             }
         }
 
-        // Serialize and Store Business List Method
+        // Serialize and store Business List
 
-        public static void SerializeBusinessList(ref Pass passed)
+        public static void SerializeBusinessList(BindingList<Business> businessList)
         {
-            //Determine if Pump List exist:
-
-            if (passed != null && passed.PassBusinessList != null && passed.PassBusinessList.Count > 0)
+            if (businessList != null && businessList.Count > 0)
             {
-                byte[] ToStore = MainProgramCode.SerializeBusinessList(passed.PassBusinessList);
+                byte[] ToStore = MainProgramCode.SerializeBusinessListData(businessList);
                 MainProgramCode.SaveData("BusinessList.json", ToStore);
             }
         }
 
         // Serialize Quote List Method
 
-        public static byte[] SerializeQuoteList(SortedDictionary<string, Quote> QuoteList)
+        public static byte[] SerializeQuoteListData(SortedDictionary<string, Quote> QuoteList)
         {
             byte[] tempByte;
             try
@@ -312,15 +308,13 @@ namespace QuoteSwift
             }
         }
 
-        // Serialize and Store Quote List Method
+        // Serialize and store Quote List
 
-        public static void SerializeQuoteList(ref Pass passed)
+        public static void SerializeQuoteList(SortedDictionary<string, Quote> quoteList)
         {
-            //Determine if Pump List exist:
-
-            if (passed != null && passed.PassQuoteMap != null && passed.PassQuoteMap.Count > 0)
+            if (quoteList != null && quoteList.Count > 0)
             {
-                byte[] ToStore = MainProgramCode.SerializeQuoteList(passed.PassQuoteMap);
+                byte[] ToStore = MainProgramCode.SerializeQuoteListData(quoteList);
                 MainProgramCode.SaveData("QuoteList.json", ToStore);
             }
         }
@@ -409,16 +403,20 @@ namespace QuoteSwift
 
 
         //Procedure Handling The Closing Of The Application
-        public static void CloseApplication(bool exitApp, ref Pass passed)
+        public static void CloseApplication(bool exitApp,
+            BindingList<Business> businessList,
+            BindingList<Pump> pumpList,
+            Dictionary<string, Part> partList,
+            SortedDictionary<string, Quote> quoteList)
         {
             if (exitApp)
             {
                 try
                 {
-                    SerializePartList(ref passed);
-                    SerializePumpList(ref passed);
-                    SerializeBusinessList(ref passed);
-                    SerializeQuoteList(ref passed);
+                    SerializePartList(partList);
+                    SerializePumpList(pumpList);
+                    SerializeBusinessList(businessList);
+                    SerializeQuoteList(quoteList);
                 }
                 catch (Exception ex)
                 {

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -31,7 +31,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnAddBusiness_Click(object sender, EventArgs e)
@@ -208,7 +212,11 @@ namespace QuoteSwift
 
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -36,9 +36,11 @@ namespace QuoteSwift
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                var p = passed;
-                MainProgramCode.CloseApplication(true, ref p);
-                passed = p;
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
             }
         }
 
@@ -241,9 +243,11 @@ namespace QuoteSwift
 
         private void FrmAddCustomer_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var p = passed;
-            MainProgramCode.CloseApplication(true, ref p);
-            passed = p;
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -49,7 +49,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
@@ -263,7 +267,11 @@ namespace QuoteSwift
 
         private void FrmAddPart_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
 

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -36,7 +36,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnAddPump_Click(object sender, EventArgs e)
@@ -433,7 +437,11 @@ namespace QuoteSwift
 
         private void FrmAddPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /*********************************************************************************/

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -80,7 +80,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void CbxPumpSelection_SelectedIndexChanged(object sender, EventArgs e)
@@ -971,7 +975,11 @@ namespace QuoteSwift
 
         private void FrmCreateQuote_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
     }
 

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -26,7 +26,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void FrmManageAllEmails_Load(object sender, EventArgs e)
@@ -165,7 +169,11 @@ namespace QuoteSwift
 
         private void FrmManageAllEmails_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
     }
 

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -28,7 +28,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnChangePhoneNumberInfo_Click(object sender, EventArgs e)
@@ -259,7 +263,11 @@ namespace QuoteSwift
 
         private void FrmManagingPhoneNumbers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
     }
 }

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -26,7 +26,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnUpdateBusiness_Click(object sender, EventArgs e)
@@ -165,7 +169,11 @@ namespace QuoteSwift
 
         private void FrmViewAllBusinesses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /**********************************************************************************/

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -23,7 +23,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e)
@@ -220,9 +224,11 @@ namespace QuoteSwift
 
         private void FrmViewCustomers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var p = passed;
-            MainProgramCode.CloseApplication(true, ref p);
-            passed = p;
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /**********************************************************************************/

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -26,7 +26,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnRemoveAddress_Click(object sender, EventArgs e)
@@ -187,7 +191,11 @@ namespace QuoteSwift
 
         private void FrmViewPOBoxAddresses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /**********************************************************************************/

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -26,7 +26,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
@@ -188,7 +192,11 @@ namespace QuoteSwift
 
         private void FrmViewParts_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /*********************************************************************************/

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -27,7 +27,11 @@ namespace QuoteSwift // Repair Quote Swift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true, ref passed);
+                MainProgramCode.CloseApplication(true,
+                    passed?.PassBusinessList,
+                    passed?.PassPumpList,
+                    passed?.PassPartList,
+                    passed?.PassQuoteMap);
         }
 
         private void BtnUpdateSelectedPump_Click(object sender, EventArgs e)
@@ -151,7 +155,11 @@ namespace QuoteSwift // Repair Quote Swift
 
         private void FrmViewPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true, ref passed);
+            MainProgramCode.CloseApplication(true,
+                passed?.PassBusinessList,
+                passed?.PassPumpList,
+                passed?.PassPartList,
+                passed?.PassQuoteMap);
         }
 
         /*********************************************************************************/

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -49,9 +49,11 @@ namespace QuoteSwift
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-                MainProgramCode.CloseApplication(true, ref p);
-                viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
+                MainProgramCode.CloseApplication(true,
+                    viewModel.BusinessList,
+                    viewModel.PumpList,
+                    viewModel.PartMap,
+                    viewModel.QuoteMap);
             }
         }
 
@@ -265,9 +267,11 @@ namespace QuoteSwift
         readonly int count = 0;
         private void FrmViewQuotes_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            MainProgramCode.CloseApplication(true, ref p);
-            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
+            MainProgramCode.CloseApplication(true,
+                viewModel.BusinessList,
+                viewModel.PumpList,
+                viewModel.PartMap,
+                viewModel.QuoteMap);
         }
 
         void LoadDataGrid()


### PR DESCRIPTION
## Summary
- accept pump, part, quote and business collections directly when closing
- update serialization helpers to use collections instead of `Pass`
- fix all forms to pass the appropriate lists to `CloseApplication`

## Testing
- `msbuild QuoteSwift.sln /t:Rebuild /p:Configuration=Debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875df653d848325a8a0b6d8df592be0