### PR TITLE
Refactor edit forms to use ApplicationData

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -5,17 +5,18 @@ namespace QuoteSwift
 {
     public partial class FrmEditBusinessAddress : Form
     {
-        readonly ViewBusinessAddressesViewModel viewModel;
+        readonly ApplicationData appData;
+        readonly Business business;
+        readonly Customer customer;
+        readonly Address address;
 
-        Pass passed;
-
-        public ref Pass Passed => ref passed;
-
-        public FrmEditBusinessAddress(ViewBusinessAddressesViewModel viewModel, Pass pass = null)
+        public FrmEditBusinessAddress(ApplicationData data, Business business = null, Customer customer = null, Address address = null)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
-            passed = pass ?? new Pass(null, null, null, null);
+            appData = data;
+            this.business = business;
+            this.customer = customer;
+            this.address = address;
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
@@ -25,14 +26,14 @@ namespace QuoteSwift
 
         private void FrmEditBusinessAddress_Load(object sender, EventArgs e)
         {
-            if (passed.AddressToChange != null)
+            if (address != null)
             {
-                txtBusinessAddresssDescription.Text = passed.AddressToChange.AddressDescription;
-                mtxtStreetnumber.Text = passed.AddressToChange.AddressStreetNumber.ToString();
-                txtStreetName.Text = passed.AddressToChange.AddressStreetName;
-                txtSuburb.Text = passed.AddressToChange.AddressSuburb;
-                txtCity.Text = passed.AddressToChange.AddressCity;
-                mtxtAreaCode.Text = passed.AddressToChange.AddressAreaCode.ToString();
+                txtBusinessAddresssDescription.Text = address.AddressDescription;
+                mtxtStreetnumber.Text = address.AddressStreetNumber.ToString();
+                txtStreetName.Text = address.AddressStreetName;
+                txtSuburb.Text = address.AddressSuburb;
+                txtCity.Text = address.AddressCity;
+                mtxtAreaCode.Text = address.AddressAreaCode.ToString();
                 txtStreetName.Enabled = false;
             }
         }
@@ -54,7 +55,15 @@ namespace QuoteSwift
 
                 if (!AddressExists(UpdatedAddress))
                 {
-                    passed.AddressToChange = UpdatedAddress;
+                    if (address != null)
+                    {
+                        address.AddressDescription = UpdatedAddress.AddressDescription;
+                        address.AddressStreetNumber = UpdatedAddress.AddressStreetNumber;
+                        address.AddressStreetName = UpdatedAddress.AddressStreetName;
+                        address.AddressSuburb = UpdatedAddress.AddressSuburb;
+                        address.AddressCity = UpdatedAddress.AddressCity;
+                        address.AddressAreaCode = UpdatedAddress.AddressAreaCode;
+                    }
                     MainProgramCode.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");
                     Close();
                 }
@@ -65,11 +74,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
-                    passed?.PassBusinessList,
-                    passed?.PassPumpList,
-                    passed?.PassPartList,
-                    passed?.PassQuoteMap);
+                appData.SaveAll();
         }
 
         private bool ValidInput()
@@ -86,7 +91,7 @@ namespace QuoteSwift
                 return (false);
             }
 
