### PR TITLE
Introduce ViewModelBase for property change support

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace QuoteSwift
 {
-    public class AddBusinessViewModel : INotifyPropertyChanged
+    public class AddBusinessViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         readonly IMessageService messageService;
@@ -15,7 +15,6 @@ namespace QuoteSwift
         bool changeSpecificObject;
         Business currentBusiness;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public AddBusinessViewModel(IDataService service, IMessageService messageService)
         {
@@ -357,9 +356,5 @@ namespace QuoteSwift
             }
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class AddCustomerViewModel : INotifyPropertyChanged
+    public class AddCustomerViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         readonly INotificationService notificationService;
@@ -12,7 +12,6 @@ namespace QuoteSwift
         bool changeSpecificObject;
         Customer currentCustomer;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public AddCustomerViewModel(IDataService service, INotificationService notifier, IMessageService messageService)
         {
@@ -314,9 +313,5 @@ namespace QuoteSwift
             return true;
         }
 
-        protected void OnPropertyChanged(string name)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        }
     }
 }

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace QuoteSwift
 {
-    public class AddPartViewModel : INotifyPropertyChanged
+    public class AddPartViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         readonly INotificationService notificationService;
@@ -19,7 +19,6 @@ namespace QuoteSwift
         Pump selectedPump;
         int quantity;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public AddPartViewModel(IDataService service, INotificationService notifier)
         {
@@ -387,9 +386,5 @@ namespace QuoteSwift
             pump.PartList.Add(new Pump_Part(part, qty));
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace QuoteSwift
 {
-    public class AddPumpViewModel : INotifyPropertyChanged
+    public class AddPumpViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         readonly INotificationService notificationService;
@@ -15,7 +15,6 @@ namespace QuoteSwift
         public Pump PumpToChange { get; set; }
         public bool ChangeSpecificObject { get; set; }
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public AddPumpViewModel(IDataService service, INotificationService notifier)
         {
@@ -156,9 +155,5 @@ namespace QuoteSwift
             pump.PartList.Add(new Pump_Part(part, quantity));
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace QuoteSwift
 {
-    public class CreateQuoteViewModel : INotifyPropertyChanged
+    public class CreateQuoteViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         Dictionary<string, Part> partList;
@@ -11,7 +11,6 @@ namespace QuoteSwift
         BindingList<Business> businesses;
         SortedDictionary<string, Quote> quoteMap;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public CreateQuoteViewModel(IDataService service)
         {
@@ -68,9 +67,5 @@ namespace QuoteSwift
             QuoteMap = dataService.LoadQuoteMap();
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -2,14 +2,13 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class EditBusinessAddressViewModel : INotifyPropertyChanged
+    public class EditBusinessAddressViewModel : ViewModelBase
     {
         readonly Business business;
         readonly Customer customer;
         readonly Address address;
         readonly IMessageService messageService;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null, IMessageService messageService = null)
         {
@@ -98,9 +97,5 @@ namespace QuoteSwift
             return false;
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -2,14 +2,13 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class EditEmailAddressViewModel : INotifyPropertyChanged
+    public class EditEmailAddressViewModel : ViewModelBase
     {
         readonly Business business;
         readonly Customer customer;
         readonly IMessageService messageService;
         string originalEmail;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public EditEmailAddressViewModel(Business business = null, Customer customer = null, string email = null, IMessageService messageService = null)
         {
@@ -61,9 +60,5 @@ namespace QuoteSwift
             return true;
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -2,14 +2,13 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class EditPhoneNumberViewModel : INotifyPropertyChanged
+    public class EditPhoneNumberViewModel : ViewModelBase
     {
         readonly Business business;
         readonly Customer customer;
         readonly IMessageService messageService;
         string originalNumber;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "", IMessageService messageService = null)
         {
@@ -71,9 +70,5 @@ namespace QuoteSwift
             return true;
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/ManageEmailsViewModel.cs
+++ b/ViewModels/ManageEmailsViewModel.cs
@@ -2,14 +2,13 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class ManageEmailsViewModel : INotifyPropertyChanged
+    public class ManageEmailsViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         Business business;
         Customer customer;
         BindingList<EmailEntry> emails;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ManageEmailsViewModel(IDataService service)
         {
@@ -102,10 +101,6 @@ namespace QuoteSwift
             RefreshEmails();
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
 
         public class EmailEntry
         {

--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class ManagePhoneNumbersViewModel : INotifyPropertyChanged
+    public class ManagePhoneNumbersViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         Business business;
@@ -10,7 +10,6 @@ namespace QuoteSwift
         BindingList<NumberEntry> telephoneNumbers;
         BindingList<NumberEntry> cellphoneNumbers;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ManagePhoneNumbersViewModel(IDataService service)
         {
@@ -135,10 +134,6 @@ namespace QuoteSwift
             RefreshNumbers();
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
 
         public class NumberEntry
         {

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace QuoteSwift
 {
-    public class QuotesViewModel : INotifyPropertyChanged
+    public class QuotesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         BindingList<Quote> quotes;
@@ -16,7 +16,6 @@ namespace QuoteSwift
         BindingList<Pump> pumpList;
         Dictionary<string, Part> partMap;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public QuotesViewModel(IDataService service)
         {
@@ -106,9 +105,5 @@ namespace QuoteSwift
             Quotes = new BindingList<Quote>(QuoteMap?.Values.ToList() ?? new List<Quote>());
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -2,12 +2,11 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class ViewBusinessAddressesViewModel : INotifyPropertyChanged
+    public class ViewBusinessAddressesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         BindingList<Business> businesses;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ViewBusinessAddressesViewModel(IDataService service)
         {
@@ -31,9 +30,5 @@ namespace QuoteSwift
             Businesses = dataService.LoadBusinessList();
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -2,12 +2,11 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class ViewBusinessesViewModel : INotifyPropertyChanged
+    public class ViewBusinessesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         BindingList<Business> businesses;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ViewBusinessesViewModel(IDataService service)
         {
@@ -46,9 +45,5 @@ namespace QuoteSwift
             Businesses?.Remove(business);
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 
 namespace QuoteSwift
 {
-    public class ViewCustomersViewModel : INotifyPropertyChanged
+    public class ViewCustomersViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         BindingList<Business> businesses;
         SortedDictionary<string, Quote> quoteMap;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ViewCustomersViewModel(IDataService service)
         {
@@ -42,9 +41,5 @@ namespace QuoteSwift
             QuoteMap = dataService.LoadQuoteMap();
         }
 
-        protected void OnPropertyChanged(string name)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        }
     }
 }

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+
+namespace QuoteSwift
+{
+    public class ViewModelBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/ViewModels/ViewPOBoxAddressesViewModel.cs
+++ b/ViewModels/ViewPOBoxAddressesViewModel.cs
@@ -2,12 +2,11 @@ using System.ComponentModel;
 
 namespace QuoteSwift
 {
-    public class ViewPOBoxAddressesViewModel : INotifyPropertyChanged
+    public class ViewPOBoxAddressesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         BindingList<Business> businesses;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ViewPOBoxAddressesViewModel(IDataService service)
         {
@@ -31,9 +30,5 @@ namespace QuoteSwift
             Businesses = dataService.LoadBusinessList();
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 
 namespace QuoteSwift
 {
-    public class ViewPartsViewModel : INotifyPropertyChanged
+    public class ViewPartsViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         Dictionary<string, Part> partList;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ViewPartsViewModel(IDataService service)
         {
@@ -37,9 +36,5 @@ namespace QuoteSwift
             PartList = parts;
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 
 namespace QuoteSwift
 {
-    public class ViewPumpViewModel : INotifyPropertyChanged
+    public class ViewPumpViewModel : ViewModelBase
     {
         readonly IDataService dataService;
         BindingList<Pump> pumps;
         HashSet<string> repairableItemNames;
 
-        public event PropertyChangedEventHandler PropertyChanged;
 
         public ViewPumpViewModel(IDataService service)
         {
@@ -54,9 +53,5 @@ namespace QuoteSwift
             }
         }
 
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ViewModelBase` implementing `INotifyPropertyChanged`
- inherit from `ViewModelBase` across all view models
- drop duplicate `PropertyChanged` members and helper methods

## Testing
- `msbuild QuoteSwift.sln` *(fails: command not found)*
- `xbuild QuoteSwift.sln /verbosity:minimal` *(fails: MSBuild XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_6876a5e379208325bc950e00502996be