### PR TITLE
Refactor ViewPump to use ApplicationData

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -41,7 +41,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPumpViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewPump(vm, this, pass))
+            using (var form = new FrmViewPump(vm, this, appData))
             {
                 form.ShowDialog();
             }

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Collections.Generic;
 
 namespace QuoteSwift
 {
@@ -6,6 +7,7 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         BindingList<Pump> pumps;
+        HashSet<string> repairableItemNames;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -26,9 +28,30 @@ namespace QuoteSwift
             }
         }
 
+        public HashSet<string> RepairableItemNames
+        {
+            get => repairableItemNames;
+            set
+            {
+                repairableItemNames = value;
+                OnPropertyChanged(nameof(RepairableItemNames));
+            }
+        }
+
         public void LoadData()
         {
             Pumps = dataService.LoadPumpList();
+            if (Pumps != null)
+            {
+                var set = new HashSet<string>();
+                foreach (var p in Pumps)
+                    set.Add(StringUtil.NormalizeKey(p.PumpName));
+                RepairableItemNames = set;
+            }
+            else
+            {
+                RepairableItemNames = new HashSet<string>();
+            }
         }
 
         protected void OnPropertyChanged(string propertyName)


### PR DESCRIPTION
## Summary
- refactor `frmViewPump` to use `ApplicationData`
- keep pump name lookup in `ViewPumpViewModel`
- update `NavigationService.ViewAllPumps` for new constructor

## Testing
- `dotnet restore QuoteSwift.sln --no-cache`
- `dotnet msbuild QuoteSwift.sln /nologo /v:m` *(fails: System.Windows.Forms not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761a61b93c8325a5fad8154953113f