-            if (txtStreetName.Text.Length < 2 && passed.AddressToChange == null)
+            if (txtStreetName.Text.Length < 2 && address == null)
             {
                 MainProgramCode.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
                 return (false);
@@ -119,17 +124,17 @@ namespace QuoteSwift
 
             string key = StringUtil.NormalizeKey(a.AddressDescription);
 
-            if (passed?.BusinessToChange != null &&
-                passed.BusinessToChange.AddressMap.TryGetValue(key, out Address existingB))
+            if (business != null &&
+                business.AddressMap.TryGetValue(key, out Address existingB))
             {
-                if (!ReferenceEquals(existingB, passed.AddressToChange))
+                if (!ReferenceEquals(existingB, address))
                     return true;
             }
 
-            if (passed?.CustomerToChange != null &&
-                passed.CustomerToChange.DeliveryAddressMap.TryGetValue(key, out Address existingC))
+            if (customer != null &&
+                customer.DeliveryAddressMap.TryGetValue(key, out Address existingC))
             {
-                if (!ReferenceEquals(existingC, passed.AddressToChange))
+                if (!ReferenceEquals(existingC, address))
                     return true;
             }
 
@@ -143,11 +148,7 @@ namespace QuoteSwift
 
         private void FrmEditBusinessAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
-                passed?.PassBusinessList,
-                passed?.PassPumpList,
-                passed?.PassPartList,
-                passed?.PassQuoteMap);
+            appData.SaveAll();
         }
     }
 }

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -6,52 +6,44 @@ namespace QuoteSwift
     public partial class FrmEditEmailAddress : Form
     {
 
-        readonly ManageEmailsViewModel viewModel;
+        readonly ApplicationData appData;
+        readonly Business business;
+        readonly Customer customer;
+        string email;
 
-        Pass passed;
-
-        public ref Pass Passed => ref passed;
-
-        public FrmEditEmailAddress(ManageEmailsViewModel viewModel, Pass pass = null)
+        public FrmEditEmailAddress(ApplicationData data, Business business = null, Customer customer = null, string email = null)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
-            passed = pass ?? new Pass(null, null, null, null);
+            appData = data;
+            this.business = business;
+            this.customer = customer;
+            this.email = email;
         }
 
         private void BtnUpdateBusinessEmail_Click(object sender, EventArgs e)
         {
             if (mtxtEmail.Text.Length > 3 && mtxtEmail.Text.Contains("@"))
             {
-                string oldEmail = passed.EmailToChange;
-                passed.EmailToChange = mtxtEmail.Text;
-                if (passed != null && passed.BusinessToChange != null)
+                string newEmail = mtxtEmail.Text;
+                if (business != null)
                 {
-                    var vm = new AddBusinessViewModel(viewModel.DataService);
-                    vm.UpdateData(passed.PassBusinessList, passed.BusinessToChange, passed.ChangeSpecificObject);
-                    vm.LoadData();
-                    FrmAddBusiness frmAddBusiness = new FrmAddBusiness(vm);
-                    frmAddBusiness.SetPass(passed);
-                    if (!frmAddBusiness.EmailAddressExisting(mtxtEmail.Text))
+                    if (!business.EmailAddresses.Contains(newEmail))
                     {
+                        business.UpdateEmailAddress(email, newEmail);
+                        email = newEmail;
                         MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
                         Close();
                     }
-                    else passed.EmailToChange = oldEmail;
                 }
-                else if (passed != null && passed.CustomerToChange != null)
+                else if (customer != null)
                 {
-                    var vm = new AddCustomerViewModel(viewModel.DataService);
-                    vm.UpdateData(passed.PassBusinessList, passed.CustomerToChange, passed.ChangeSpecificObject);
-                    vm.LoadData();
-                    FrmAddCustomer frmAddCustomer = new FrmAddCustomer(vm);
-                    frmAddCustomer.SetPass(passed);
-                    if (!frmAddCustomer.EmailAddressExisting(mtxtEmail.Text))
+                    if (!customer.EmailAddresses.Contains(newEmail))
                     {
+                        customer.UpdateEmailAddress(email, newEmail);
+                        email = newEmail;
                         MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
                         Close();
                     }
-                    else passed.EmailToChange = oldEmail;
                 }
             }
             else MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
@@ -59,7 +51,7 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_Load(object sender, EventArgs e)
         {
-            mtxtEmail.Text = passed.EmailToChange;
+            mtxtEmail.Text = email;
 
         }
 
@@ -70,22 +62,14 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            MainProgramCode.CloseApplication(
-                MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"),
-                passed?.PassBusinessList,
-                passed?.PassPumpList,
-                passed?.PassPartList,
-                passed?.PassQuoteMap);
+            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"))
+                appData.SaveAll();
         }
 
         private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
