### PR TITLE
Refactor message boxes into injectable service

### DIFF
--- a/ExcelExporter.cs
+++ b/ExcelExporter.cs
@@ -9,7 +9,7 @@ namespace QuoteSwift
     public static class ExcelExporter
     {
         [STAThread]
-        public static void ExportQuoteToExcel(Quote quote)
+        public static void ExportQuoteToExcel(Quote quote, IMessageService messageService)
         {
             if (quote == null) return;
 
@@ -30,7 +30,7 @@ namespace QuoteSwift
 
                 if (excelApp == null)
                 {
-                    MainProgramCode.ShowError("Excel is not installed on this machine.", "ERROR - Excel Export Failed");
+                    messageService.ShowError("Excel is not installed on this machine.", "ERROR - Excel Export Failed");
                     return;
                 }
 
@@ -157,11 +157,11 @@ namespace QuoteSwift
 
                             if (dr != DialogResult.OK)
                             {
-                                MainProgramCode.ShowError("Quote could not export correctly.\nQuote Export Canceled", "ERROR - Quote Not Exported");
+                                messageService.ShowError("Quote could not export correctly.\nQuote Export Canceled", "ERROR - Quote Not Exported");
                                 return;
                             }
                         }
-                        MainProgramCode.ShowInformation("Excel file created and stored at selected location.", "INFORMATION - Quote Stored Successfully");
+                        messageService.ShowInformation("Excel file created and stored at selected location.", "INFORMATION - Quote Stored Successfully");
                     }
                     else return;
                 }
@@ -183,7 +183,7 @@ namespace QuoteSwift
                 }
                 else
                 {
-                    MainProgramCode.ShowError("The template file needed to export the quote cannot be found.\nQuote was created successfully but the exportation of the quote was unsuccessful.", "ERROR - Template File Missing");
+                    messageService.ShowError("The template file needed to export the quote cannot be found.\nQuote was created successfully but the exportation of the quote was unsuccessful.", "ERROR - Template File Missing");
                 }
             }
             finally

--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -6,18 +6,20 @@ namespace QuoteSwift
     public partial class FrmEditBusinessAddress : Form
     {
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly EditBusinessAddressViewModel viewModel;
 
-        public FrmEditBusinessAddress(EditBusinessAddressViewModel viewModel, ApplicationData data = null)
+        public FrmEditBusinessAddress(EditBusinessAddressViewModel viewModel, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             appData = data;
+            this.messageService = messageService;
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void FrmEditBusinessAddress_Load(object sender, EventArgs e)
@@ -48,14 +50,14 @@ namespace QuoteSwift
 
             if (viewModel.UpdateAddress(updated))
             {
-                MainProgramCode.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");
+                messageService.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");
                 Close();
             }
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 appData.SaveAll();
         }
 

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -7,13 +7,15 @@ namespace QuoteSwift
     {
 
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly EditEmailAddressViewModel viewModel;
 
-        public FrmEditEmailAddress(EditEmailAddressViewModel viewModel, ApplicationData data = null)
+        public FrmEditEmailAddress(EditEmailAddressViewModel viewModel, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             appData = data;
+            this.messageService = messageService;
         }
 
         private void BtnUpdateBusinessEmail_Click(object sender, EventArgs e)
@@ -21,7 +23,7 @@ namespace QuoteSwift
             viewModel.CurrentEmail = mtxtEmail.Text;
             if (viewModel.UpdateEmail())
             {
-                MainProgramCode.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
+                messageService.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
                 Close();
             }
         }
@@ -34,18 +36,18 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"))
                 appData.SaveAll();
         }
 
         private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 appData.SaveAll();
         }
 

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -7,13 +7,15 @@ namespace QuoteSwift
     {
 
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly EditPhoneNumberViewModel viewModel;
 
-        public FrmEditPhoneNumber(EditPhoneNumberViewModel viewModel, ApplicationData data = null)
+        public FrmEditPhoneNumber(EditPhoneNumberViewModel viewModel, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             appData = data;
+            this.messageService = messageService;
         }
 
         private void FrmEditPhoneNumber_Load(object sender, EventArgs e)
@@ -27,19 +29,19 @@ namespace QuoteSwift
             viewModel.CurrentNumber = txtPhoneNumber.Text;
             if (viewModel.UpdateNumber())
             {
-                MainProgramCode.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
+                messageService.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");
                 Close();
             }
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 appData.SaveAll();
         }
 

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -11,22 +11,24 @@ namespace QuoteSwift
         readonly ViewBusinessAddressesViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly Business business;
         readonly Customer customer;
 
-        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null)
+        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             this.business = business;
             this.customer = customer;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 appData.SaveAll();
                 Application.Exit();
@@ -70,7 +72,7 @@ namespace QuoteSwift
 
             if (address == null)
             {
-                MainProgramCode.ShowError("Please select a valid Business Address, the current selection is invalid", "ERROR - Invalid Address Selection");
+                messageService.ShowError("Please select a valid Business Address, the current selection is invalid", "ERROR - Invalid Address Selection");
                 return;
             }
 
@@ -85,7 +87,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void BtnRemoveSelected_Click(object sender, EventArgs e)
@@ -93,17 +95,17 @@ namespace QuoteSwift
             Address SelectedAddress = GetAddressSelection();
             if (SelectedAddress != null)
             {
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete '" + SelectedAddress.AddressDescription + "' address from the list?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete '" + SelectedAddress.AddressDescription + "' address from the list?", "REQUEST - Deletion Request"))
                 {
                     if (business != null && customer == null)
                     {
                         business.RemoveAddress(SelectedAddress);
-                        MainProgramCode.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
                     }
                     else if (business == null && customer != null)
                     {
                         customer.RemoveDeliveryAddress(SelectedAddress);
-                        MainProgramCode.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
                     }
 
                     LoadInformation();
@@ -111,7 +113,7 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid address from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid address from the list.", "ERROR - Invalid Selection");
             }
         }
 

--- a/MainProgramLibrary/MainProgramCode.cs
+++ b/MainProgramLibrary/MainProgramCode.cs
@@ -39,33 +39,6 @@ namespace QuoteSwift
             return null;
         }
 
-        /** Message Box Custom Functions */
-
-
-
-        //Confirmation Request:
-
-        public static bool RequestConfirmation(string text, string caption)
-        {
-            DialogResult MessageBoxResult = MessageBox.Show(text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-
-            return MessageBoxResult == DialogResult.Yes;
-        }
-
-        public static void ShowError(string text, string caption)
-        {
-            MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
-        }
-
-        public static void ShowInformation(string text, string caption)
-        {
-            MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Information);
-        }
-
-
-        /*********************************/
-
-
         /** Serialization Methods: */
 
         //Read file into byte Array
@@ -81,10 +54,6 @@ namespace QuoteSwift
             }
             catch (FileNotFoundException)
             {
-                if (FileName != "ExportQuote.json")
-                    if (MainProgramCode.RequestConfirmation(FileName + " could not be found.\nWould you like to continue the execution? (Recommended for first launch)", "REQUEST - Execution Continuation")) return Data;
-                MainProgramCode.ShowError(FileName + " Could not be found, please contact the developer to fix this issue.", "ERROR - " + FileName + " Not Found");
-                
             }
             catch
             {
@@ -422,7 +391,6 @@ namespace QuoteSwift
                 {
                     while (ex != null)
                     {
-                        ShowError(ex.Message, "ERROR Occurred");
                         ex = ex.InnerException;
                     }
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -11,18 +11,19 @@ namespace QuoteSwift
         [STAThread]
         static void Main()
         {
-            IDataService dataService = new FileDataService();
+            IDataService dataService = new FileDataService(messenger);
             var appData = new ApplicationData(dataService);
             appData.Load();
 
             INotificationService notifier = new MessageBoxNotificationService();
-            var navigation = new NavigationService(appData, notifier);
+            IMessageService messenger = new MessageBoxService();
+            var navigation = new NavigationService(appData, notifier, messenger);
             QuotesViewModel viewModel = new QuotesViewModel(dataService);
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new FrmViewQuotes(viewModel, navigation, appData));
+            Application.Run(new FrmViewQuotes(viewModel, navigation, appData, messenger));
         }
     }
 }

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -231,6 +231,8 @@
     <Compile Include="Services\ApplicationData.cs" />
     <Compile Include="Services\INotificationService.cs" />
     <Compile Include="Services\MessageBoxNotificationService.cs" />
+    <Compile Include="Services\IMessageService.cs" />
+    <Compile Include="Services\MessageBoxService.cs" />
     <Compile Include="Services\INavigationService.cs" />
     <Compile Include="Services\NavigationService.cs" />
     <Compile Include="ViewModels\QuotesViewModel.cs" />

