### PR TITLE
Add save methods to IDataService

### DIFF
--- a/Services/ApplicationData.cs
+++ b/Services/ApplicationData.cs
@@ -27,10 +27,10 @@ namespace QuoteSwift
 
         public void SaveAll()
         {
-            MainProgramCode.SerializePartList(PartList);
-            MainProgramCode.SerializePumpList(PumpList);
-            MainProgramCode.SerializeBusinessList(BusinessList);
-            MainProgramCode.SerializeQuoteList(QuoteMap);
+            dataService.SaveParts(PartList);
+            dataService.SavePumps(PumpList);
+            dataService.SaveBusinesses(BusinessList);
+            dataService.SaveQuotes(QuoteMap);
         }
     }
 }

--- a/Services/FileDataService.cs
+++ b/Services/FileDataService.cs
@@ -28,5 +28,25 @@ namespace QuoteSwift
             byte[] bytes = MainProgramCode.RetreiveData("QuoteList.json");
             return bytes != null && bytes.Length > 0 ? MainProgramCode.DeserializeQuoteList(bytes) : new SortedDictionary<string, Quote>();
         }
+
+        public void SaveParts(Dictionary<string, Part> parts)
+        {
+            MainProgramCode.SerializePartList(parts);
+        }
+
+        public void SavePumps(BindingList<Pump> pumps)
+        {
+            MainProgramCode.SerializePumpList(pumps);
+        }
+
+        public void SaveBusinesses(BindingList<Business> businesses)
+        {
+            MainProgramCode.SerializeBusinessList(businesses);
+        }
+
+        public void SaveQuotes(SortedDictionary<string, Quote> quotes)
+        {
+            MainProgramCode.SerializeQuoteList(quotes);
+        }
     }
 }

--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -9,5 +9,10 @@ namespace QuoteSwift
         BindingList<Pump> LoadPumpList();
         BindingList<Business> LoadBusinessList();
         SortedDictionary<string, Quote> LoadQuoteMap();
+
+        void SaveParts(Dictionary<string, Part> parts);
+        void SavePumps(BindingList<Pump> pumps);
+        void SaveBusinesses(BindingList<Business> businesses);
+        void SaveQuotes(SortedDictionary<string, Quote> quotes);
     }
 }


### PR DESCRIPTION
## Summary
- extend IDataService to include save operations
- implement save methods in FileDataService using `MainProgramCode`
- update `ApplicationData.SaveAll` to use the new interface

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6875eadd5b4c832590d3d2de550e37a3