-                    passed?.PassBusinessList,
-                    passed?.PassPumpList,
-                    passed?.PassPartList,
-                    passed?.PassQuoteMap);
+                appData.SaveAll();
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -95,11 +79,7 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
-                passed?.PassBusinessList,
-                passed?.PassPumpList,
-                passed?.PassPartList,
-                passed?.PassQuoteMap);
+            appData.SaveAll();
         }
     }
 }

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -6,50 +6,55 @@ namespace QuoteSwift
     public partial class FrmEditPhoneNumber : Form
     {
 
-        readonly ManagePhoneNumbersViewModel viewModel;
+        readonly ApplicationData appData;
+        readonly Business business;
+        readonly Customer customer;
+        string number;
 
-        Pass passed;
-
-        public ref Pass Passed => ref passed;
-
-        public FrmEditPhoneNumber(ManagePhoneNumbersViewModel viewModel, Pass pass = null)
+        public FrmEditPhoneNumber(ApplicationData data, Business business = null, Customer customer = null, string number = "")
         {
             InitializeComponent();
-            this.viewModel = viewModel;
-            passed = pass ?? new Pass(null, null, null, null);
+            appData = data;
+            this.business = business;
+            this.customer = customer;
+            this.number = number;
         }
 
         private void FrmEditPhoneNumber_Load(object sender, EventArgs e)
         {
-            if (passed.PhoneNumberToChange != "") txtPhoneNumber.Text = passed.PhoneNumberToChange;
+            if (!string.IsNullOrWhiteSpace(number))
+                txtPhoneNumber.Text = number;
         }
 
         private void BtnUpdateNumber_Click(object sender, EventArgs e)
         {
-            if (passed != null && passed.BusinessToChange != null)
+            string newNumber = txtPhoneNumber.Text;
+            if (business != null)
             {
-                var vm = new AddBusinessViewModel(viewModel.DataService);
-                vm.UpdateData(passed.PassBusinessList, passed.BusinessToChange, passed.ChangeSpecificObject);
-                vm.LoadData();
-                FrmAddBusiness frmAddBusiness = new FrmAddBusiness(vm);
-                frmAddBusiness.SetPass(passed);
-                if (!frmAddBusiness.PhoneNumberExisting(txtPhoneNumber.Text))
+                bool isCell = business.CellphoneNumbers.Contains(number);
+                bool isTel = business.TelephoneNumbers.Contains(number);
+                if (!business.CellphoneNumbers.Contains(newNumber) && !business.TelephoneNumbers.Contains(newNumber))
                 {
-                    passed.PhoneNumberToChange = txtPhoneNumber.Text;
+                    if (isCell)
+                        business.UpdateCellphoneNumber(number, newNumber);
+                    else if (isTel)
+                        business.UpdateTelephoneNumber(number, newNumber);
+                    number = newNumber;
                     MainProgramCode.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
                     Close();
                 }
             }
-            else if (passed != null && passed.CustomerToChange != null)
+            else if (customer != null)
             {
-                var vm = new AddCustomerViewModel(viewModel.DataService);
-                vm.UpdateData(passed.PassBusinessList, passed.CustomerToChange, passed.ChangeSpecificObject);
-                vm.LoadData();
-                FrmAddCustomer frmAddCustomer = new FrmAddCustomer(vm);
-                frmAddCustomer.SetPass(passed);
-                if (!frmAddCustomer.PhoneNumberExisting(txtPhoneNumber.Text))
+                bool isCell = customer.CellphoneNumbers.Contains(number);
+                bool isTel = customer.TelephoneNumbers.Contains(number);
+                if (!customer.CellphoneNumbers.Contains(newNumber) && !customer.TelephoneNumbers.Contains(newNumber))
                 {
-                    passed.PhoneNumberToChange = txtPhoneNumber.Text;
+                    if (isCell)
+                        customer.UpdateCellphoneNumber(number, newNumber);
+                    else if (isTel)
+                        customer.UpdateTelephoneNumber(number, newNumber);
+                    number = newNumber;
                     MainProgramCode.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
                     Close();
                 }
@@ -64,11 +69,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
-                    passed?.PassBusinessList,
-                    passed?.PassPumpList,
-                    passed?.PassPartList,
-                    passed?.PassQuoteMap);
+                appData.SaveAll();
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -78,11 +79,7 @@ namespace QuoteSwift
 
         private void FrmEditPhoneNumber_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
-                passed?.PassBusinessList,
-                passed?.PassPumpList,
-                passed?.PassPartList,
-                passed?.PassQuoteMap);
+            appData.SaveAll();
         }
     }
 }

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -10,16 +10,18 @@ namespace QuoteSwift
 
         readonly ViewBusinessAddressesViewModel viewModel;
         readonly INavigationService navigation;
