### PR TITLE
Refactor part views to use ApplicationData

### DIFF
--- a/QuoteSwiftMainCode.cs
+++ b/QuoteSwiftMainCode.cs
@@ -175,7 +175,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPartsViewModel(new FileDataService());
             vm.LoadData();
-            FrmViewParts frmViewParts = new FrmViewParts(vm, null, passed);
+            FrmViewParts frmViewParts = new FrmViewParts(vm, null, null);
             try
             {
                 frmViewParts.ShowDialog();
@@ -194,8 +194,7 @@ namespace QuoteSwift
         {
             var vm = new AddPartViewModel(new FileDataService());
             vm.UpdatePass(passed.PassPartList, passed.PassPumpList, passed.PartToChange, passed.ChangeSpecificObject);
-            FrmAddPart frmAddPart = new FrmAddPart(vm, null);
-            frmAddPart.SetPass(passed);
+            FrmAddPart frmAddPart = new FrmAddPart(vm, null, null);
             frmAddPart.ShowDialog();
             return ref passed;
         }

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -6,10 +6,10 @@ namespace QuoteSwift
     {
         Pass CreateNewQuote(Pass pass);
         Pass ViewAllQuotes(Pass pass);
-        Pass ViewAllPumps(Pass pass);
+        void ViewAllPumps(ApplicationData data);
         void CreateNewPump(ApplicationData data);
-        Pass ViewAllParts(Pass pass);
-        Pass AddNewPart(Pass pass);
+        void ViewAllParts(ApplicationData data);
+        void AddNewPart(ApplicationData data, Part partToChange = null, bool changeSpecificObject = false);
         Pass AddCustomer(Pass pass);
         Pass ViewCustomers(Pass pass);
         Pass AddBusiness(Pass pass);

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -37,15 +37,14 @@ namespace QuoteSwift
             return pass;
         }
 
-        public Pass ViewAllPumps(Pass pass)
+        public void ViewAllPumps(ApplicationData data)
         {
             var vm = new ViewPumpViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewPump(vm, this, appData))
+            using (var form = new FrmViewPump(vm, this, data))
             {
                 form.ShowDialog();
             }
-            return pass;
         }
 
         public void CreateNewPump(ApplicationData data)
@@ -62,28 +61,27 @@ namespace QuoteSwift
             data.SaveAll();
         }
 
-        public Pass ViewAllParts(Pass pass)
+        public void ViewAllParts(ApplicationData data)
         {
             var vm = new ViewPartsViewModel(dataService);
-            vm.LoadData();
-            using (var form = new FrmViewParts(vm, this, pass))
+            vm.UpdateData(data.PartList);
+            using (var form = new FrmViewParts(vm, this, data))
             {
                 form.ShowDialog();
             }
-            return pass;
         }
 
-        public Pass AddNewPart(Pass pass)
+        public void AddNewPart(ApplicationData data, Part partToChange = null, bool changeSpecificObject = false)
         {
             var vm = new AddPartViewModel(dataService);
-            vm.UpdatePass(pass.PassPartList, pass.PassPumpList, pass.PartToChange, pass.ChangeSpecificObject);
-            vm.LoadData();
-            using (var form = new FrmAddPart(vm, this))
+            vm.UpdatePass(data.PartList, data.PumpList, partToChange, changeSpecificObject);
+            using (var form = new FrmAddPart(vm, this, data))
             {
-                form.SetPass(pass);
                 form.ShowDialog();
             }
-            return pass;
+            data.PartList = vm.PartMap;
+            data.PumpList = vm.PumpList;
+            data.SaveAll();
         }
 
         public Pass AddCustomer(Pass pass)

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -32,6 +32,11 @@ namespace QuoteSwift
             PartList = dataService.LoadPartList();
         }
 
+        public void UpdateData(Dictionary<string, Part> parts)
+        {
+            PartList = parts;
+        }
+
         protected void OnPropertyChanged(string propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -10,22 +10,14 @@ namespace QuoteSwift
         readonly AddPartViewModel viewModel;
         readonly INavigationService navigation;
 
-        Pass passed;
+        readonly ApplicationData appData;
 
-        public ref Pass Passed { get => ref passed; }
-
-        public void SetPass(Pass value)
-        {
-            passed = value;
-            if (value != null)
-                viewModel.UpdatePass(value.PassPartList, value.PassPumpList, value.PartToChange, value.ChangeSpecificObject);
-        }
-
-        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null)
+        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            appData = data;
             viewModel.Initialize();
             SetupBindings();
         }