--- a/Services/FileDataService.cs
+++ b/Services/FileDataService.cs
@@ -1,31 +1,40 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
+using System.Reflection;
 
 namespace QuoteSwift
 {
     public class FileDataService : IDataService
     {
+        readonly IMessageService messageService;
+
+        public FileDataService(IMessageService messenger = null)
+        {
+            messageService = messenger;
+        }
+
         public Dictionary<string, Part> LoadPartList()
         {
-            byte[] bytes = MainProgramCode.RetreiveData("Parts.json");
+            byte[] bytes = RetrieveData("Parts.json");
             return bytes != null && bytes.Length > 0 ? MainProgramCode.DeserializePartList(bytes) : new Dictionary<string, Part>();
         }
 
         public BindingList<Pump> LoadPumpList()
         {
-            byte[] bytes = MainProgramCode.RetreiveData("PumpList.json");
+            byte[] bytes = RetrieveData("PumpList.json");
             return bytes != null && bytes.Length > 0 ? new BindingList<Pump>(MainProgramCode.DeserializePumpList(bytes)) : new BindingList<Pump>();
         }
 
         public BindingList<Business> LoadBusinessList()
         {
-            byte[] bytes = MainProgramCode.RetreiveData("BusinessList.json");
+            byte[] bytes = RetrieveData("BusinessList.json");
             return bytes != null && bytes.Length > 0 ? new BindingList<Business>(MainProgramCode.DeserializeBusinessList(bytes)) : new BindingList<Business>();
         }
 
         public SortedDictionary<string, Quote> LoadQuoteMap()
         {
-            byte[] bytes = MainProgramCode.RetreiveData("QuoteList.json");
+            byte[] bytes = RetrieveData("QuoteList.json");
             return bytes != null && bytes.Length > 0 ? MainProgramCode.DeserializeQuoteList(bytes) : new SortedDictionary<string, Quote>();
         }
 
@@ -47,6 +56,30 @@ namespace QuoteSwift
         public void SaveQuotes(SortedDictionary<string, Quote> quotes)
         {
             MainProgramCode.SerializeQuoteList(quotes);
+        }
+
+        byte[] RetrieveData(string fileName)
+        {
+            string storePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\" + fileName;
+            byte[] data = null;
+            try
+            {
+                data = File.ReadAllBytes(storePath);
+                return data;
+            }
+            catch (FileNotFoundException)
+            {
+                if (fileName != "ExportQuote.json")
+                    if (messageService != null && messageService.RequestConfirmation(fileName + " could not be found.\nWould you like to continue the execution? (Recommended for first launch)", "REQUEST - Execution Continuation"))
+                        return data;
+
+                messageService?.ShowError(fileName + " Could not be found, please contact the developer to fix this issue.", "ERROR - " + fileName + " Not Found");
+            }
+            catch
+            {
+                throw;
+            }
+            return null;
         }
     }
 }

--- a/Services/IMessageService.cs
+++ b/Services/IMessageService.cs
@@ -1,0 +1,9 @@
+namespace QuoteSwift
+{
+    public interface IMessageService
+    {
+        bool RequestConfirmation(string text, string caption);
+        void ShowError(string text, string caption);
+        void ShowInformation(string text, string caption);
+    }
+}