+        readonly ApplicationData appData;
 
         Pass passed;
 
         public ref Pass Passed => ref passed;
 
-        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, Pass pass = null)
+        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Pass pass = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            appData = data;
             passed = pass ?? new Pass(null, null, null, null);
         }
 
@@ -74,15 +76,7 @@ namespace QuoteSwift
                 return;
             }
 
-            passed.AddressToChange = address;
-            passed.ChangeSpecificObject = false;
-
-            passed = navigation.EditBusinessAddress(passed);
-
-            if (!ReplacePOBoxAddress(address, passed.AddressToChange)) MainProgramCode.ShowError("An error occurred during the updating procedure of the Address.\nUpdated address will not be stored.", "ERROR - Address Not Updated");
-
-            passed.AddressToChange = null;
-            passed.ChangeSpecificObject = false;
+            navigation.EditBusinessAddress(passed);
 
             LoadInformation();
         }
@@ -167,22 +161,6 @@ namespace QuoteSwift
                                                          passed.CustomerToChange.CustomerDeliveryAddressList[i].AddressCity, passed.CustomerToChange.CustomerDeliveryAddressList[i].AddressAreaCode);
         }
 
-        private bool ReplacePOBoxAddress(Address Original, Address New)
-        {
-            if (passed != null && passed.BusinessToChange != null && New != null && Original != null)
-            {
-                passed.BusinessToChange.UpdateAddress(Original, New);
-                return true;
-            }
-
-            if (passed != null && passed.CustomerToChange != null && New != null && Original != null)
-            {
-                passed.CustomerToChange.UpdateDeliveryAddress(Original, New);
-                return true;
-            }
-
-            return false;
-        }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -15,7 +15,7 @@ namespace QuoteSwift
             var appData = new ApplicationData(dataService);
             appData.Load();
 
-            var navigation = new NavigationService(dataService);
+            var navigation = new NavigationService(dataService, appData);
             QuotesViewModel viewModel = new QuotesViewModel(dataService);
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
 

--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -263,7 +263,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessAddressesViewModel(new FileDataService());
             vm.LoadData();
-            FrmViewBusinessAddresses FrmViewBusinessAddresses = new FrmViewBusinessAddresses(vm, null, passed);
+            FrmViewBusinessAddresses FrmViewBusinessAddresses = new FrmViewBusinessAddresses(vm, null, null, passed);
             FrmViewBusinessAddresses.ShowDialog();
             return ref passed;
         }
@@ -287,7 +287,7 @@ namespace QuoteSwift
         {
             var vm = new ManageEmailsViewModel(new FileDataService());
             vm.LoadData();
-            FrmManageAllEmails FrmManageAllEmails = new FrmManageAllEmails(vm, null, passed);
+            FrmManageAllEmails FrmManageAllEmails = new FrmManageAllEmails(vm, null, null, passed);
             FrmManageAllEmails.ShowDialog();
             return ref passed;
         }
