### PR TITLE
Refactor edit dialogs to use view models

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -6,17 +6,13 @@ namespace QuoteSwift
     public partial class FrmEditBusinessAddress : Form
     {
         readonly ApplicationData appData;
-        readonly Business business;
-        readonly Customer customer;
-        readonly Address address;
+        readonly EditBusinessAddressViewModel viewModel;
 
-        public FrmEditBusinessAddress(ApplicationData data, Business business = null, Customer customer = null, Address address = null)
+        public FrmEditBusinessAddress(EditBusinessAddressViewModel viewModel, ApplicationData data = null)
         {
             InitializeComponent();
+            this.viewModel = viewModel;
             appData = data;
-            this.business = business;
-            this.customer = customer;
-            this.address = address;
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
@@ -26,48 +22,34 @@ namespace QuoteSwift
 
         private void FrmEditBusinessAddress_Load(object sender, EventArgs e)
         {
-            if (address != null)
+            if (viewModel.Address != null)
             {
-                txtBusinessAddresssDescription.Text = address.AddressDescription;
-                mtxtStreetnumber.Text = address.AddressStreetNumber.ToString();
-                txtStreetName.Text = address.AddressStreetName;
-                txtSuburb.Text = address.AddressSuburb;
-                txtCity.Text = address.AddressCity;
-                mtxtAreaCode.Text = address.AddressAreaCode.ToString();
+                txtBusinessAddresssDescription.Text = viewModel.Address.AddressDescription;
+                mtxtStreetnumber.Text = viewModel.Address.AddressStreetNumber.ToString();
+                txtStreetName.Text = viewModel.Address.AddressStreetName;
+                txtSuburb.Text = viewModel.Address.AddressSuburb;
+                txtCity.Text = viewModel.Address.AddressCity;
+                mtxtAreaCode.Text = viewModel.Address.AddressAreaCode.ToString();
                 txtStreetName.Enabled = false;
             }
         }
 
         private void BtnUpdateAddress_Click(object sender, EventArgs e)
         {
-            if (ValidInput())
+            Address updated = new Address
             {
-                Address UpdatedAddress = new Address
-                {
-                    AddressDescription = txtBusinessAddresssDescription.Text,
-                    AddressStreetNumber = QuoteSwiftMainCode.ParseInt(mtxtStreetnumber.Text),
-                    AddressStreetName = txtStreetName.Text,
-                    AddressSuburb = txtSuburb.Text,
-                    AddressCity = txtCity.Text,
-                    AddressAreaCode = QuoteSwiftMainCode.ParseInt(mtxtAreaCode.Text)
-                };
+                AddressDescription = txtBusinessAddresssDescription.Text,
+                AddressStreetNumber = QuoteSwiftMainCode.ParseInt(mtxtStreetnumber.Text),
+                AddressStreetName = txtStreetName.Text,
+                AddressSuburb = txtSuburb.Text,
+                AddressCity = txtCity.Text,
+                AddressAreaCode = QuoteSwiftMainCode.ParseInt(mtxtAreaCode.Text)
+            };
 
-
-                if (!AddressExists(UpdatedAddress))
-                {
-                    if (address != null)
-                    {
-                        address.AddressDescription = UpdatedAddress.AddressDescription;
-                        address.AddressStreetNumber = UpdatedAddress.AddressStreetNumber;
-                        address.AddressStreetName = UpdatedAddress.AddressStreetName;
-                        address.AddressSuburb = UpdatedAddress.AddressSuburb;
-                        address.AddressCity = UpdatedAddress.AddressCity;
-                        address.AddressAreaCode = UpdatedAddress.AddressAreaCode;
-                    }
-                    MainProgramCode.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");
-                    Close();
-                }
-                else MainProgramCode.ShowError("Address not updated since this address is already in the list of addresses.\nNOTE: Address Description should be unique.", "ERROR - Address Already Added");
+            if (viewModel.UpdateAddress(updated))
+            {
+                MainProgramCode.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");
+                Close();
             }
         }
 
@@ -77,69 +59,6 @@ namespace QuoteSwift
                 appData.SaveAll();
         }
 
-        private bool ValidInput()
-        {
-            if (txtBusinessAddresssDescription.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
-                return (false);
-            }
-
-            if (QuoteSwiftMainCode.ParseInt(mtxtStreetnumber.Text) == 0)
-            {
-                MainProgramCode.ShowError("The provided Business Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business Address Street Number");
-                return (false);
-            }
-
-            if (txtStreetName.Text.Length < 2 && address == null)
-            {
-                MainProgramCode.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
-                return (false);
-            }
-
-            if (txtSuburb.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
-                return (false);
-            }
-
-            if (txtCity.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
-                return (false);
-            }
-
-            if (QuoteSwiftMainCode.ParseInt(mtxtAreaCode.Text) == 0)
-            {
-                MainProgramCode.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business Address Area Code");
-                return (false);
-            }
-
-            return true;
-        }
-
-        private bool AddressExists(Address a)
-        {
-            if (a == null) return false;
-
-            string key = StringUtil.NormalizeKey(a.AddressDescription);
-
-            if (business != null &&
-                business.AddressMap.TryGetValue(key, out Address existingB))
-            {
-                if (!ReferenceEquals(existingB, address))
-                    return true;
-            }
-
-            if (customer != null &&
-                customer.DeliveryAddressMap.TryGetValue(key, out Address existingC))
-            {
-                if (!ReferenceEquals(existingC, address))
-                    return true;
-            }
-
-            return false;
-        }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -7,51 +7,28 @@ namespace QuoteSwift
     {
 
         readonly ApplicationData appData;
-        readonly Business business;
-        readonly Customer customer;
-        string email;
+        readonly EditEmailAddressViewModel viewModel;
 
-        public FrmEditEmailAddress(ApplicationData data, Business business = null, Customer customer = null, string email = null)
+        public FrmEditEmailAddress(EditEmailAddressViewModel viewModel, ApplicationData data = null)
         {
             InitializeComponent();
+            this.viewModel = viewModel;
             appData = data;
-            this.business = business;
-            this.customer = customer;
-            this.email = email;
         }
 
         private void BtnUpdateBusinessEmail_Click(object sender, EventArgs e)
         {
-            if (mtxtEmail.Text.Length > 3 && mtxtEmail.Text.Contains("@"))
+            viewModel.CurrentEmail = mtxtEmail.Text;
+            if (viewModel.UpdateEmail())
             {
-                string newEmail = mtxtEmail.Text;
-                if (business != null)
-                {
-                    if (!business.EmailAddresses.Contains(newEmail))
-                    {
-                        business.UpdateEmailAddress(email, newEmail);
-                        email = newEmail;
-                        MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
-                        Close();
-                    }
-                }
-                else if (customer != null)
-                {
-                    if (!customer.EmailAddresses.Contains(newEmail))
-                    {
-                        customer.UpdateEmailAddress(email, newEmail);
-                        email = newEmail;
-                        MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
-                        Close();
-                    }
-                }
+                MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
+                Close();
             }
-            else MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
         }
 
         private void FrmEditEmailAddress_Load(object sender, EventArgs e)
         {
-            mtxtEmail.Text = email;
+            mtxtEmail.Text = viewModel.CurrentEmail;
 
         }
 

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -7,57 +7,28 @@ namespace QuoteSwift
     {
 
         readonly ApplicationData appData;
-        readonly Business business;
-        readonly Customer customer;
-        string number;
+        readonly EditPhoneNumberViewModel viewModel;
 
-        public FrmEditPhoneNumber(ApplicationData data, Business business = null, Customer customer = null, string number = "")
+        public FrmEditPhoneNumber(EditPhoneNumberViewModel viewModel, ApplicationData data = null)
         {
             InitializeComponent();
+            this.viewModel = viewModel;
             appData = data;
-            this.business = business;
-            this.customer = customer;
-            this.number = number;
         }
 
         private void FrmEditPhoneNumber_Load(object sender, EventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(number))
-                txtPhoneNumber.Text = number;
+            if (!string.IsNullOrWhiteSpace(viewModel.CurrentNumber))
+                txtPhoneNumber.Text = viewModel.CurrentNumber;
         }
 
         private void BtnUpdateNumber_Click(object sender, EventArgs e)
         {
-            string newNumber = txtPhoneNumber.Text;
-            if (business != null)
+            viewModel.CurrentNumber = txtPhoneNumber.Text;
+            if (viewModel.UpdateNumber())
             {
-                bool isCell = business.CellphoneNumbers.Contains(number);
-                bool isTel = business.TelephoneNumbers.Contains(number);
-                if (!business.CellphoneNumbers.Contains(newNumber) && !business.TelephoneNumbers.Contains(newNumber))
-                {
-                    if (isCell)
-                        business.UpdateCellphoneNumber(number, newNumber);
-                    else if (isTel)
-                        business.UpdateTelephoneNumber(number, newNumber);
-                    number = newNumber;
-                    MainProgramCode.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
-                    Close();
-                }
-            }
-            else if (customer != null)
-            {
-                bool isCell = customer.CellphoneNumbers.Contains(number);
-                bool isTel = customer.TelephoneNumbers.Contains(number);
-                if (!customer.CellphoneNumbers.Contains(newNumber) && !customer.TelephoneNumbers.Contains(newNumber))
-                {
-                    if (isCell)
-                        customer.UpdateCellphoneNumber(number, newNumber);
-                    else if (isTel)
-                        customer.UpdateTelephoneNumber(number, newNumber);
-                    number = newNumber;
-                    MainProgramCode.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
-                    Close();
-                }
+                MainProgramCode.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
+                Close();
             }
         }
 

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -74,7 +74,8 @@ namespace QuoteSwift
                 return;
             }
 
-            using (var form = new FrmEditBusinessAddress(appData, business, customer, address))
+            var vm = new EditBusinessAddressViewModel(business, customer, address);
+            using (var form = new FrmEditBusinessAddress(vm, appData))
             {
                 form.ShowDialog();
             }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -172,7 +172,8 @@ namespace QuoteSwift
 
         public void EditBusinessAddress(Business business = null, Customer customer = null, Address address = null)
         {
-            using (var form = new FrmEditBusinessAddress(appData, business, customer, address))
+            var vm = new EditBusinessAddressViewModel(business, customer, address);
+            using (var form = new FrmEditBusinessAddress(vm, appData))
             {
                 form.ShowDialog();
             }
@@ -180,7 +181,8 @@ namespace QuoteSwift
 
         public void EditBusinessEmailAddress(Business business = null, Customer customer = null, string email = "")
         {
-            using (var form = new FrmEditEmailAddress(appData, business, customer, email))
+            var vm = new EditEmailAddressViewModel(business, customer, email);
+            using (var form = new FrmEditEmailAddress(vm, appData))
             {
                 form.ShowDialog();
             }
@@ -188,7 +190,8 @@ namespace QuoteSwift
 
         public void EditPhoneNumber(Business business = null, Customer customer = null, string number = "")
         {
-            using (var form = new FrmEditPhoneNumber(appData, business, customer, number))
+            var vm = new EditPhoneNumberViewModel(business, customer, number);
+            using (var form = new FrmEditPhoneNumber(vm, appData))
             {
                 form.ShowDialog();
             }

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+
+namespace QuoteSwift
+{
+    public class EditBusinessAddressViewModel : INotifyPropertyChanged
+    {
+        readonly Business business;
+        readonly Customer customer;
+        readonly Address address;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null)
+        {
+            this.business = business;
+            this.customer = customer;
+            this.address = address;
+        }
+
+        public Business Business => business;
+        public Customer Customer => customer;
+        public Address Address => address;
+
+        public bool UpdateAddress(Address updated)
+        {
+            if (!ValidateInput(updated))
+                return false;
+            if (AddressExists(updated))
+            {
+                MainProgramCode.ShowError("Address not updated since this address is already in the list of addresses.\nNOTE: Address Description should be unique.", "ERROR - Address Already Added");
+                return false;
+            }
+            if (address != null)
+            {
+                address.AddressDescription = updated.AddressDescription;
+                address.AddressStreetNumber = updated.AddressStreetNumber;
+                address.AddressStreetName = updated.AddressStreetName;
+                address.AddressSuburb = updated.AddressSuburb;
+                address.AddressCity = updated.AddressCity;
+                address.AddressAreaCode = updated.AddressAreaCode;
+            }
+            return true;
+        }
+
+        bool ValidateInput(Address a)
+        {
+            if (a == null)
+                return false;
+            if (string.IsNullOrWhiteSpace(a.AddressDescription) || a.AddressDescription.Length < 2)
+            {
+                MainProgramCode.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
+                return false;
+            }
+            if (a.AddressStreetNumber == 0)
+            {
+                MainProgramCode.ShowError("The provided Business Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business Address Street Number");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(a.AddressStreetName) || a.AddressStreetName.Length < 2)
+            {
+                MainProgramCode.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(a.AddressSuburb) || a.AddressSuburb.Length < 2)
+            {
+                MainProgramCode.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(a.AddressCity) || a.AddressCity.Length < 2)
+            {
+                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
+                return false;
+            }
+            if (a.AddressAreaCode == 0)
+            {
+                MainProgramCode.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business Address Area Code");
+                return false;
+            }
+            return true;
+        }
+
+        bool AddressExists(Address a)
+        {
+            if (a == null) return false;
+            string key = StringUtil.NormalizeKey(a.AddressDescription);
+            if (business != null && business.AddressMap.TryGetValue(key, out Address existingB))
+            {
+                if (!ReferenceEquals(existingB, address))
+                    return true;
+            }
+            if (customer != null && customer.DeliveryAddressMap.TryGetValue(key, out Address existingC))
+            {
+                if (!ReferenceEquals(existingC, address))
+                    return true;
+            }
+            return false;
+        }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+
+namespace QuoteSwift
+{
+    public class EditEmailAddressViewModel : INotifyPropertyChanged
+    {
+        readonly Business business;
+        readonly Customer customer;
+        string originalEmail;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public EditEmailAddressViewModel(Business business = null, Customer customer = null, string email = null)
+        {
+            this.business = business;
+            this.customer = customer;
+            originalEmail = email ?? string.Empty;
+            CurrentEmail = originalEmail;
+        }
+
+        public string CurrentEmail { get; set; }
+        public Business Business => business;
+        public Customer Customer => customer;
+        public string OriginalEmail => originalEmail;
+
+        public bool UpdateEmail()
+        {
+            if (!ValidateEmail(CurrentEmail))
+                return false;
+            if (business != null)
+            {
+                if (business.EmailAddresses.Contains(CurrentEmail) && CurrentEmail != originalEmail)
+                {
+                    MainProgramCode.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
+                    return false;
+                }
+                business.UpdateEmailAddress(originalEmail, CurrentEmail);
+            }
+            else if (customer != null)
+            {
+                if (customer.EmailAddresses.Contains(CurrentEmail) && CurrentEmail != originalEmail)
+                {
+                    MainProgramCode.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
+                    return false;
+                }
+                customer.UpdateEmailAddress(originalEmail, CurrentEmail);
+            }
+            originalEmail = CurrentEmail;
+            return true;
+        }
+
+        bool ValidateEmail(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email) || email.Length <= 3 || !email.Contains("@"))
+            {
+                MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
+                return false;
+            }
+            return true;
+        }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+
+namespace QuoteSwift
+{
+    public class EditPhoneNumberViewModel : INotifyPropertyChanged
+    {
+        readonly Business business;
+        readonly Customer customer;
+        string originalNumber;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "")
+        {
+            this.business = business;
+            this.customer = customer;
+            originalNumber = number ?? string.Empty;
+            CurrentNumber = originalNumber;
+        }
+
+        public Business Business => business;
+        public Customer Customer => customer;
+        public string OriginalNumber => originalNumber;
+        public string CurrentNumber { get; set; }
+
+        public bool UpdateNumber()
+        {
+            if (!ValidateNumber(CurrentNumber))
+                return false;
+            if (business != null)
+            {
+                bool isCell = business.CellphoneNumbers.Contains(originalNumber);
+                bool isTel = business.TelephoneNumbers.Contains(originalNumber);
+                if ((business.CellphoneNumbers.Contains(CurrentNumber) || business.TelephoneNumbers.Contains(CurrentNumber)) && CurrentNumber != originalNumber)
+                {
+                    MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                    return false;
+                }
+                if (isCell)
+                    business.UpdateCellphoneNumber(originalNumber, CurrentNumber);
+                else if (isTel)
+                    business.UpdateTelephoneNumber(originalNumber, CurrentNumber);
+            }
+            else if (customer != null)
+            {
+                bool isCell = customer.CellphoneNumbers.Contains(originalNumber);
+                bool isTel = customer.TelephoneNumbers.Contains(originalNumber);
+                if ((customer.CellphoneNumbers.Contains(CurrentNumber) || customer.TelephoneNumbers.Contains(CurrentNumber)) && CurrentNumber != originalNumber)
+                {
+                    MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                    return false;
+                }
+                if (isCell)
+                    customer.UpdateCellphoneNumber(originalNumber, CurrentNumber);
+                else if (isTel)
+                    customer.UpdateTelephoneNumber(originalNumber, CurrentNumber);
+            }
+            originalNumber = CurrentNumber;
+            return true;
+        }
+
+        bool ValidateNumber(string number)
+        {
+            if (string.IsNullOrWhiteSpace(number) || number.Length < 10)
+            {
+                MainProgramCode.ShowError("A valid phone number was not provided.", "ERROR - Invalid Number Provided");
+                return false;
+            }
+            return true;
+        }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -92,7 +92,8 @@ namespace QuoteSwift
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
         {
             string email = GetEmailSelection();
-            using (var form = new FrmEditEmailAddress(appData, business, customer, email))
+            var vm = new EditEmailAddressViewModel(business, customer, email);
+            using (var form = new FrmEditEmailAddress(vm, appData))
             {
                 form.ShowDialog();
             }

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -40,7 +40,8 @@ namespace QuoteSwift
             if (business != null && business.BusinessCellphoneNumberList != null)
             {
                 string oldNumber = GetNumberSelection(business.BusinessCellphoneNumberList, ref dgvCellphoneNumbers);
-                using (var form = new FrmEditPhoneNumber(appData, business, null, oldNumber))
+                var vm = new EditPhoneNumberViewModel(business, null, oldNumber);
+                using (var form = new FrmEditPhoneNumber(vm, appData))
                 {
                     form.ShowDialog();
                 }
@@ -48,7 +49,8 @@ namespace QuoteSwift
             else if (customer != null && customer.CustomerCellphoneNumberList != null)
             {
                 string oldNumber = GetNumberSelection(customer.CustomerCellphoneNumberList, ref dgvCellphoneNumbers);
-                using (var form = new FrmEditPhoneNumber(appData, null, customer, oldNumber))
+                var vm = new EditPhoneNumberViewModel(null, customer, oldNumber);
+                using (var form = new FrmEditPhoneNumber(vm, appData))
                 {
                     form.ShowDialog();
                 }
@@ -62,7 +64,8 @@ namespace QuoteSwift
             if (business != null && business.BusinessTelephoneNumberList != null)
             {
                 string oldNumber = GetNumberSelection(business.BusinessTelephoneNumberList, ref dgvTelephoneNumbers);
-                using (var form = new FrmEditPhoneNumber(appData, business, null, oldNumber))
+                var vm = new EditPhoneNumberViewModel(business, null, oldNumber);
+                using (var form = new FrmEditPhoneNumber(vm, appData))
                 {
                     form.ShowDialog();
                 }
@@ -70,7 +73,8 @@ namespace QuoteSwift
             else if (customer != null && customer.CustomerTelephoneNumberList != null)
             {
                 string oldNumber = GetNumberSelection(customer.CustomerTelephoneNumberList, ref dgvTelephoneNumbers);
-                using (var form = new FrmEditPhoneNumber(appData, null, customer, oldNumber))
+                var vm = new EditPhoneNumberViewModel(null, customer, oldNumber);
+                using (var form = new FrmEditPhoneNumber(vm, appData))
                 {
                     form.ShowDialog();
                 }

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -75,7 +75,8 @@ namespace QuoteSwift
                 return;
             }
 
-            using (var form = new FrmEditBusinessAddress(appData, business, customer, address))
+            var vm = new EditBusinessAddressViewModel(business, customer, address);
+            using (var form = new FrmEditBusinessAddress(vm, appData))
             {
                 form.ShowDialog();
             }


### PR DESCRIPTION
## Summary
- add `EditBusinessAddressViewModel`, `EditEmailAddressViewModel` and `EditPhoneNumberViewModel`
- refactor edit dialog forms to use the new view models
- move validation logic from forms into the view models
- update NavigationService and other callers to construct view models

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `apt-get install -y mono-xbuild`
- `xbuild QuoteSwift.sln` *(fails: default XML namespace errors)*
- `msbuild QuoteSwift.sln` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687651c8112c8325b3b1143b47f00207