@@ -50,10 +42,10 @@ namespace QuoteSwift
         {
             if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
-                    passed?.PassBusinessList,
-                    passed?.PassPumpList,
-                    passed?.PassPartList,
-                    passed?.PassQuoteMap);
+                    appData?.BusinessList,
+                    appData?.PumpList,
+                    appData?.PartList,
+                    appData?.QuoteMap);
         }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
@@ -62,7 +54,7 @@ namespace QuoteSwift
             if (!ValidInput())
                 return;
 
-            bool updating = passed.ChangeSpecificObject;
+            bool updating = viewModel.ChangeSpecificObject;
 
             if (!viewModel.AddOrUpdatePart())
             {
@@ -73,7 +65,7 @@ namespace QuoteSwift
             if (updating)
             {
                 MainProgramCode.ShowInformation("Successfully updated the part", "CONFIRMATION - Update Successful");
-                passed.ChangeSpecificObject = false;
+                viewModel.ChangeSpecificObject = false;
                 Close();
             }
             else
@@ -151,13 +143,13 @@ namespace QuoteSwift
 
         private void FrmAddPart_Load(object sender, EventArgs e)
         {
-            if (passed.ChangeSpecificObject && passed.PartToChange != null)
+            if (viewModel.ChangeSpecificObject && viewModel.PartToChange != null)
             {
                 ReadWriteComponents();
                 btnAddPart.Text = "Update";
                 updatePartToolStripMenuItem.Enabled = false;
             }
-            else if (!passed.ChangeSpecificObject && passed.PartToChange != null)
+            else if (!viewModel.ChangeSpecificObject && viewModel.PartToChange != null)
             {
                 btnAddPart.Visible = false;
                 Read_OnlyComponents();
@@ -251,12 +243,12 @@ namespace QuoteSwift
 
         private void UpdatePartToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!passed.ChangeSpecificObject)
-                if (MainProgramCode.RequestConfirmation("You are currently only viewing " + passed.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
+            if (!viewModel.ChangeSpecificObject)
+                if (MainProgramCode.RequestConfirmation("You are currently only viewing " + viewModel.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
                 {
                     ReadWriteComponents();
                     updatePartToolStripMenuItem.Enabled = false;
-                    passed.ChangeSpecificObject = true;
+                    viewModel.ChangeSpecificObject = true;
                 }
         }
 
@@ -268,10 +260,10 @@ namespace QuoteSwift
         private void FrmAddPart_FormClosing(object sender, FormClosingEventArgs e)
         {
             MainProgramCode.CloseApplication(true,
-                passed?.PassBusinessList,
-                passed?.PassPumpList,
-                passed?.PassPartList,
-                passed?.PassQuoteMap);
+                appData?.BusinessList,
+                appData?.PumpList,
+                appData?.PartList,
+                appData?.QuoteMap);
         }
 
 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -62,9 +62,8 @@ namespace QuoteSwift
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            p = navigation.ViewAllPumps(p);
-            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
+            navigation.ViewAllPumps(appData);
+            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
                 Show();
@@ -224,9 +223,8 @@ namespace QuoteSwift
         private void ViewAllPartsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            p = navigation.ViewAllParts(p);
-            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
+            navigation.ViewAllParts(appData);
+            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
                 Show();
@@ -245,9 +243,8 @@ namespace QuoteSwift
         private void AddNewPartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            var p = new Pass(viewModel.QuoteMap, viewModel.BusinessList, viewModel.PumpList, viewModel.PartMap);
-            p = navigation.AddNewPart(p);
-            viewModel.UpdateData(p.PassQuoteMap, p.PassBusinessList, p.PassPumpList, p.PassPartList);
+            navigation.AddNewPart(appData);
+            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
                 Show();


### PR DESCRIPTION
## Summary
- inject `ApplicationData` into `FrmViewParts` and `FrmAddPart`
- use app-wide data rather than `Pass` for part and pump lists
- update `NavigationService` and `INavigationService` to accept `ApplicationData`
- remove pass creation in `FrmViewQuotes` when navigating to part screens
- add helper `UpdateData` method to `ViewPartsViewModel`

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln -t:Rebuild -p:Configuration=Debug` *(fails: System.Windows.Forms reference not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876217e0c7483258629c848b42a0251