@@ -299,7 +299,7 @@ namespace QuoteSwift
         {
             var vm = new ManagePhoneNumbersViewModel(new FileDataService());
             vm.LoadData();
-            FrmManagingPhoneNumbers FrmManagingPhoneNumbers = new FrmManagingPhoneNumbers(vm, null, passed);
+            FrmManagingPhoneNumbers FrmManagingPhoneNumbers = new FrmManagingPhoneNumbers(vm, null, null, passed);
             FrmManagingPhoneNumbers.ShowDialog();
             return ref passed;
         }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -5,10 +5,12 @@ namespace QuoteSwift
     public class NavigationService : INavigationService
     {
         readonly IDataService dataService;
+        readonly ApplicationData appData;
 
-        public NavigationService(IDataService service)
+        public NavigationService(IDataService service, ApplicationData data)
         {
             dataService = service;
+            appData = data;
         }
 
         public Pass CreateNewQuote(Pass pass)
@@ -142,7 +144,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewBusinessAddresses(vm, this, pass))
+            using (var form = new FrmViewBusinessAddresses(vm, this, appData, pass))
             {
                 form.ShowDialog();
             }
@@ -164,7 +166,7 @@ namespace QuoteSwift
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmManageAllEmails(vm, this, pass))
+            using (var form = new FrmManageAllEmails(vm, this, appData, pass))
             {
                 form.ShowDialog();
             }
@@ -175,7 +177,7 @@ namespace QuoteSwift
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmManagingPhoneNumbers(vm, this, pass))
+            using (var form = new FrmManagingPhoneNumbers(vm, this, appData, pass))
             {
                 form.ShowDialog();
             }
@@ -184,9 +186,7 @@ namespace QuoteSwift
 
         public Pass EditBusinessAddress(Pass pass)
         {
-            var vm = new ViewBusinessAddressesViewModel(dataService);
-            vm.LoadData();
-            using (var form = new FrmEditBusinessAddress(vm, pass))
+            using (var form = new FrmEditBusinessAddress(appData, pass.BusinessToChange, pass.CustomerToChange, pass.AddressToChange))
             {
                 form.ShowDialog();
             }
@@ -195,9 +195,7 @@ namespace QuoteSwift
 
         public Pass EditBusinessEmailAddress(Pass pass)
         {
-            var vm = new ManageEmailsViewModel(dataService);
-            vm.LoadData();
-            using (var form = new FrmEditEmailAddress(vm, pass))
+            using (var form = new FrmEditEmailAddress(appData, pass.BusinessToChange, pass.CustomerToChange, pass.EmailToChange))
             {
                 form.ShowDialog();
             }
@@ -206,9 +204,7 @@ namespace QuoteSwift
 
         public Pass EditPhoneNumber(Pass pass)
         {
-            var vm = new ManagePhoneNumbersViewModel(dataService);
-            vm.LoadData();
-            using (var form = new FrmEditPhoneNumber(vm, pass))
+            using (var form = new FrmEditPhoneNumber(appData, pass.BusinessToChange, pass.CustomerToChange, pass.PhoneNumberToChange))
             {
                 form.ShowDialog();
             }

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -10,16 +10,18 @@ namespace QuoteSwift
 
         readonly ManageEmailsViewModel viewModel;
         readonly INavigationService navigation;
+        readonly ApplicationData appData;
 
         Pass passed;
 
         public ref Pass Passed => ref passed;
 
-        public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, Pass pass = null)
+        public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Pass pass = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            appData = data;
             passed = pass ?? new Pass(null, null, null, null);
         }
 
@@ -100,21 +102,7 @@ namespace QuoteSwift
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
         {
             string email = GetEmailSelection();
-            passed.EmailToChange = email;
-            passed.ChangeSpecificObject = true;
-            passed = navigation.EditBusinessEmailAddress(passed);
-
-            if (passed.BusinessToChange != null && passed.BusinessToChange.BusinessEmailAddressList != null)
-            {
-                passed.BusinessToChange.UpdateEmailAddress(email, passed.EmailToChange);
-            }
-            else if (passed.CustomerToChange != null && passed.CustomerToChange.CustomerEmailList != null)
-            {
-                passed.CustomerToChange.UpdateEmailAddress(email, passed.EmailToChange);
-            }
-
-            passed.ChangeSpecificObject = false;
-            passed.EmailToChange = null;
+            navigation.EditBusinessEmailAddress(passed);
             LoadInformation();
         }
 

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -44,8 +44,6 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = true;
 
                 passed = navigation.EditPhoneNumber(passed);
-                passed.BusinessToChange.UpdateCellphoneNumber(OldNumber, passed.PhoneNumberToChange);
-
                 passed.PhoneNumberToChange = "";
                 passed.ChangeSpecificObject = false;
             }
