### PR TITLE
Move validation logic to view models

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -15,7 +15,8 @@ namespace QuoteSwift
             var appData = new ApplicationData(dataService);
             appData.Load();
 
-            var navigation = new NavigationService(appData);
+            INotificationService notifier = new MessageBoxNotificationService();
+            var navigation = new NavigationService(appData, notifier);
             QuotesViewModel viewModel = new QuotesViewModel(dataService);
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
 

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -229,6 +229,8 @@
     <Compile Include="Services\IDataService.cs" />
     <Compile Include="Services\FileDataService.cs" />
     <Compile Include="Services\ApplicationData.cs" />
+    <Compile Include="Services\INotificationService.cs" />
+    <Compile Include="Services\MessageBoxNotificationService.cs" />
     <Compile Include="Services\INavigationService.cs" />
     <Compile Include="Services\NavigationService.cs" />
     <Compile Include="ViewModels\QuotesViewModel.cs" />

--- a/Services/INotificationService.cs
+++ b/Services/INotificationService.cs
@@ -1,0 +1,7 @@
+namespace QuoteSwift
+{
+    public interface INotificationService
+    {
+        void ShowError(string text, string caption);
+    }
+}

--- a/Services/MessageBoxNotificationService.cs
+++ b/Services/MessageBoxNotificationService.cs
@@ -1,0 +1,12 @@
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    public class MessageBoxNotificationService : INotificationService
+    {
+        public void ShowError(string text, string caption)
+        {
+            MainProgramCode.ShowError(text, caption);
+        }
+    }
+}

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -6,11 +6,13 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         readonly ApplicationData appData;
+        readonly INotificationService notificationService;
 
-        public NavigationService(ApplicationData data)
+        public NavigationService(ApplicationData data, INotificationService notifier)
         {
             dataService = new FileDataService();
             appData = data;
+            notificationService = notifier;
         }
 
         public void CreateNewQuote(ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false)
