### PR TITLE
Share MessageBoxService across view models

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,12 +11,12 @@ namespace QuoteSwift
         [STAThread]
         static void Main()
         {
+            IMessageService messenger = new MessageBoxService();
             IDataService dataService = new FileDataService(messenger);
             var appData = new ApplicationData(dataService);
             appData.Load();
 
             INotificationService notifier = new MessageBoxNotificationService();
-            IMessageService messenger = new MessageBoxService();
             var navigation = new NavigationService(appData, notifier, messenger);
             QuotesViewModel viewModel = new QuotesViewModel(dataService);
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -4,16 +4,16 @@ namespace QuoteSwift
 {
     public interface INavigationService
     {
-        void CreateNewQuote(ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false);
-        void ViewAllQuotes(ApplicationData data);
-        void ViewAllPumps(ApplicationData data);
-        void CreateNewPump(ApplicationData data);
-        void ViewAllParts(ApplicationData data);
-        void AddNewPart(ApplicationData data, Part partToChange = null, bool changeSpecificObject = false);
-        void AddCustomer(ApplicationData data, Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false);
-        void ViewCustomers(ApplicationData data);
-        void AddBusiness(ApplicationData data, Business businessToChange = null, bool changeSpecificObject = false);
-        void ViewBusinesses(ApplicationData data);
+        void CreateNewQuote(Quote quoteToChange = null, bool changeSpecificObject = false);
+        void ViewAllQuotes();
+        void ViewAllPumps();
+        void CreateNewPump();
+        void ViewAllParts();
+        void AddNewPart(Part partToChange = null, bool changeSpecificObject = false);
+        void AddCustomer(Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false);
+        void ViewCustomers();
+        void AddBusiness(Business businessToChange = null, bool changeSpecificObject = false);
+        void ViewBusinesses();
         void ViewBusinessesAddresses(Business business = null, Customer customer = null);
         void ViewBusinessesPOBoxAddresses(Business business = null, Customer customer = null);
         void ViewBusinessesEmailAddresses(Business business = null, Customer customer = null);

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -17,7 +17,7 @@ namespace QuoteSwift
             messageService = messenger;
         }
 
-        public void CreateNewQuote(ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false)
+        public void CreateNewQuote(Quote quoteToChange = null, bool changeSpecificObject = false)
         {
             var vm = new CreateQuoteViewModel(dataService);
             using (var form = new FrmCreateQuote(vm, appData, quoteToChange, changeSpecificObject, messageService))
@@ -27,7 +27,7 @@ namespace QuoteSwift
             appData.SaveAll();
         }
 
-        public void ViewAllQuotes(ApplicationData data)
+        public void ViewAllQuotes()
         {
             var vm = new QuotesViewModel(dataService);
             vm.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
@@ -42,7 +42,7 @@ namespace QuoteSwift
             appData.SaveAll();
         }
 
-        public void ViewAllPumps(ApplicationData data)
+        public void ViewAllPumps()
         {
             var vm = new ViewPumpViewModel(dataService);
             vm.LoadData();
@@ -52,7 +52,7 @@ namespace QuoteSwift
             }
         }
 
-        public void CreateNewPump(ApplicationData data)
+        public void CreateNewPump()
         {
             var vm = new AddPumpViewModel(dataService, notificationService);
             vm.UpdateData(appData.PumpList, appData.PartList);
@@ -66,7 +66,7 @@ namespace QuoteSwift
             appData.SaveAll();
         }
 
-        public void ViewAllParts(ApplicationData data)
+        public void ViewAllParts()
         {
             var vm = new ViewPartsViewModel(dataService);
             vm.UpdateData(appData.PartList);
@@ -76,7 +76,7 @@ namespace QuoteSwift
             }
         }
 
-        public void AddNewPart(ApplicationData data, Part partToChange = null, bool changeSpecificObject = false)
+        public void AddNewPart(Part partToChange = null, bool changeSpecificObject = false)
         {
             var vm = new AddPartViewModel(dataService, notificationService);
             vm.UpdateData(appData.PartList, appData.PumpList, partToChange, changeSpecificObject);
@@ -90,7 +90,7 @@ namespace QuoteSwift
         }
 
 
-        public void AddCustomer(ApplicationData data, Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false)
+        public void AddCustomer(Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false)
         {
             var vm = new AddCustomerViewModel(dataService, notificationService, messageService);
             vm.UpdateData(appData.BusinessList, customerToChange, changeSpecificObject);
@@ -101,7 +101,7 @@ namespace QuoteSwift
             appData.SaveAll();
         }
 
-        public void ViewCustomers(ApplicationData data)
+        public void ViewCustomers()
         {
             var vm = new ViewCustomersViewModel(dataService);
             vm.LoadData();
@@ -111,7 +111,7 @@ namespace QuoteSwift
             }
         }
 
-        public void AddBusiness(ApplicationData data, Business businessToChange = null, bool changeSpecificObject = false)
+        public void AddBusiness(Business businessToChange = null, bool changeSpecificObject = false)
         {
             var vm = new AddBusinessViewModel(dataService, messageService);
             vm.UpdateData(appData.BusinessList, businessToChange, changeSpecificObject);
@@ -124,7 +124,7 @@ namespace QuoteSwift
             appData.SaveAll();
         }
 