--- a/Services/MessageBoxNotificationService.cs
+++ b/Services/MessageBoxNotificationService.cs
@@ -6,7 +6,7 @@ namespace QuoteSwift
     {
         public void ShowError(string text, string caption)
         {
-            MainProgramCode.ShowError(text, caption);
+            MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 }

--- a/Services/MessageBoxService.cs
+++ b/Services/MessageBoxService.cs
@@ -1,0 +1,23 @@
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    public class MessageBoxService : IMessageService
+    {
+        public bool RequestConfirmation(string text, string caption)
+        {
+            DialogResult result = MessageBox.Show(text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            return result == DialogResult.Yes;
+        }
+
+        public void ShowError(string text, string caption)
+        {
+            MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+        public void ShowInformation(string text, string caption)
+        {
+            MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+    }
+}

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -7,18 +7,20 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly ApplicationData appData;
         readonly INotificationService notificationService;
+        readonly IMessageService messageService;
 
-        public NavigationService(ApplicationData data, INotificationService notifier)
+        public NavigationService(ApplicationData data, INotificationService notifier, IMessageService messenger)
         {
-            dataService = new FileDataService();
+            dataService = new FileDataService(messenger);
             appData = data;
             notificationService = notifier;
+            messageService = messenger;
         }
 
         public void CreateNewQuote(ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false)
         {
             var vm = new CreateQuoteViewModel(dataService);
-            using (var form = new FrmCreateQuote(vm, appData, quoteToChange, changeSpecificObject))
+            using (var form = new FrmCreateQuote(vm, appData, quoteToChange, changeSpecificObject, messageService))
             {
                 form.ShowDialog();
             }
@@ -29,7 +31,7 @@ namespace QuoteSwift
         {
             var vm = new QuotesViewModel(dataService);
             vm.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
-            using (var form = new FrmViewQuotes(vm, this, appData))
+            using (var form = new FrmViewQuotes(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -44,7 +46,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPumpViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewPump(vm, this, appData))
+            using (var form = new FrmViewPump(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -55,7 +57,7 @@ namespace QuoteSwift
             var vm = new AddPumpViewModel(dataService, notificationService);
             vm.UpdateData(appData.PumpList, appData.PartList);
             vm.LoadData();
-            using (var form = new FrmAddPump(vm, this, appData))
+            using (var form = new FrmAddPump(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -68,7 +70,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPartsViewModel(dataService);
             vm.UpdateData(appData.PartList);
-            using (var form = new FrmViewParts(vm, this, appData))
+            using (var form = new FrmViewParts(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -78,7 +80,7 @@ namespace QuoteSwift
         {
             var vm = new AddPartViewModel(dataService, notificationService);
             vm.UpdateData(appData.PartList, appData.PumpList, partToChange, changeSpecificObject);
-            using (var form = new FrmAddPart(vm, this, appData))
+            using (var form = new FrmAddPart(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -90,9 +92,9 @@ namespace QuoteSwift
 
         public void AddCustomer(ApplicationData data, Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false)
         {
-            var vm = new AddCustomerViewModel(dataService, notificationService);
+            var vm = new AddCustomerViewModel(dataService, notificationService, messageService);
             vm.UpdateData(appData.BusinessList, customerToChange, changeSpecificObject);
-            using (var form = new FrmAddCustomer(vm, this, appData, businessToChange))
+            using (var form = new FrmAddCustomer(vm, this, appData, businessToChange, messageService))
             {
                 form.ShowDialog();
             }
@@ -103,7 +105,7 @@ namespace QuoteSwift
         {
             var vm = new ViewCustomersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewCustomers(vm, this, appData))
+            using (var form = new FrmViewCustomers(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -111,10 +113,10 @@ namespace QuoteSwift
 
         public void AddBusiness(ApplicationData data, Business businessToChange = null, bool changeSpecificObject = false)
         {
-            var vm = new AddBusinessViewModel(dataService);
+            var vm = new AddBusinessViewModel(dataService, messageService);
             vm.UpdateData(appData.BusinessList, businessToChange, changeSpecificObject);
             vm.LoadData();
-            using (var form = new FrmAddBusiness(vm, this, appData))
+            using (var form = new FrmAddBusiness(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -126,7 +128,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewAllBusinesses(vm, this, appData))
+            using (var form = new FrmViewAllBusinesses(vm, this, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -136,7 +138,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewBusinessAddresses(vm, this, appData, business, customer))
+            using (var form = new FrmViewBusinessAddresses(vm, this, appData, business, customer, messageService))
             {
                 form.ShowDialog();
             }
@@ -146,7 +148,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPOBoxAddressesViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewPOBoxAddresses(vm, this, appData, business, customer))
+            using (var form = new FrmViewPOBoxAddresses(vm, this, appData, business, customer, messageService))
             {
                 form.ShowDialog();
             }
@@ -156,7 +158,7 @@ namespace QuoteSwift
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmManageAllEmails(vm, this, appData, business, customer))
+            using (var form = new FrmManageAllEmails(vm, this, appData, business, customer, messageService))
             {
                 form.ShowDialog();
             }
@@ -166,7 +168,7 @@ namespace QuoteSwift
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmManagingPhoneNumbers(vm, this, appData, business, customer))
+            using (var form = new FrmManagingPhoneNumbers(vm, this, appData, business, customer, messageService))
             {
                 form.ShowDialog();
             }
@@ -174,8 +176,8 @@ namespace QuoteSwift
 
         public void EditBusinessAddress(Business business = null, Customer customer = null, Address address = null)
         {
-            var vm = new EditBusinessAddressViewModel(business, customer, address);
-            using (var form = new FrmEditBusinessAddress(vm, appData))
+            var vm = new EditBusinessAddressViewModel(business, customer, address, messageService);
+            using (var form = new FrmEditBusinessAddress(vm, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -183,8 +185,8 @@ namespace QuoteSwift
 
         public void EditBusinessEmailAddress(Business business = null, Customer customer = null, string email = "")
         {
-            var vm = new EditEmailAddressViewModel(business, customer, email);
-            using (var form = new FrmEditEmailAddress(vm, appData))
+            var vm = new EditEmailAddressViewModel(business, customer, email, messageService);
+            using (var form = new FrmEditEmailAddress(vm, appData, messageService))
             {
                 form.ShowDialog();
             }
@@ -192,8 +194,8 @@ namespace QuoteSwift
 
         public void EditPhoneNumber(Business business = null, Customer customer = null, string number = "")
         {
-            var vm = new EditPhoneNumberViewModel(business, customer, number);
-            using (var form = new FrmEditPhoneNumber(vm, appData))
+            var vm = new EditPhoneNumberViewModel(business, customer, number, messageService);
+            using (var form = new FrmEditPhoneNumber(vm, appData, messageService))
             {
                 form.ShowDialog();
             }

--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -6,6 +6,7 @@ namespace QuoteSwift
     public class AddBusinessViewModel : INotifyPropertyChanged
     {
         readonly IDataService dataService;
+        readonly IMessageService messageService;
         BindingList<Business> businessList;
         readonly Dictionary<string, Business> businessLookup = new Dictionary<string, Business>();
         readonly HashSet<string> businessVatNumbers = new HashSet<string>();
@@ -16,9 +17,10 @@ namespace QuoteSwift
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public AddBusinessViewModel(IDataService service)
+        public AddBusinessViewModel(IDataService service, IMessageService messageService)
         {
             dataService = service;
+            this.messageService = messageService;
         }
 
         public IDataService DataService => dataService;
@@ -78,7 +80,7 @@ namespace QuoteSwift
                 businessVatNumbers.Contains(CurrentBusiness.BusinessLegalDetails?.VatNumber) ||
                 businessRegNumbers.Contains(CurrentBusiness.BusinessLegalDetails?.RegistrationNumber))
             {
-                MainProgramCode.ShowError("This business has already been added previously.\nHINT: Business Name,VAT Number and Registration Number should be unique", "ERROR - Business Already Added");
+                messageService.ShowError("This business has already been added previously.\nHINT: Business Name,VAT Number and Registration Number should be unique", "ERROR - Business Already Added");
                 return false;
             }
 
@@ -128,7 +130,7 @@ namespace QuoteSwift
             string key = StringUtil.NormalizeKey(address.AddressDescription);
             if (CurrentBusiness.AddressMap.ContainsKey(key))
             {
-                MainProgramCode.ShowError("This address has already been added previously.\nHINT: Description should be unique", "ERROR - Address Already Added");
+                messageService.ShowError("This address has already been added previously.\nHINT: Description should be unique", "ERROR - Address Already Added");
                 return false;
             }
 
@@ -144,7 +146,7 @@ namespace QuoteSwift
             string key = StringUtil.NormalizeKey(address.AddressDescription);
             if (CurrentBusiness.POBoxMap.ContainsKey(key))
             {
-                MainProgramCode.ShowError("This P.O.Box address has already been added previously.\nHINT: Description should be unique", "ERROR - P.O.Box Address Already Added");
+                messageService.ShowError("This P.O.Box address has already been added previously.\nHINT: Description should be unique", "ERROR - P.O.Box Address Already Added");
                 return false;
             }
 
@@ -157,7 +159,7 @@ namespace QuoteSwift
             bool added = false;
             if ((telephone == null || telephone.Length < 10) && (cellphone == null || cellphone.Length < 10))
             {
-                MainProgramCode.ShowError("a Valid Phone Number/s were not provided, please provide at least one valid phone number.", "ERROR - Invalid Number/s Provided");
+                messageService.ShowError("a Valid Phone Number/s were not provided, please provide at least one valid phone number.", "ERROR - Invalid Number/s Provided");
                 return false;
             }
 
@@ -165,7 +167,7 @@ namespace QuoteSwift
             {
                 if (CurrentBusiness.TelephoneNumbers.Contains(telephone) || CurrentBusiness.CellphoneNumbers.Contains(telephone))
                 {
-                    MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                    messageService.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
                 }
                 else
                 {
@@ -178,7 +180,7 @@ namespace QuoteSwift
             {
                 if (CurrentBusiness.TelephoneNumbers.Contains(cellphone) || CurrentBusiness.CellphoneNumbers.Contains(cellphone))
                 {
-                    MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                    messageService.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
                 }
                 else
                 {
@@ -194,13 +196,13 @@ namespace QuoteSwift
         {
             if (string.IsNullOrWhiteSpace(email) || email.Length <= 3 || !email.Contains("@"))
             {
-                MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
+                messageService.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
                 return false;
             }
 
             if (CurrentBusiness.EmailAddresses.Contains(email))
             {
-                MainProgramCode.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
+                messageService.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
                 return false;
             }
 
@@ -215,37 +217,37 @@ namespace QuoteSwift
 
             if (string.IsNullOrWhiteSpace(a.AddressDescription) || a.AddressDescription.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
+                messageService.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
                 return false;
             }
 
             if (a.AddressStreetNumber == 0)
             {
-                MainProgramCode.ShowError("The provided Business Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business Address Street Number");
+                messageService.ShowError("The provided Business Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business Address Street Number");
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(a.AddressStreetName) || a.AddressStreetName.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
+                messageService.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(a.AddressSuburb) || a.AddressSuburb.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
+                messageService.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(a.AddressCity) || a.AddressCity.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
+                messageService.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
                 return false;
             }
 
             if (a.AddressAreaCode == 0)
             {
-                MainProgramCode.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business Address Area Code");
+                messageService.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business Address Area Code");
                 return false;
             }
 
@@ -259,31 +261,31 @@ namespace QuoteSwift
 
             if (string.IsNullOrWhiteSpace(a.AddressDescription) || a.AddressDescription.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business P.O.Box Address Description is invalid, please provide a valid description", "ERROR - Invalid Business P.O.Box Address Description");
+                messageService.ShowError("The provided Business P.O.Box Address Description is invalid, please provide a valid description", "ERROR - Invalid Business P.O.Box Address Description");
                 return false;
             }
 
             if (a.AddressStreetNumber == 0)
             {
-                MainProgramCode.ShowError("The provided Business' P.O.Box Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business' P.O.Box Address Street Number");
+                messageService.ShowError("The provided Business' P.O.Box Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business' P.O.Box Address Street Number");
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(a.AddressSuburb) || a.AddressSuburb.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business' P.O.Box Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business' P.O.Box Address Suburb");
+                messageService.ShowError("The provided Business' P.O.Box Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business' P.O.Box Address Suburb");
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(a.AddressCity) || a.AddressCity.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business' P.O.Box Address City");
+                messageService.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business' P.O.Box Address City");
                 return false;
             }
 
             if (a.AddressAreaCode == 0)
             {
-                MainProgramCode.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business' P.O.Box Address Area Code");
+                messageService.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business' P.O.Box Address Area Code");
                 return false;
             }
 
@@ -294,44 +296,44 @@ namespace QuoteSwift
         {
             if (string.IsNullOrWhiteSpace(CurrentBusiness.BusinessName) || CurrentBusiness.BusinessName.Length < 3)
             {
-                MainProgramCode.ShowError("The provided business name is invalid, please provide a business name longer that 2 characters.", "ERROR - Invalid Business Name");
+                messageService.ShowError("The provided business name is invalid, please provide a business name longer that 2 characters.", "ERROR - Invalid Business Name");
                 return false;
             }
 
             if (CurrentBusiness.BusinessLegalDetails == null || string.IsNullOrWhiteSpace(CurrentBusiness.BusinessLegalDetails.VatNumber) || CurrentBusiness.BusinessLegalDetails.VatNumber.Length < 7)
             {
-                MainProgramCode.ShowError("The provided VAT number is invalid, please provide a valid VAT number.", "ERROR - Invalid Business VAT Number");
+                messageService.ShowError("The provided VAT number is invalid, please provide a valid VAT number.", "ERROR - Invalid Business VAT Number");
                 return false;
             }
 
             if (CurrentBusiness.BusinessLegalDetails == null || string.IsNullOrWhiteSpace(CurrentBusiness.BusinessLegalDetails.RegistrationNumber) || CurrentBusiness.BusinessLegalDetails.RegistrationNumber.Length < 7)
             {
-                MainProgramCode.ShowError("The provided registration number is invalid, please provide a valid registration number.", "ERROR - Invalid Business Registration Number");
+                messageService.ShowError("The provided registration number is invalid, please provide a valid registration number.", "ERROR - Invalid Business Registration Number");
                 return false;
             }
 
             if (CurrentBusiness.BusinessAddressList == null || CurrentBusiness.BusinessAddressList.Count == 0)
             {
-                MainProgramCode.ShowError("Please add a valid business address under the 'Business Address' section.", "ERROR - Current Business Invalid");
+                messageService.ShowError("Please add a valid business address under the 'Business Address' section.", "ERROR - Current Business Invalid");
                 return false;
             }
 
             if (CurrentBusiness.BusinessPOBoxAddressList == null || CurrentBusiness.BusinessPOBoxAddressList.Count == 0)
             {
-                MainProgramCode.ShowError("Please add a valid business P.O.Box address under the 'Business P.O.Box Address' section.", "ERROR - Current Business Invalid");
+                messageService.ShowError("Please add a valid business P.O.Box address under the 'Business P.O.Box Address' section.", "ERROR - Current Business Invalid");
                 return false;
             }
 
             if ((CurrentBusiness.BusinessTelephoneNumberList == null || CurrentBusiness.BusinessTelephoneNumberList.Count == 0) &&
                 (CurrentBusiness.BusinessCellphoneNumberList == null || CurrentBusiness.BusinessCellphoneNumberList.Count == 0))
             {
-                MainProgramCode.ShowError("Please add a valid phone number under the 'Phone Related' section.", "ERROR - Current Business Invalid");
+                messageService.ShowError("Please add a valid phone number under the 'Phone Related' section.", "ERROR - Current Business Invalid");
                 return false;
             }
 
             if (CurrentBusiness.BusinessEmailAddressList == null || CurrentBusiness.BusinessEmailAddressList.Count == 0)
             {
-                MainProgramCode.ShowError("Please add a valid business email address under the 'Email Related' section.", "ERROR - Current Business Invalid");
+                messageService.ShowError("Please add a valid business email address under the 'Email Related' section.", "ERROR - Current Business Invalid");
                 return false;
             }
 

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -6,6 +6,7 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         readonly INotificationService notificationService;
+        readonly IMessageService messageService;
         BindingList<Business> businessList;
         Customer customerToChange;
         bool changeSpecificObject;
@@ -13,10 +14,11 @@ namespace QuoteSwift
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public AddCustomerViewModel(IDataService service, INotificationService notifier)
+        public AddCustomerViewModel(IDataService service, INotificationService notifier, IMessageService messageService)
         {
             dataService = service;
             notificationService = notifier;
+            this.messageService = messageService;
             currentCustomer = new Customer();
         }
 
@@ -81,13 +83,13 @@ namespace QuoteSwift
         {
             if (container == null)
             {
-                MainProgramCode.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
+                messageService.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
                 return false;
             }
 
             if (container.CustomerMap.ContainsKey(CurrentCustomer.CustomerCompanyName))
             {
-                MainProgramCode.ShowError("This customer has already been added previously.\nHINT: Customer Name,VAT Number and Registration Number should be unique", "ERROR - Customer Already Added");
+                messageService.ShowError("This customer has already been added previously.\nHINT: Customer Name,VAT Number and Registration Number should be unique", "ERROR - Customer Already Added");
                 return false;
             }
 
@@ -102,13 +104,13 @@ namespace QuoteSwift
         {
             if (container == null)
             {
-                MainProgramCode.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
+                messageService.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
                 return false;
             }
 
             if (container.CustomerMap.TryGetValue(CurrentCustomer.CustomerCompanyName, out Customer existing) && existing != CustomerToChange)
             {
-                MainProgramCode.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
+                messageService.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
                 CurrentCustomer.CustomerCompanyName = oldName;
                 return false;
             }
@@ -125,7 +127,7 @@ namespace QuoteSwift
             string key = StringUtil.NormalizeKey(address.AddressDescription);
             if (CurrentCustomer.DeliveryAddressMap.ContainsKey(key))
             {
-                MainProgramCode.ShowError("This address has already been added previously.\nHINT: Description should be unique", "ERROR - Address Already Added");
+                messageService.ShowError("This address has already been added previously.\nHINT: Description should be unique", "ERROR - Address Already Added");
                 return false;
             }
             CurrentCustomer.AddDeliveryAddress(address);
@@ -138,7 +140,7 @@ namespace QuoteSwift
             string key = StringUtil.NormalizeKey(address.AddressDescription);
             if (CurrentCustomer.POBoxMap.ContainsKey(key))
             {
-                MainProgramCode.ShowError("This P.O.Box address has already been added previously.\nHINT: Description should be unique", "ERROR - P.O.Box Address Already Added");
+                messageService.ShowError("This P.O.Box address has already been added previously.\nHINT: Description should be unique", "ERROR - P.O.Box Address Already Added");
                 return false;
             }
             CurrentCustomer.AddPOBoxAddress(address);
@@ -150,7 +152,7 @@ namespace QuoteSwift
             bool added = false;
             if (string.IsNullOrWhiteSpace(telephone) && string.IsNullOrWhiteSpace(cellphone))
             {
-                MainProgramCode.ShowError("a Valid Phone Number/s were not provided, please provide at least one valid phone number.", "ERROR - Invalid Number/s Provided");
+                messageService.ShowError("a Valid Phone Number/s were not provided, please provide at least one valid phone number.", "ERROR - Invalid Number/s Provided");
                 return false;
             }
 
@@ -161,7 +163,7 @@ namespace QuoteSwift
             }
             else if (!string.IsNullOrWhiteSpace(telephone) && CurrentCustomer.TelephoneNumbers.Contains(telephone))
             {
-                MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                messageService.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
             }
 
             if (!string.IsNullOrWhiteSpace(cellphone) && cellphone.Length >= 10 && !CurrentCustomer.CellphoneNumbers.Contains(cellphone))
@@ -171,7 +173,7 @@ namespace QuoteSwift
             }
             else if (!string.IsNullOrWhiteSpace(cellphone) && CurrentCustomer.CellphoneNumbers.Contains(cellphone))
             {
-                MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                messageService.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
             }
 
             return added;

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -7,14 +7,16 @@ namespace QuoteSwift
         readonly Business business;
         readonly Customer customer;
         readonly Address address;
+        readonly IMessageService messageService;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null)
+        public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null, IMessageService messageService = null)
         {
             this.business = business;
             this.customer = customer;
             this.address = address;
+            this.messageService = messageService;
         }
 
         public Business Business => business;
@@ -27,7 +29,7 @@ namespace QuoteSwift
                 return false;
             if (AddressExists(updated))
             {
-                MainProgramCode.ShowError("Address not updated since this address is already in the list of addresses.\nNOTE: Address Description should be unique.", "ERROR - Address Already Added");
+                messageService.ShowError("Address not updated since this address is already in the list of addresses.\nNOTE: Address Description should be unique.", "ERROR - Address Already Added");
                 return false;
             }
             if (address != null)
@@ -48,32 +50,32 @@ namespace QuoteSwift
                 return false;
             if (string.IsNullOrWhiteSpace(a.AddressDescription) || a.AddressDescription.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
+                messageService.ShowError("The provided Business Address Description is invalid, please provide a valid description", "ERROR - Invalid Business Address Description");
                 return false;
             }
             if (a.AddressStreetNumber == 0)
             {
-                MainProgramCode.ShowError("The provided Business Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business Address Street Number");
+                messageService.ShowError("The provided Business Address Street Number is invalid, please provide a valid street number", "ERROR - Invalid Business Address Street Number");
                 return false;
             }
             if (string.IsNullOrWhiteSpace(a.AddressStreetName) || a.AddressStreetName.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
+                messageService.ShowError("The provided Business Address Street Name is invalid, please provide a valid street name", "ERROR - Invalid Business Address Street Name");
                 return false;
             }
             if (string.IsNullOrWhiteSpace(a.AddressSuburb) || a.AddressSuburb.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
+                messageService.ShowError("The provided Business Address Suburb is invalid, please provide a valid suburb", "ERROR - Invalid Business Address Suburb");
                 return false;
             }
             if (string.IsNullOrWhiteSpace(a.AddressCity) || a.AddressCity.Length < 2)
             {
-                MainProgramCode.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
+                messageService.ShowError("The provided Business Address City is invalid, please provide a valid city", "ERROR - Invalid Business Address City");
                 return false;
             }
             if (a.AddressAreaCode == 0)
             {
-                MainProgramCode.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business Address Area Code");
+                messageService.ShowError("The provided Business Address Area Code is invalid, please provide a valid area code", "ERROR - Invalid Business Address Area Code");
                 return false;
             }
             return true;

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -6,15 +6,17 @@ namespace QuoteSwift
     {
         readonly Business business;
         readonly Customer customer;
+        readonly IMessageService messageService;
         string originalEmail;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public EditEmailAddressViewModel(Business business = null, Customer customer = null, string email = null)
+        public EditEmailAddressViewModel(Business business = null, Customer customer = null, string email = null, IMessageService messageService = null)
         {
             this.business = business;
             this.customer = customer;
             originalEmail = email ?? string.Empty;
+            this.messageService = messageService;
             CurrentEmail = originalEmail;
         }
 
@@ -31,7 +33,7 @@ namespace QuoteSwift
             {
                 if (business.EmailAddresses.Contains(CurrentEmail) && CurrentEmail != originalEmail)
                 {
-                    MainProgramCode.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
+                    messageService.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
                     return false;
                 }
                 business.UpdateEmailAddress(originalEmail, CurrentEmail);
@@ -40,7 +42,7 @@ namespace QuoteSwift
             {
                 if (customer.EmailAddresses.Contains(CurrentEmail) && CurrentEmail != originalEmail)
                 {
-                    MainProgramCode.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
+                    messageService.ShowError("This email address has already been added previously.", "ERROR - Email Address Already Added");
                     return false;
                 }
                 customer.UpdateEmailAddress(originalEmail, CurrentEmail);
@@ -53,7 +55,7 @@ namespace QuoteSwift
         {
             if (string.IsNullOrWhiteSpace(email) || email.Length <= 3 || !email.Contains("@"))
             {
-                MainProgramCode.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
+                messageService.ShowError("The provided Email Address is invalid. Please provide a valid Email Address", "ERROR - Invalid Email Address");
                 return false;
             }
             return true;

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -6,15 +6,17 @@ namespace QuoteSwift
     {
         readonly Business business;
         readonly Customer customer;
+        readonly IMessageService messageService;
         string originalNumber;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "")
+        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "", IMessageService messageService = null)
         {
             this.business = business;
             this.customer = customer;
             originalNumber = number ?? string.Empty;
+            this.messageService = messageService;
             CurrentNumber = originalNumber;
         }
 
@@ -33,7 +35,7 @@ namespace QuoteSwift
                 bool isTel = business.TelephoneNumbers.Contains(originalNumber);
                 if ((business.CellphoneNumbers.Contains(CurrentNumber) || business.TelephoneNumbers.Contains(CurrentNumber)) && CurrentNumber != originalNumber)
                 {
-                    MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                    messageService.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
                     return false;
                 }
                 if (isCell)
@@ -47,7 +49,7 @@ namespace QuoteSwift
                 bool isTel = customer.TelephoneNumbers.Contains(originalNumber);
                 if ((customer.CellphoneNumbers.Contains(CurrentNumber) || customer.TelephoneNumbers.Contains(CurrentNumber)) && CurrentNumber != originalNumber)
                 {
-                    MainProgramCode.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
+                    messageService.ShowError("This number has already been added previously.", "ERROR - Number Already Added");
                     return false;
                 }
                 if (isCell)
@@ -63,7 +65,7 @@ namespace QuoteSwift
         {
             if (string.IsNullOrWhiteSpace(number) || number.Length < 10)
             {
-                MainProgramCode.ShowError("A valid phone number was not provided.", "ERROR - Invalid Number Provided");
+                messageService.ShowError("A valid phone number was not provided.", "ERROR - Invalid Number Provided");
                 return false;
             }
             return true;

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -11,18 +11,20 @@ namespace QuoteSwift
         readonly AddBusinessViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null)
+        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.appData = appData;
+            this.messageService = messageService;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -36,7 +38,7 @@ namespace QuoteSwift
             {
                 if (viewModel.AddBusiness())
                 {
-                    MainProgramCode.ShowInformation(viewModel.CurrentBusiness.BusinessName + " has been added.", "INFORMATION - Business Successfully Added");
+                    messageService.ShowInformation(viewModel.CurrentBusiness.BusinessName + " has been added.", "INFORMATION - Business Successfully Added");
                     viewModel.CurrentBusiness = new Business { BusinessLegalDetails = new Legal("", "") };
                     SetupBindings();
                     ResetScreenInput();
@@ -46,7 +48,7 @@ namespace QuoteSwift
             {
                 if (viewModel.UpdateBusiness())
                 {
-                    MainProgramCode.ShowInformation(viewModel.CurrentBusiness.BusinessName + " has been successfully updated.", "INFORMATION - Business Successfully Updated");
+                    messageService.ShowInformation(viewModel.CurrentBusiness.BusinessName + " has been successfully updated.", "INFORMATION - Business Successfully Updated");
                     ConvertToViewOnly();
                 }
             }
@@ -58,7 +60,7 @@ namespace QuoteSwift
                                           "", txtPOBoxSuburb.Text, txtPOBoxCity.Text, QuoteSwiftMainCode.ParseInt(mtxtPOBoxAreaCode.Text));
             if (viewModel.AddPOBoxAddress(address))
             {
-                MainProgramCode.ShowInformation("Successfully added the business P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
+                messageService.ShowInformation("Successfully added the business P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
                 ClearPOBoxAddressInput();
             }
         }
@@ -69,7 +71,7 @@ namespace QuoteSwift
                                           txtStreetName.Text, txtSuburb.Text, txtCity.Text, QuoteSwiftMainCode.ParseInt(mtxtAreaCode.Text));
             if (viewModel.AddAddress(address))
             {
-                MainProgramCode.ShowInformation("Successfully added the business address", "INFORMATION - Business Address Added Successfully");
+                messageService.ShowInformation("Successfully added the business address", "INFORMATION - Business Address Added Successfully");
                 ClearBusinessAddressInput();
             }
         }
@@ -78,7 +80,7 @@ namespace QuoteSwift
         {
             if (viewModel.AddPhoneNumber(mtxtTelephoneNumber.Text, mtxtCellphoneNumber.Text))
             {
-                MainProgramCode.ShowInformation("Successfully added the business phone number/s", "INFORMATION - Business Phone Number/s Added Successfully");
+                messageService.ShowInformation("Successfully added the business phone number/s", "INFORMATION - Business Phone Number/s Added Successfully");
                 mtxtTelephoneNumber.ResetText();
                 mtxtCellphoneNumber.ResetText();
             }
@@ -86,14 +88,14 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void BtnAddBusinessEmail_Click(object sender, EventArgs e)
         {
             if (viewModel.AddEmailAddress(mtxtEmail.Text))
             {
-                MainProgramCode.ShowInformation("Successfully added the business Email address", "INFORMATION - Business Email Address Added Successfully");
+                messageService.ShowInformation("Successfully added the business Email address", "INFORMATION - Business Email Address Added Successfully");
                 mtxtEmail.ResetText();
             }
         }
@@ -107,7 +109,7 @@ namespace QuoteSwift
                 Show();
 
             }
-            else MainProgramCode.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Email Addresses");
+            else messageService.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Email Addresses");
         }
 
         private void BtnViewAddresses_Click(object sender, EventArgs e)
@@ -118,7 +120,7 @@ namespace QuoteSwift
                 navigation.ViewBusinessesAddresses(viewModel.CurrentBusiness, null);
                 Show();
             }
-            else MainProgramCode.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Addresses");
+            else messageService.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Addresses");
         }
 
         private void BtnViewAllPOBoxAddresses_Click(object sender, EventArgs e)
@@ -129,7 +131,7 @@ namespace QuoteSwift
                 navigation.ViewBusinessesPOBoxAddresses(viewModel.CurrentBusiness, null);
                 Show();
             }
-            else MainProgramCode.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business P.O.Box Addresses");
+            else messageService.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business P.O.Box Addresses");
         }
 
         private void BtnViewAll_Click(object sender, EventArgs e)
@@ -140,7 +142,7 @@ namespace QuoteSwift
                 navigation.ViewBusinessesPhoneNumbers(viewModel.CurrentBusiness, null);
                 Show();
             }
-            else MainProgramCode.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Business Phone Numbers");
+            else messageService.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Business Phone Numbers");
         }
 
         private void FrmAddBusiness_Load(object sender, EventArgs e)
@@ -161,7 +163,7 @@ namespace QuoteSwift
             }
             else // Undefined Use - Show ERROR
             {
-                MainProgramCode.ShowError("The form was activated without the correct parameters to have an achievable goal.\nThe Form's input parameters will be disabled to avoid possible data corruption.", "ERROR - Undefined Form Use Called");
+                messageService.ShowError("The form was activated without the correct parameters to have an achievable goal.\nThe Form's input parameters will be disabled to avoid possible data corruption.", "ERROR - Undefined Form Use Called");
                 DisableMainComponents();
             }
 

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -11,15 +11,17 @@ namespace QuoteSwift
         readonly AddCustomerViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
         Business Container;
 
-        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, Business container = null)
+        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, Business container = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.appData = appData;
+            this.messageService = messageService;
             this.Container = container;
             viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
 
@@ -29,7 +31,7 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
@@ -50,7 +52,7 @@ namespace QuoteSwift
 
                 if (viewModel.AddCustomer(linkBusiness))
                 {
-                    MainProgramCode.ShowInformation(viewModel.CurrentCustomer.CustomerCompanyName + " has been added.", "INFORMATION - Business Successfully Added");
+                    messageService.ShowInformation(viewModel.CurrentCustomer.CustomerCompanyName + " has been added.", "INFORMATION - Business Successfully Added");
                     ResetScreenInput();
                 }
             }
@@ -64,7 +66,7 @@ namespace QuoteSwift
                 Business container = GetSelectedBusiness();
                 if (viewModel.UpdateCustomer(container, oldName))
                 {
-                    MainProgramCode.ShowInformation(viewModel.CurrentCustomer.CustomerCompanyName + " has been successfully updated.", "INFORMATION - Customer Successfully Updated");
+                    messageService.ShowInformation(viewModel.CurrentCustomer.CustomerCompanyName + " has been successfully updated.", "INFORMATION - Customer Successfully Updated");
                     ConvertToViewOnly();
                 }
             }
@@ -98,7 +100,7 @@ namespace QuoteSwift
             }
             else // Undefined Use - Show ERROR
             {
-                MainProgramCode.ShowError("The form was activated without the correct parameters to have an achievable goal.\nThe Form's input parameters will be disabled to avoid possible data corruption.", "ERROR - Undefined Form Use Called");
+                messageService.ShowError("The form was activated without the correct parameters to have an achievable goal.\nThe Form's input parameters will be disabled to avoid possible data corruption.", "ERROR - Undefined Form Use Called");
                 DisableMainComponents();
             }
         }
@@ -110,7 +112,7 @@ namespace QuoteSwift
             {
                 if (viewModel.AddDeliveryAddress(addr))
                 {
-                    MainProgramCode.ShowInformation("Successfully added the customer address", "INFORMATION - Customer Address Added Successfully");
+                    messageService.ShowInformation("Successfully added the customer address", "INFORMATION - Customer Address Added Successfully");
                     ClearCustomerAddressInput();
                 }
             }
@@ -124,7 +126,7 @@ namespace QuoteSwift
             {
                 if (viewModel.AddPOBoxAddress(po))
                 {
-                    MainProgramCode.ShowInformation("Successfully added the customer P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
+                    messageService.ShowInformation("Successfully added the customer P.O.Box address", "INFORMATION - Business P.O.Box Address Added Successfully");
                     ClearPOBoxAddressInput();
                 }
             }
@@ -136,13 +138,13 @@ namespace QuoteSwift
             {
                 mtxtTelephoneNumber.ResetText();
                 mtxtCellphoneNumber.ResetText();
-                MainProgramCode.ShowInformation("Successfully added the customer phone number/s", "INFORMATION - Customer Phone Number/s Added Successfully");
+                messageService.ShowInformation("Successfully added the customer phone number/s", "INFORMATION - Customer Phone Number/s Added Successfully");
             }
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void BtnViewAll_Click(object sender, EventArgs e)
@@ -153,7 +155,7 @@ namespace QuoteSwift
                 navigation.ViewBusinessesPhoneNumbers(null, viewModel.CurrentCustomer);
                 Show();
             }
-            else MainProgramCode.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Customer Phone Numbers");
+            else messageService.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Customer Phone Numbers");
         }
 
         private void BtnViewAllPOBoxAddresses_Click(object sender, EventArgs e)
@@ -164,7 +166,7 @@ namespace QuoteSwift
                 navigation.ViewBusinessesPOBoxAddresses(null, viewModel.CurrentCustomer);
                 Show();
             }
-            else MainProgramCode.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer P.O.Box Addresses");
+            else messageService.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer P.O.Box Addresses");
         }
 
         private void BtnViewEmailAddresses_Click(object sender, EventArgs e)
@@ -176,7 +178,7 @@ namespace QuoteSwift
                 Show();
 
             }
-            else MainProgramCode.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Email Addresses");
+            else messageService.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Email Addresses");
         }
 
         private void BtnViewAddresses_Click(object sender, EventArgs e)
@@ -187,7 +189,7 @@ namespace QuoteSwift
                 navigation.ViewBusinessesAddresses(null, viewModel.CurrentCustomer);
                 Show();
             }
-            else MainProgramCode.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Addresses");
+            else messageService.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Addresses");
         }
 
         private void UpdatedCustomerInformationToolStripMenuItem_Click(object sender, EventArgs e)
@@ -201,7 +203,7 @@ namespace QuoteSwift
         {
             if (viewModel.AddEmailAddress(mtxtEmailAddress.Text))
             {
-                MainProgramCode.ShowInformation("Successfully added the customer Email address", "INFORMATION - Customer Email Address Added Successfully");
+                messageService.ShowInformation("Successfully added the customer Email address", "INFORMATION - Customer Email Address Added Successfully");
                 mtxtEmailAddress.ResetText();
             }
         }

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -11,13 +11,15 @@ namespace QuoteSwift
         readonly INavigationService navigation;
 
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null)
+        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             viewModel.Initialize();
             SetupBindings();
         }
@@ -40,7 +42,7 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -58,13 +60,13 @@ namespace QuoteSwift
 
             if (!viewModel.AddOrUpdatePart())
             {
-                MainProgramCode.ShowInformation("The provided new part information already has a part which has the same New Part Number or Original Part Number.\nPlease ensure that the provided Part Numbers' are distinct.", "INFORMATION - Part Already Listed");
+                messageService.ShowInformation("The provided new part information already has a part which has the same New Part Number or Original Part Number.\nPlease ensure that the provided Part Numbers' are distinct.", "INFORMATION - Part Already Listed");
                 return;
             }
 
             if (updating)
             {
-                MainProgramCode.ShowInformation("Successfully updated the part", "CONFIRMATION - Update Successful");
+                messageService.ShowInformation("Successfully updated the part", "CONFIRMATION - Update Successful");
                 viewModel.ChangeSpecificObject = false;
                 Close();
             }
@@ -73,10 +75,10 @@ namespace QuoteSwift
                 string info = viewModel.CurrentPart.MandatoryPart ?
                     " successfully added to the mandatory part list." :
                     " successfully added to the non-mandatory part list.";
-                MainProgramCode.ShowInformation(viewModel.CurrentPart.PartName + info, "INFORMATION - Part Added Success");
+                messageService.ShowInformation(viewModel.CurrentPart.PartName + info, "INFORMATION - Part Added Success");
                 if (viewModel.SelectedPump != null)
                 {
-                    MainProgramCode.ShowInformation(viewModel.CurrentPart.PartName + " successfully added to " + viewModel.SelectedPump.PumpName + " pump the part list.", "INFORMATION - Part Added  To Pump Success");
+                    messageService.ShowInformation(viewModel.CurrentPart.PartName + " successfully added to " + viewModel.SelectedPump.PumpName + " pump the part list.", "INFORMATION - Part Added  To Pump Success");
                 }
                 ClearInput();
             }
@@ -106,15 +108,15 @@ namespace QuoteSwift
             if (result == DialogResult.OK)
             {
                 OfdOpenCSVFile.ShowDialog();
-                bool updateDup = MainProgramCode.RequestConfirmation("In the case that a duplicate part is being added would you like to update the parts that has already been added before?", "REQUEST - Update Duplicate Part");
+                bool updateDup = messageService.RequestConfirmation("In the case that a duplicate part is being added would you like to update the parts that has already been added before?", "REQUEST - Update Duplicate Part");
                 try
                 {
                     viewModel.ImportPartsFromCsv(OfdOpenCSVFile.FileName, updateDup);
-                    MainProgramCode.ShowInformation("The selected CSV file has been successfully imported.", "CONFIRMATION - Batch Part Import Successful");
+                    messageService.ShowInformation("The selected CSV file has been successfully imported.", "CONFIRMATION - Batch Part Import Successful");
                 }
                 catch
                 {
-                    MainProgramCode.ShowError("The provided CSV File's format is incorrect, please try again once the format has been corrected.", "ERROR - CSV File Format Incorrect");
+                    messageService.ShowError("The provided CSV File's format is incorrect, please try again once the format has been corrected.", "ERROR - CSV File Format Incorrect");
                 }
             }
             else return;
@@ -128,7 +130,7 @@ namespace QuoteSwift
 
         private void ResetInputToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to reset the current screen to it's default values?", "REQUEST - Screen Defaults Reset"))
+            if (messageService.RequestConfirmation("Are you sure you want to reset the current screen to it's default values?", "REQUEST - Screen Defaults Reset"))
             {
                 ClearInput();
                 NudQuantity.Enabled = false;
@@ -138,7 +140,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
         }
 
         private void FrmAddPart_Load(object sender, EventArgs e)
@@ -205,7 +207,7 @@ namespace QuoteSwift
         private void UpdatePartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (!viewModel.ChangeSpecificObject)
-                if (MainProgramCode.RequestConfirmation("You are currently only viewing " + viewModel.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
+                if (messageService.RequestConfirmation("You are currently only viewing " + viewModel.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
                 {
                     ReadWriteComponents();
                     updatePartToolStripMenuItem.Enabled = false;

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -12,13 +12,15 @@ namespace QuoteSwift
         readonly AddPumpViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null)
+        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             if (data != null)
                 viewModel.UpdateData(data.PumpList, data.PartList, viewModel.PumpToChange, viewModel.ChangeSpecificObject,
                                      data.PumpList != null ? new HashSet<string>(data.PumpList.Select(p => StringUtil.NormalizeKey(p.PumpName))) : null);
@@ -26,7 +28,7 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -43,7 +45,7 @@ namespace QuoteSwift
 
             if (newPumpParts == null)
             {
-                MainProgramCode.ShowError("There wasn't any parts chosen from any of the lists below\nPlease ensure that parts are selected and/or that there is parts available to select from.", "ERROR - No Pump Part Selection");
+                messageService.ShowError("There wasn't any parts chosen from any of the lists below\nPlease ensure that parts are selected and/or that there is parts available to select from.", "ERROR - No Pump Part Selection");
                 return;
             }
 
@@ -55,14 +57,14 @@ namespace QuoteSwift
                 result = viewModel.UpdatePump();
                 if (result)
                 {
-                    MainProgramCode.ShowInformation(viewModel.PumpToChange.PumpName + " has been updated in the list of pumps", "INFORMATION - Pump Update Successfully");
+                    messageService.ShowInformation(viewModel.PumpToChange.PumpName + " has been updated in the list of pumps", "INFORMATION - Pump Update Successfully");
                     viewModel.ChangeSpecificObject = false;
                     ConvertToViewForm();
                     updatePumpToolStripMenuItem.Enabled = true;
                 }
                 else
                 {
-                    MainProgramCode.ShowError("This item name is already in use.", "ERROR - Duplicate Item Name");
+                    messageService.ShowError("This item name is already in use.", "ERROR - Duplicate Item Name");
                 }
             }
             else
@@ -70,11 +72,11 @@ namespace QuoteSwift
                 result = viewModel.AddPump();
                 if (result)
                 {
-                    MainProgramCode.ShowInformation(viewModel.CurrentPump.PumpName + " has been added to the list of pumps", "INFORMATION - Pump Added Successfully");
+                    messageService.ShowInformation(viewModel.CurrentPump.PumpName + " has been added to the list of pumps", "INFORMATION - Pump Added Successfully");
                 }
                 else
                 {
-                    MainProgramCode.ShowError("This item name is already in use.", "ERROR - Duplicate Item Name");
+                    messageService.ShowError("This item name is already in use.", "ERROR - Duplicate Item Name");
                 }
             }
         }
@@ -133,7 +135,7 @@ namespace QuoteSwift
             }
             else //This should never happen. Error message displayed and application will not allow input
             {
-                MainProgramCode.ShowError("An error occurred that was not suppose to ever happen.\nAll input will now be disabled for this current screen", "ERROR - Undefined Action Called");
+                messageService.ShowError("An error occurred that was not suppose to ever happen.\nAll input will now be disabled for this current screen", "ERROR - Undefined Action Called");
 
                 Read_OnlyMainComponents();
             }
@@ -319,7 +321,7 @@ namespace QuoteSwift
         void ChangeViewToEdit()
         {
             if (viewModel.PumpToChange != null && viewModel.ChangeSpecificObject == false)
-                if (MainProgramCode.RequestConfirmation("You are currently viewing " + viewModel.PumpToChange.PumpName + " pump, would you like to edit it instead?", "REQUEST - View To Edit REQUEST"))
+                if (messageService.RequestConfirmation("You are currently viewing " + viewModel.PumpToChange.PumpName + " pump, would you like to edit it instead?", "REQUEST - View To Edit REQUEST"))
                 {
                     ConvertToEditForm();
                     viewModel.ChangeSpecificObject = true;
@@ -387,7 +389,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
         }
 
         private void UpdatePumpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -14,17 +14,19 @@ namespace QuoteSwift
     {
         readonly CreateQuoteViewModel viewModel;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         Quote quoteToChange;
         bool changeSpecificObject;
         public Quote NewQuote;
 
         readonly Pricing P = new Pricing();
 
-        public FrmCreateQuote(CreateQuoteViewModel viewModel, ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false)
+        public FrmCreateQuote(CreateQuoteViewModel viewModel, ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             appData = data;
+            this.messageService = messageService;
             this.quoteToChange = quoteToChange;
             this.changeSpecificObject = changeSpecificObject;
         }
@@ -46,7 +48,7 @@ namespace QuoteSwift
                 {
                     if (!DistinctQuote(ref NewQuote))
                     {
-                        MainProgramCode.ShowError("The provided quote number or Job number has been used in a previous quote.\nPlease ensure that the provided details are indeed correct.", "ERROR - Quote Number or Job Number Already Exists.");
+                        messageService.ShowError("The provided quote number or Job number has been used in a previous quote.\nPlease ensure that the provided details are indeed correct.", "ERROR - Quote Number or Job Number Already Exists.");
                         return;
                     }
 
@@ -58,28 +60,28 @@ namespace QuoteSwift
                     else
                         appData.QuoteMap = new SortedDictionary<string, Quote> { [NewQuote.QuoteNumber] = NewQuote };
 
-                    if (MainProgramCode.RequestConfirmation("The quote was successfully created. Would you like to export the quote an Excel document?", "REQUEST - Export Quote to Excel"))
+                    if (messageService.RequestConfirmation("The quote was successfully created. Would you like to export the quote an Excel document?", "REQUEST - Export Quote to Excel"))
                     {
                         ExportQuoteToTemplate();
                     }
-                    else MainProgramCode.ShowInformation("The quote was successfully added to the list of quotes.", "INFORMATION - Quote Added To List");
+                    else messageService.ShowInformation("The quote was successfully added to the list of quotes.", "INFORMATION - Quote Added To List");
 
                     quoteToChange = NewQuote;
                     ConvertToReadOnly();
                     createNewQuoteUsingThisQuoteToolStripMenuItem.Enabled = true;
                 }
-                else MainProgramCode.ShowError("The Quote could not be created successfully.", "ERROR - Quote Creation Unsuccessful");
+                else messageService.ShowError("The Quote could not be created successfully.", "ERROR - Quote Creation Unsuccessful");
             }
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -614,37 +616,37 @@ namespace QuoteSwift
         {
             if (txtCustomerVATNumber.Text.Length < 3)
             {
-                MainProgramCode.ShowError("Please provide a valid Customer VAT Number", "ERROR - Invalid Quote Input");
+                messageService.ShowError("Please provide a valid Customer VAT Number", "ERROR - Invalid Quote Input");
                 return false;
             }
 
             if (txtJobNumber.Text.Length < 3)
             {
-                MainProgramCode.ShowError("Please provide a valid Job Number", "ERROR - Invalid Quote Input");
+                messageService.ShowError("Please provide a valid Job Number", "ERROR - Invalid Quote Input");
                 return false;
             }
 
             if (txtReferenceNumber.Text.Length < 3)
             {
-                MainProgramCode.ShowError("Please provide a valid Reference Number", "ERROR - Invalid Quote Input");
+                messageService.ShowError("Please provide a valid Reference Number", "ERROR - Invalid Quote Input");
                 return false;
             }
 
             if (txtPRNumber.Text.Length < 3)
             {
-                MainProgramCode.ShowError("Please provide a valid PR Number", "ERROR - Invalid Quote Input");
+                messageService.ShowError("Please provide a valid PR Number", "ERROR - Invalid Quote Input");
                 return false;
             }
 
             if (txtLineNumber.Text.Length == 0)
             {
-                MainProgramCode.ShowError("Please provide a valid Line Number", "ERROR - Invalid Quote Input");
+                messageService.ShowError("Please provide a valid Line Number", "ERROR - Invalid Quote Input");
                 return false;
             }
 
             if (txtQuoteNumber.Text.Length < 8)
             {
-                MainProgramCode.ShowError("Please provide a valid Quote Number", "ERROR - Invalid Quote Input");
+                messageService.ShowError("Please provide a valid Quote Number", "ERROR - Invalid Quote Input");
                 return false;
             }
 
@@ -757,7 +759,7 @@ namespace QuoteSwift
         public void ExportQuoteToTemplate()
         {
             UseWaitCursor = true;
-            ExcelExporter.ExportQuoteToExcel(NewQuote);
+            ExcelExporter.ExportQuoteToExcel(NewQuote, messageService);
             UseWaitCursor = false;
         }
 

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -11,22 +11,24 @@ namespace QuoteSwift
         readonly ManageEmailsViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly Business business;
         readonly Customer customer;
 
-        public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null)
+        public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             this.business = business;
             this.customer = customer;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 appData.SaveAll();
                 Application.Exit();
@@ -58,7 +60,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void BtnRemoveAddress_Click(object sender, EventArgs e)
@@ -66,17 +68,17 @@ namespace QuoteSwift
             string SelectedEmail = GetEmailSelection();
             if (SelectedEmail != "")
             {
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete '" + SelectedEmail + "' email address from the list?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete '" + SelectedEmail + "' email address from the list?", "REQUEST - Deletion Request"))
                 {
                     if (business != null && business.BusinessEmailAddressList != null)
                     {
                         business.RemoveEmailAddress(SelectedEmail);
-                        MainProgramCode.ShowInformation("Successfully deleted '" + SelectedEmail + "' from the email address list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted '" + SelectedEmail + "' from the email address list", "CONFIRMATION - Deletion Success");
                     }
                     else if (customer != null && customer.CustomerEmailList != null)
                     {
                         customer.RemoveEmailAddress(SelectedEmail);
-                        MainProgramCode.ShowInformation("Successfully deleted '" + SelectedEmail + "' from the email address list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted '" + SelectedEmail + "' from the email address list", "CONFIRMATION - Deletion Success");
                     }
 
 
@@ -85,7 +87,7 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid email address from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid email address from the list.", "ERROR - Invalid Selection");
             }
         }
 

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -13,22 +13,24 @@ namespace QuoteSwift
         readonly ManagePhoneNumbersViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly Business business;
         readonly Customer customer;
 
-        public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null)
+        public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             this.business = business;
             this.customer = customer;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 appData.SaveAll();
                 Application.Exit();
@@ -121,18 +123,18 @@ namespace QuoteSwift
 
             if (SelectedNumber != "")
             {
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete this '" + SelectedNumber + "' number from the list?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete this '" + SelectedNumber + "' number from the list?", "REQUEST - Deletion Request"))
                 {
                     if (business != null && business.BusinessTelephoneNumberList != null)
                     {
                         business.RemoveTelephoneNumber(SelectedNumber);
-                        MainProgramCode.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
 
                     }
                     else if (customer != null && customer.CustomerTelephoneNumberList != null)
                     {
                         customer.RemoveTelephoneNumber(SelectedNumber);
-                        MainProgramCode.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
 
                     }
 
@@ -141,7 +143,7 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid number from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid number from the list.", "ERROR - Invalid Selection");
             }
         }
 
@@ -157,13 +159,13 @@ namespace QuoteSwift
                 if (business != null && business.BusinessCellphoneNumberList != null)
                 {
                     business.RemoveCellphoneNumber(SelectedNumber);
-                    MainProgramCode.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
+                    messageService.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
 
                 }
                 else if (customer != null && customer.CustomerCellphoneNumberList != null)
                 {
                     customer.RemoveCellphoneNumber(SelectedNumber);
-                    MainProgramCode.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
+                    messageService.ShowInformation("Successfully deleted this '" + SelectedNumber + "' number from the list", "CONFIRMATION - Deletion Success");
 
                 }
 
@@ -171,13 +173,13 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid number from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid number from the list.", "ERROR - Invalid Selection");
             }
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();
         }
 
         string GetNumberSelection(IReadOnlyList<string> b, ref DataGridView d)

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -11,18 +11,20 @@ namespace QuoteSwift
         readonly ViewBusinessesViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null)
+        public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.appData = appData;
+            this.messageService = messageService;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -37,7 +39,7 @@ namespace QuoteSwift
 
             if (Business == null)
             {
-                MainProgramCode.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
+                messageService.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
                 return;
             }
 
@@ -74,10 +76,10 @@ namespace QuoteSwift
 
             if (business != null && appData.BusinessList != null)
             {
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete '" + business.BusinessName + "' from the business list?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete '" + business.BusinessName + "' from the business list?", "REQUEST - Deletion Request"))
                 {
                     appData.BusinessList.Remove(business);
-                    MainProgramCode.ShowInformation("Successfully deleted '" + business.BusinessName + "' from the business list", "CONFIRMATION - Deletion Success");
+                    messageService.ShowInformation("Successfully deleted '" + business.BusinessName + "' from the business list", "CONFIRMATION - Deletion Success");
 
                     LoadInformation();
                 }
@@ -126,7 +128,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -10,18 +10,20 @@ namespace QuoteSwift
         readonly ViewCustomersViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null)
+        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.appData = appData;
+            this.messageService = messageService;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -36,7 +38,7 @@ namespace QuoteSwift
 
             if (customer == null)
             {
-                MainProgramCode.ShowError("Please select a valid customer, the current selection is invalid", "ERROR - Invalid Customer Selection");
+                messageService.ShowError("Please select a valid customer, the current selection is invalid", "ERROR - Invalid Customer Selection");
                 return;
             }
 
@@ -74,10 +76,10 @@ namespace QuoteSwift
 
             if (customer != null && container != null)
             {
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete '" + customer.CustomerName + "' from the customer list?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete '" + customer.CustomerName + "' from the customer list?", "REQUEST - Deletion Request"))
                 {
                     container.RemoveCustomer(customer);
-                    MainProgramCode.ShowInformation("Successfully deleted '" + customer.CustomerName + "' from the business list", "CONFIRMATION - Deletion Success");
+                    messageService.ShowInformation("Successfully deleted '" + customer.CustomerName + "' from the business list", "CONFIRMATION - Deletion Success");
 
                     LoadInformation();
                 }
@@ -140,7 +142,7 @@ namespace QuoteSwift
             {
                 if (Container.CustomerMap.TryGetValue(New.CustomerCompanyName, out Customer existing) && existing != Original)
                 {
-                    MainProgramCode.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
+                    messageService.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
                     return false;
                 }
 
@@ -203,7 +205,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -11,22 +11,24 @@ namespace QuoteSwift
         readonly ViewPOBoxAddressesViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
         readonly Business business;
         readonly Customer customer;
 
-        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null)
+        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             this.business = business;
             this.customer = customer;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 appData.SaveAll();
                 Application.Exit();
@@ -38,17 +40,17 @@ namespace QuoteSwift
             Address SelectedAddress = GetAddressSelection();
             if (SelectedAddress != null)
             {
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete '" + SelectedAddress.AddressDescription + "' address from the list?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete '" + SelectedAddress.AddressDescription + "' address from the list?", "REQUEST - Deletion Request"))
                 {
                     if (business != null && business.BusinessPOBoxAddressList != null)
                     {
                         business.RemovePOBoxAddress(SelectedAddress);
-                        MainProgramCode.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
                     }
                     else if (customer != null && customer.CustomerPOBoxAddress != null)
                     {
                         customer.RemovePOBoxAddress(SelectedAddress);
-                        MainProgramCode.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
                     }
 
                     LoadInformation();
@@ -56,13 +58,13 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid P.O.Box address from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid P.O.Box address from the list.", "ERROR - Invalid Selection");
             }
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
@@ -71,7 +73,7 @@ namespace QuoteSwift
 
             if (address == null)
             {
-                MainProgramCode.ShowError("Please select a valid P.O.Box Address, the current selection is invalid", "ERROR - Invalid P.O.Box Address Selection");
+                messageService.ShowError("Please select a valid P.O.Box Address, the current selection is invalid", "ERROR - Invalid P.O.Box Address Selection");
                 return;
             }
 

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -12,20 +12,22 @@ namespace QuoteSwift
         readonly INavigationService navigation;
 
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null)
+        public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
             if (appData != null)
                 viewModel.UpdateData(appData.PartList);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
                 MainProgramCode.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
@@ -52,7 +54,7 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid Part from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid Part from the list.", "ERROR - Invalid Selection");
             }
         }
 
@@ -73,24 +75,24 @@ namespace QuoteSwift
             {
                 if (SelectedPart.MandatoryPart)
                 {
-                    if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
+                    if (messageService.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
                     {
                         appData.PartList?.Remove(StringUtil.NormalizeKey(SelectedPart.OriginalItemPartNumber));
-                        MainProgramCode.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
                     }
                 }
                 else
                 {
-                    if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
+                    if (messageService.RequestConfirmation("Are you sure you want to permanently delete " + SelectedPart.PartName + " part from the list of parts?", "REQUEST - Deletion Request"))
                     {
                         appData.PartList?.Remove(StringUtil.NormalizeKey(SelectedPart.OriginalItemPartNumber));
-                        MainProgramCode.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
+                        messageService.ShowInformation("Successfully deleted " + SelectedPart.PartName + " from the pump list", "CONFIRMATION - Deletion Success");
                     }
                 }
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid Part from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid Part from the list.", "ERROR - Invalid Selection");
             }
 
         }
@@ -169,7 +171,7 @@ namespace QuoteSwift
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.", "REQUEST - Cancellation")) Close();
+            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.", "REQUEST - Cancellation")) Close();
         }
 
         private void FrmViewParts_Load(object sender, EventArgs e)

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -12,18 +12,20 @@ namespace QuoteSwift // Repair Quote Swift
         readonly ViewPumpViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null)
+        public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 appData.SaveAll();
                 Application.Exit();
@@ -47,7 +49,7 @@ namespace QuoteSwift // Repair Quote Swift
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid Pump from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid Pump from the list.", "ERROR - Invalid Selection");
             }
         }
 