@@ -50,7 +52,7 @@ namespace QuoteSwift
 
         public void CreateNewPump(ApplicationData data)
         {
-            var vm = new AddPumpViewModel(dataService);
+            var vm = new AddPumpViewModel(dataService, notificationService);
             vm.UpdateData(appData.PumpList, appData.PartList);
             vm.LoadData();
             using (var form = new FrmAddPump(vm, this, appData))
@@ -74,7 +76,7 @@ namespace QuoteSwift
 
         public void AddNewPart(ApplicationData data, Part partToChange = null, bool changeSpecificObject = false)
         {
-            var vm = new AddPartViewModel(dataService);
+            var vm = new AddPartViewModel(dataService, notificationService);
             vm.UpdateData(appData.PartList, appData.PumpList, partToChange, changeSpecificObject);
             using (var form = new FrmAddPart(vm, this, appData))
             {
@@ -88,7 +90,7 @@ namespace QuoteSwift
 
         public void AddCustomer(ApplicationData data, Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false)
         {
-            var vm = new AddCustomerViewModel(dataService);
+            var vm = new AddCustomerViewModel(dataService, notificationService);
             vm.UpdateData(appData.BusinessList, customerToChange, changeSpecificObject);
             using (var form = new FrmAddCustomer(vm, this, appData, businessToChange))
             {

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -5,6 +5,7 @@ namespace QuoteSwift
     public class AddCustomerViewModel : INotifyPropertyChanged
     {
         readonly IDataService dataService;
+        readonly INotificationService notificationService;
         BindingList<Business> businessList;
         Customer customerToChange;
         bool changeSpecificObject;
@@ -12,9 +13,10 @@ namespace QuoteSwift
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public AddCustomerViewModel(IDataService service)
+        public AddCustomerViewModel(IDataService service, INotificationService notifier)
         {
             dataService = service;
+            notificationService = notifier;
             currentCustomer = new Customer();
         }
 
@@ -179,17 +181,134 @@ namespace QuoteSwift
         {
             if (string.IsNullOrWhiteSpace(email) || !email.Contains("@"))
             {
-                MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
+                notificationService.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
                 return false;
             }
 
             if (CurrentCustomer.EmailAddresses.Contains(email))
             {
-                MainProgramCode.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
+                notificationService.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
                 return false;
             }
 
             CurrentCustomer.AddEmailAddress(email);
+            return true;
+        }
+
+        public bool ValidateCustomerAddress(Address address)
+        {
+            if (address == null)
+                return false;
+
+            if (string.IsNullOrWhiteSpace(address.AddressDescription) || address.AddressDescription.Length < 2)
+            {
+                notificationService.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(address.AddressStreetName) || address.AddressStreetName.Length < 2)
+            {
+                notificationService.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(address.AddressSuburb) || address.AddressSuburb.Length < 2)
+            {
+                notificationService.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(address.AddressCity) || address.AddressCity.Length < 2)
+            {
+                notificationService.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool ValidateCustomerPOBoxAddress(Address address)
+        {
+            if (address == null)
+                return false;
+
+            if (string.IsNullOrWhiteSpace(address.AddressDescription) || address.AddressDescription.Length < 2)
+            {
+                notificationService.ShowError("The provided Business P.O.Box Address Description is invalid, please provide a valid description", "ERROR - Invalid Business P.O.Box Address Description");
+                return false;
+            }
+
+            if (address.AddressStreetNumber == 0)
+            {
+                notificationService.ShowError("The provided Business' P.O.Box Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business' P.O.Box Address Street Number");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(address.AddressSuburb) || address.AddressSuburb.Length < 2)
+            {
+                notificationService.ShowError("The provided Business' P.O.Box Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business' P.O.Box Address Suburb");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(address.AddressCity) || address.AddressCity.Length < 2)
+            {
+                notificationService.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business' P.O.Box Address City");
+                return false;
+            }
+
+            if (address.AddressAreaCode == 0)
+            {
+                notificationService.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business' P.O.Box Address Area Code");
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool ValidateBusiness()
+        {
+            if (string.IsNullOrWhiteSpace(CurrentCustomer.CustomerLegalDetails?.VatNumber) || CurrentCustomer.CustomerLegalDetails.VatNumber.Length < 7)
+            {
+                notificationService.ShowError("The provided VAT number is invalid, please provide a valid VAT number.", "ERROR - Invalid Business VAT Number");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(CurrentCustomer.CustomerLegalDetails?.RegistrationNumber) || CurrentCustomer.CustomerLegalDetails.RegistrationNumber.Length < 7)
+            {
+                notificationService.ShowError("The provided registration number is invalid, please provide a valid registration number.", "ERROR - Invalid Business Registration Number");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(CurrentCustomer.VendorNumber) || CurrentCustomer.VendorNumber.Length < 5)
+            {
+                notificationService.ShowError("The provided vendor number is invalid, please provide a valid vendor number.", "ERROR - Invalid Business Registration Number");
+                return false;
+            }
+
+            if (CurrentCustomer.DeliveryAddressMap == null || CurrentCustomer.DeliveryAddressMap.Count == 0)
+            {
+                notificationService.ShowError("Please add a valid customer delivery address under the 'Customer Address' section.", "ERROR - Current Customer Invalid");
+                return false;
+            }
+
+            if (CurrentCustomer.POBoxMap == null || CurrentCustomer.POBoxMap.Count == 0)
+            {
+                notificationService.ShowError("Please add a valid customer P.O.Box address under the 'Customer P.O.Box Address' section.", "ERROR - Current Customer Invalid");
+                return false;
+            }
+
+            if ((CurrentCustomer.CellphoneNumbers == null || CurrentCustomer.CellphoneNumbers.Count == 0) && (CurrentCustomer.TelephoneNumbers == null || CurrentCustomer.TelephoneNumbers.Count == 0))
+            {
+                notificationService.ShowError("Please add a valid phone number under the 'Phone Related' section.", "ERROR - Current Customer Invalid");
+                return false;
+            }
+
+            if (CurrentCustomer.EmailAddresses == null || CurrentCustomer.EmailAddresses.Count == 0)
+            {
+                notificationService.ShowError("Please add a valid customer email address under the 'Email Related' section.", "ERROR - Current Customer Invalid");
+                return false;
+            }
+
             return true;
         }
 

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -8,6 +8,7 @@ namespace QuoteSwift
     public class AddPartViewModel : INotifyPropertyChanged
     {
         readonly IDataService dataService;
+        readonly INotificationService notificationService;
         Dictionary<string, Part> partMap;
         BindingList<Pump> pumpList;
         Part partToChange;
@@ -20,9 +21,10 @@ namespace QuoteSwift
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public AddPartViewModel(IDataService service)
+        public AddPartViewModel(IDataService service, INotificationService notifier)
         {
             dataService = service;
+            notificationService = notifier;
             CurrentPart = new Part();
         }
 
@@ -303,6 +305,41 @@ namespace QuoteSwift
                 return true;
             }
             return false;
+        }
+
+        public bool ValidateInput()
+        {
+            if (string.IsNullOrWhiteSpace(CurrentPart.PartName) || CurrentPart.PartName.Length < 3)
+            {
+                notificationService.ShowError("Please ensure that the name of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(CurrentPart.PartDescription) || CurrentPart.PartDescription.Length < 3)
+            {
+                notificationService.ShowError("Please ensure that the description of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(CurrentPart.OriginalItemPartNumber) || CurrentPart.OriginalItemPartNumber.Length < 3)
+            {
+                notificationService.ShowError("Please ensure that the original part number of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(CurrentPart.NewPartNumber) || CurrentPart.NewPartNumber.Length < 3)
+            {
+                notificationService.ShowError("Please ensure that the new part number of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
+                return false;
+            }
+
+            if (CurrentPart.PartPrice == 0)
+            {
+                notificationService.ShowError("Please ensure that the price of the Item is valid and it has a value greater than R99.", "ERROR - Invalid Input");
+                return false;
+            }
+
+            return true;
         }
 
         void AddPart(Part part)

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -6,6 +6,7 @@ namespace QuoteSwift
     public class AddPumpViewModel : INotifyPropertyChanged
     {
         readonly IDataService dataService;
+        readonly INotificationService notificationService;
         Pump currentPump;
 
         public BindingList<Pump> PumpList { get; private set; }
@@ -16,9 +17,10 @@ namespace QuoteSwift
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public AddPumpViewModel(IDataService service)
+        public AddPumpViewModel(IDataService service, INotificationService notifier)
         {
             dataService = service;
+            notificationService = notifier;
             SelectedMandatoryParts = new BindingList<Pump_Part>();
             SelectedNonMandatoryParts = new BindingList<Pump_Part>();
             RepairableItemNames = new HashSet<string>();
@@ -107,6 +109,29 @@ namespace QuoteSwift
             if (RepairableItemNames == null)
                 RepairableItemNames = new HashSet<string>();
             RepairableItemNames.Add(newKey);
+            return true;
+        }
+
+        public bool ValidateInput()
+        {
+            if (string.IsNullOrWhiteSpace(CurrentPump?.PumpName) || CurrentPump.PumpName.Length < 3)
+            {
+                notificationService.ShowError("Please ensure the input for the Pump Name is correct and longer than 3 characters.", "INFORMATION -Pump Name Input Incorrect");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(CurrentPump?.PumpDescription) || CurrentPump.PumpDescription.Length < 3)
+            {
+                notificationService.ShowError("Please ensure the input for the description of the pump is correct and longer than 3 characters.", "INFORMATION - Pump Description Input Incorrect");
+                return false;
+            }
+
+            if (CurrentPump.NewPumpPrice == 0)
+            {
+                notificationService.ShowError("Please ensure the input for the price of the pump is correct and longer than 2 characters.", "INFORMATION - Pump Price Input Incorrect");
+                return false;
+            }
+
             return true;
         }
 

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -41,7 +41,7 @@ namespace QuoteSwift
 
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
-            if (ValidBusiness() && !viewModel.ChangeSpecificObject)
+            if (viewModel.ValidateBusiness() && !viewModel.ChangeSpecificObject)
             {
                 Business linkBusiness = GetSelectedBusiness();
                 viewModel.CurrentCustomer.CustomerName = string.Empty;
@@ -54,7 +54,7 @@ namespace QuoteSwift
                     ResetScreenInput();
                 }
             }
-            else if (ValidBusiness() && viewModel.ChangeSpecificObject)
+            else if (viewModel.ValidateBusiness() && viewModel.ChangeSpecificObject)
             {
                 string oldName = viewModel.CustomerToChange.CustomerCompanyName;
                 viewModel.CurrentCustomer.CustomerName = string.Empty;
@@ -105,10 +105,10 @@ namespace QuoteSwift
 
         private void BtnAddAddress_Click(object sender, EventArgs e)
         {
-            if (ValidCustomerAddress())
+            var addr = new Address(txtCustomerAddresssDescription.Text, 0, txtAtt.Text, txtWorkArea.Text, txtWorkPlace.Text, 0);
+            if (viewModel.ValidateCustomerAddress(addr))
             {
-                Address address = new Address(txtCustomerAddresssDescription.Text, 0, txtAtt.Text, txtWorkArea.Text, txtWorkPlace.Text, 0);
-                if (viewModel.AddDeliveryAddress(address))
+                if (viewModel.AddDeliveryAddress(addr))
                 {
                     MainProgramCode.ShowInformation("Successfully added the customer address", "INFORMATION - Customer Address Added Successfully");
                     ClearCustomerAddressInput();
@@ -118,11 +118,11 @@ namespace QuoteSwift
 
         private void BtnAddPOBoxAddress_Click(object sender, EventArgs e)
         {
-            if (ValidCustomerPOBoxAddress())
-            {
-                Address address = new Address(txtCustomerPODescription.Text, QuoteSwiftMainCode.ParseInt(mtxtPOBoxStreetNumber.Text),
+            var po = new Address(txtCustomerPODescription.Text, QuoteSwiftMainCode.ParseInt(mtxtPOBoxStreetNumber.Text),
                                               "", txtPOBoxSuburb.Text, txtPOBoxCity.Text, QuoteSwiftMainCode.ParseInt(mtxtPOBoxAreaCode.Text));
-                if (viewModel.AddPOBoxAddress(address))
+            if (viewModel.ValidateCustomerPOBoxAddress(po))
+            {
+                if (viewModel.AddPOBoxAddress(po))
                 {
                     MainProgramCode.ShowInformation("Successfully added the customer P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
                     ClearPOBoxAddressInput();
@@ -222,117 +222,6 @@ namespace QuoteSwift
        *       and clutter free.                                                          
        */
 
-        private bool ValidCustomerAddress()
-        {
-            if (txtCustomerAddresssDescription.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
-                return (false);
-            }
-
-            if (txtAtt.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
-                return (false);
-            }
-
-            if (txtWorkArea.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
-                return (false);
-            }
-
-            if (txtWorkPlace.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
-                return (false);
-            }
-
-            return true;
-        }
-
-        private bool ValidCustomerPOBoxAddress()
-        {
-            if (txtCustomerPODescription.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business P.O.Box Address Description is invalid, please provide a valid description", "ERROR - Invalid Business P.O.Box Address Description");
-                return (false);
-            }
-
-            if (QuoteSwiftMainCode.ParseInt(mtxtPOBoxStreetNumber.Text) == 0)
-            {
-                MainProgramCode.ShowError("The provided Business' P.O.Box Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business' P.O.Box Address Street Number");
-                return (false);
-            }
-
-            if (txtPOBoxSuburb.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business' P.O.Box Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business' P.O.Box Address Suburb");
-                return (false);
-            }
-
-            if (txtPOBoxCity.Text.Length < 2)
-            {
-                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business' P.O.Box Address City");
-                return (false);
-            }
-
-            if (QuoteSwiftMainCode.ParseInt(mtxtPOBoxAreaCode.Text) == 0)
-            {
-                MainProgramCode.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business' P.O.Box Address Area Code");
-                return (false);
-            }
-
-            return true;
-        }
-
-        private bool ValidBusiness()
-        {
-
-            if (mtxtVATNumber.Text.Length < 7)
-            {
-                MainProgramCode.ShowError("The provided VAT number is invalid, please provide a valid VAT number.", "ERROR - Invalid Business VAT Number");
-                return false;
-            }
-
-            if (mtxtRegistrationNumber.Text.Length < 7)
-            {
-                MainProgramCode.ShowError("The provided registration number is invalid, please provide a valid registration number.", "ERROR - Invalid Business Registration Number");
-                return false;
-            }
-
-            if (mtxtVendorNumber.Text.Length < 5)
-            {
-                MainProgramCode.ShowError("The provided vendor number is invalid, please provide a valid vendor number.", "ERROR - Invalid Business Registration Number");
-                return false;
-            }
-
-            if (viewModel.CurrentCustomer.CustomerDeliveryAddressList == null)
-            {
-                MainProgramCode.ShowError("Please add a valid customer delivery address under the 'Customer Address' section.", "ERROR - Current Customer Invalid");
-                return false;
-            }
-
-            if (viewModel.CurrentCustomer.CustomerPOBoxAddress == null)
-            {
-                MainProgramCode.ShowError("Please add a valid customer P.O.Box address under the 'Customer P.O.Box Address' section.", "ERROR - Current Customer Invalid");
-                return false;
-            }
-
-            if (viewModel.CurrentCustomer.CustomerCellphoneNumberList == null && viewModel.CurrentCustomer.CustomerTelephoneNumberList == null)
-            {
-                MainProgramCode.ShowError("Please add a valid phone number under the 'Phone Related' section.", "ERROR - Current Customer Invalid");
-                return false;
-            }
-
-            if (viewModel.CurrentCustomer.CustomerEmailList == null)
-            {
-                MainProgramCode.ShowError("Please add a valid customer email address under the 'Email Related' section.", "ERROR - Current Customer Invalid");
-                return false;
-            }
-
-            return true;
-        }
 
         private void DisableMainComponents()
         {

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -51,7 +51,7 @@ namespace QuoteSwift
         private void BtnAddPart_Click(object sender, EventArgs e)
         {
 
-            if (!ValidInput())
+            if (!viewModel.ValidateInput())
                 return;
 
             bool updating = viewModel.ChangeSpecificObject;
@@ -164,45 +164,6 @@ namespace QuoteSwift
         *       and clutter free.                                                          
         */
 
-        private bool ValidInput()
-        {
-            if (mtxtPartName.Text.Length < 3)
-            {
-                MainProgramCode.ShowError("Please ensure that the name of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
-                mtxtPartName.Focus();
-                return false;
-            }
-
-            if (mtxtPartDescription.Text.Length < 3)
-            {
-                MainProgramCode.ShowError("Please ensure that the description of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
-                mtxtPartDescription.Focus();
-                return false;
-            }
-
-            if (mtxtOriginalPartNumber.Text.Length < 3)
-            {
-                MainProgramCode.ShowError("Please ensure that the original part number of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
-                mtxtOriginalPartNumber.Focus();
-                return false;
-            }
-
-            if (mtxtNewPartNumber.Text.Length < 3)
-            {
-                MainProgramCode.ShowError("Please ensure that the new part number of the Item is valid and it has a length greater than two(2) characters.", "ERROR - Invalid Input");
-                mtxtNewPartNumber.Focus();
-                return false;
-            }
-
-            if (QuoteSwiftMainCode.ParseDecimal(mtxtPartPrice.Text) == 0)
-            {
-                MainProgramCode.ShowError("Please ensure that the price of the Item is valid and it has a value greater than R99.", "ERROR - Invalid Input");
-                mtxtPartPrice.Focus();
-                return false;
-            }
-
-            return true;
-        }
 
         private void ClearInput()
         {

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -36,7 +36,7 @@ namespace QuoteSwift
 
         private void BtnAddPump_Click(object sender, EventArgs e)
         {
-            if (!ValidInput())
+            if (!viewModel.ValidateInput())
                 return;
 
             BindingList<Pump_Part> newPumpParts = RetreivePumpPartList();
@@ -236,32 +236,8 @@ namespace QuoteSwift
             }
         }
 
+
         //Links the binding-lists with the corresponding datagridview components
-
-        bool ValidInput()
-        {
-            if (mtxtPumpName.TextLength < 3)
-            {
-                MainProgramCode.ShowInformation("Please ensure the input for the Pump Name is correct and longer than 3 characters.", "INFORMATION -Pump Name Input Incorrect");
-                mtxtPumpName.Focus();
-                return false;
-            }
-
-            if (mtxtPumpDescription.TextLength < 3)
-            {
-                MainProgramCode.ShowInformation("Please ensure the input for the description of the pump is correct and longer than 3 characters.", "INFORMATION - Pump Description Input Incorrect");
-                mtxtPumpDescription.Focus();
-                return false;
-            }
-
-            if (NewPumpValueInput() == 0)
-            {
-                MainProgramCode.ShowInformation("Please ensure the input for the price of the pump is correct and longer than 2 characters.", "INFORMATION - Pump Price Input Incorrect");
-                mtxtNewPumpPrice.Focus();
-                return false;
-            }
-            return true;
-        }
 
         BindingList<Pump_Part> RetreivePumpPartList()
         {


### PR DESCRIPTION
## Summary
- inject notification service for error display
- implement `ValidateInput` methods in `AddPartViewModel` and `AddPumpViewModel`
- implement customer validation helpers in `AddCustomerViewModel`
- update forms to call the new view-model methods
- pass notification service through navigation and program startup

## Testing
- `xbuild QuoteSwift.sln` *(fails: default MSBuild namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_68768a43acd083258af240249d90be3c