-        public void ViewBusinesses(ApplicationData data)
+        public void ViewBusinesses()
         {
             var vm = new ViewBusinessesViewModel(dataService);
             vm.UpdateData(appData.BusinessList);

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -37,7 +37,7 @@ namespace QuoteSwift
                 return;
             }
 
-            navigation.AddBusiness(null, Business, false);
+            navigation.AddBusiness(Business, false);
 
             LoadInformation();
 
@@ -46,7 +46,7 @@ namespace QuoteSwift
         private void BtnAddBusiness_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.AddBusiness(null);
+            navigation.AddBusiness();
             Show();
 
             LoadInformation();

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -42,7 +42,7 @@ namespace QuoteSwift
                 return;
             }
 
-            navigation.AddCustomer(appData, container, customer, false);
+            navigation.AddCustomer(container, customer, false);
 
             LoadInformation();
 
@@ -52,7 +52,7 @@ namespace QuoteSwift
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.AddCustomer(appData);
+            navigation.AddCustomer();
             Show();
 
             LoadInformation();

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -38,7 +38,7 @@ namespace QuoteSwift
         private void BtnAddPart_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.AddNewPart(appData);
+            navigation.AddNewPart();
             Show();
         }
 
@@ -49,7 +49,7 @@ namespace QuoteSwift
             if (objPartSelection != null)
             {
                 Hide();
-                navigation.AddNewPart(appData, objPartSelection, false);
+                navigation.AddNewPart(objPartSelection, false);
                 Show();
             }
             else

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -40,7 +40,7 @@ namespace QuoteSwift // Repair Quote Swift
 
                 var pToChange = appData.PumpList.ElementAt(iGridSelection);
                 Hide();
-                navigation.CreateNewPump(appData);
+                navigation.CreateNewPump();
                 Show();
 
                 viewModel.RepairableItemNames = new HashSet<string>(appData.PumpList.Select(p => StringUtil.NormalizeKey(p.PumpName)));
@@ -56,7 +56,7 @@ namespace QuoteSwift // Repair Quote Swift
         private void BtnAddPump_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.CreateNewPump(appData);
+            navigation.CreateNewPump();
             viewModel.RepairableItemNames = new HashSet<string>(appData.PumpList.Select(pu => StringUtil.NormalizeKey(pu.PumpName)));
             Show();
         }

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -28,7 +28,7 @@ namespace QuoteSwift
             if (viewModel.BusinessList != null && viewModel.BusinessList.Count > 0 && viewModel.PumpList != null && viewModel.BusinessList[0].BusinessCustomerList != null)
             {
                 Hide();
-                navigation.CreateNewQuote(appData);
+                navigation.CreateNewQuote();
                 viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
                 try
                 {
@@ -63,7 +63,7 @@ namespace QuoteSwift
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.ViewAllPumps(appData);
+            navigation.ViewAllPumps();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -78,7 +78,7 @@ namespace QuoteSwift
         private void CreateNewPumpToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.CreateNewPump(appData);
+            navigation.CreateNewPump();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -98,7 +98,7 @@ namespace QuoteSwift
         private void AddNewCustomerToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.AddCustomer(appData);
+            navigation.AddCustomer();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -113,7 +113,7 @@ namespace QuoteSwift
         private void ViewAllCustomersToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.ViewCustomers(appData);
+            navigation.ViewCustomers();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -133,7 +133,7 @@ namespace QuoteSwift
         private void AddNewBusinessToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.AddBusiness(appData);
+            navigation.AddBusiness();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -148,7 +148,7 @@ namespace QuoteSwift
         private void ViewAllBusinessesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.ViewBusinesses(appData);
+            navigation.ViewBusinesses();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -185,7 +185,7 @@ namespace QuoteSwift
                 if (selected != null)
                 {
                     Hide();
-                    navigation.CreateNewQuote(appData, selected, false);
+                    navigation.CreateNewQuote(selected, false);
                     viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
                     Show();
                 }
@@ -200,7 +200,7 @@ namespace QuoteSwift
                 if (selected != null)
                 {
                     this.Hide();
-                    navigation.CreateNewQuote(appData, selected, true);
+                    navigation.CreateNewQuote(selected, true);
                     viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
                     this.Show();
                 }
@@ -210,7 +210,7 @@ namespace QuoteSwift
         private void ViewAllPartsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.ViewAllParts(appData);
+            navigation.ViewAllParts();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {
@@ -230,7 +230,7 @@ namespace QuoteSwift
         private void AddNewPartToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Hide();
-            navigation.AddNewPart(appData);
+            navigation.AddNewPart();
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             try
             {


### PR DESCRIPTION
## Summary
- create a single `MessageBoxService` in `Program.Main`
- simplify `INavigationService` signatures to drop `ApplicationData` args
- update `NavigationService` implementation to match
- adjust form calls to new navigation API

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_68769d48523c8325b9ec7e8beee66f61