@@ -67,17 +69,17 @@ namespace QuoteSwift // Repair Quote Swift
 
                 Pump objPumpSelection = appData.PumpList.ElementAt(iGridSelection);
 
-                if (MainProgramCode.RequestConfirmation("Are you sure you want to permanently delete " + objPumpSelection.PumpName + "pump from the list of pumps?", "REQUEST - Deletion Request"))
+                if (messageService.RequestConfirmation("Are you sure you want to permanently delete " + objPumpSelection.PumpName + "pump from the list of pumps?", "REQUEST - Deletion Request"))
                 {
                     appData.PumpList.RemoveAt(iGridSelection);
                     viewModel.RepairableItemNames.Remove(StringUtil.NormalizeKey(objPumpSelection.PumpName));
 
-                    MainProgramCode.ShowInformation("Successfully deleted " + objPumpSelection.PumpName + " from the pump list", "INFORMATION - Deletion Success");
+                    messageService.ShowInformation("Successfully deleted " + objPumpSelection.PumpName + " from the pump list", "INFORMATION - Deletion Success");
                 }
             }
             else
             {
-                MainProgramCode.ShowError("The current selection is invalid.\nPlease choose a valid Pump from the list.", "ERROR - Invalid Selection");
+                messageService.ShowError("The current selection is invalid.\nPlease choose a valid Pump from the list.", "ERROR - Invalid Selection");
             }
         }
 