@@ -56,8 +54,6 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = true;
 
                 passed = navigation.EditPhoneNumber(passed);
-                passed.CustomerToChange.UpdateCellphoneNumber(OldNumber, passed.PhoneNumberToChange);
-
                 passed.PhoneNumberToChange = "";
                 passed.ChangeSpecificObject = false;
             }
@@ -74,8 +70,6 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = true;
 
                 passed = navigation.EditPhoneNumber(passed);
-                passed.BusinessToChange.UpdateTelephoneNumber(OldNumber, passed.PhoneNumberToChange);
-
                 passed.PhoneNumberToChange = "";
                 passed.ChangeSpecificObject = false;
             }
@@ -86,8 +80,6 @@ namespace QuoteSwift
                 passed.ChangeSpecificObject = true;
 
                 passed = navigation.EditPhoneNumber(passed);
-                passed.CustomerToChange.UpdateTelephoneNumber(OldNumber, passed.PhoneNumberToChange);
-
                 passed.PhoneNumberToChange = "";
                 passed.ChangeSpecificObject = false;
             }
@@ -263,11 +255,7 @@ namespace QuoteSwift
 
         private void FrmManagingPhoneNumbers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
-                passed?.PassBusinessList,
-                passed?.PassPumpList,
-                passed?.PassPartList,
-                passed?.PassQuoteMap);
+            appData.SaveAll();
         }
     }
 }

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -10,16 +10,18 @@ namespace QuoteSwift
 
         readonly ViewPOBoxAddressesViewModel viewModel;
         readonly INavigationService navigation;
+        readonly ApplicationData appData;
 
         Pass passed;
 
         public ref Pass Passed => ref passed;
 
-        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, Pass pass = null)
+        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Pass pass = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            appData = data;
             passed = pass ?? new Pass(null, null, null, null);
         }
 
@@ -75,15 +77,7 @@ namespace QuoteSwift
                 return;
             }
 
-            passed.ChangeSpecificObject = false;
-            passed.AddressToChange = address;
-
-            passed = navigation.EditBusinessAddress(passed);
-
-            if (!ReplacePOBoxAddress(address, passed.AddressToChange)) MainProgramCode.ShowError("An error occurred during the updating procedure of the P.O.Box Address.\nUpdated P.O.Box address will not be stored.", "ERROR - P.O.Box Address Not Updated");
-
-            passed.AddressToChange = null;
-            passed.ChangeSpecificObject = false;
+            navigation.EditBusinessAddress(passed);
 
             LoadInformation();
         }
@@ -167,22 +161,6 @@ namespace QuoteSwift
                                                          passed.CustomerToChange.CustomerPOBoxAddress[i].AddressAreaCode);
         }
 
-        private bool ReplacePOBoxAddress(Address Original, Address New)
-        {
-            if (passed != null && passed.BusinessToChange != null && New != null && Original != null)
-            {
-                passed.BusinessToChange.UpdatePOBoxAddress(Original, New);
-                return true;
-            }
-
-            if (passed != null && passed.CustomerToChange != null && New != null && Original != null)
-            {
-                passed.CustomerToChange.UpdatePOBoxAddress(Original, New);
-                return true;
-            }
-
-            return false;
-        }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- inject `ApplicationData` into edit forms instead of using `Pass`
- update navigation service and program to pass the new parameter
- adjust view forms that launch the editors
- persist data by calling `ApplicationData.SaveAll()` on close

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ec98e8388325b31009a96bc161b8