@@ -135,11 +137,11 @@ namespace QuoteSwift // Repair Quote Swift
                     try
                     {
                         MainProgramCode.ExportInventory(appData.PumpList, sfd.FileName);
-                        MainProgramCode.ShowInformation("Inventory exported successfully.", "INFORMATION - Export Successful");
+                        messageService.ShowInformation("Inventory exported successfully.", "INFORMATION - Export Successful");
                     }
                     catch (Exception ex)
                     {
-                        MainProgramCode.ShowError("Inventory export failed.\n" + ex.Message, "ERROR - Export Failed");
+                        messageService.ShowError("Inventory export failed.\n" + ex.Message, "ERROR - Export Failed");
                     }
                 }
             }

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -12,13 +12,15 @@ namespace QuoteSwift
         readonly QuotesViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly IMessageService messageService;
 
-        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null)
+        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.messageService = messageService;
         }
 
         private void BtnCreateNewQuote_Click(object sender, EventArgs e)
@@ -39,7 +41,7 @@ namespace QuoteSwift
             }
             else
             {
-                MainProgramCode.ShowError("Please ensure that the following information is provided before creating a quote:\n" +
+                messageService.ShowError("Please ensure that the following information is provided before creating a quote:\n" +
                                           ">  Business Information.\n" +
                                           ">  Business' Customer's Information.\n" +
                                           ">  Pump Information.", "ERROR - Prerequisites Not Met");
@@ -48,7 +50,7 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (MainProgramCode.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
+            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
                 MainProgramCode.CloseApplication(true,
                     viewModel.BusinessList,


### PR DESCRIPTION
## Summary
- define `IMessageService` and concrete `MessageBoxService`
- inject message service throughout forms and view models
- route message dialogs through the new service
- drop old message box helpers from `MainProgramCode`
- pass `MessageBoxService` via `NavigationService` and `Program`

## Testing
- `dotnet msbuild QuoteSwift.sln` *(fails: The type or namespace name 'Forms' does not exist in the namespace 'System.Windows')*

------
https://chatgpt.com/codex/tasks/task_e_68768d00211083259ecf7668dcd7d67b