### PR TITLE
Move pump actions to ViewPumpViewModel

### DIFF
--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Linq;
+using System;
 
 namespace QuoteSwift
 {
@@ -51,6 +53,32 @@ namespace QuoteSwift
             {
                 RepairableItemNames = new HashSet<string>();
             }
+        }
+
+        public void UpdateData(BindingList<Pump> pumpList)
+        {
+            Pumps = pumpList;
+            if (Pumps != null)
+                RepairableItemNames = new HashSet<string>(Pumps.Select(p => StringUtil.NormalizeKey(p.PumpName)));
+            else
+                RepairableItemNames = new HashSet<string>();
+        }
+
+        public void RemovePump(Pump pump)
+        {
+            if (pump == null || Pumps == null)
+                return;
+
+            Pumps.Remove(pump);
+            RepairableItemNames?.Remove(StringUtil.NormalizeKey(pump.PumpName));
+        }
+
+        public void ExportInventory(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+
+            MainProgramCode.ExportInventory(Pumps, filePath);
         }
 
     }

--- a/frmViewPump.Designer.cs
+++ b/frmViewPump.Designer.cs
@@ -113,6 +113,7 @@ namespace QuoteSwift
             // 
             // clmPumpName
             // 
+            this.clmPumpName.DataPropertyName = "PumpName";
             this.clmPumpName.HeaderText = "Pump Name";
             this.clmPumpName.Name = "clmPumpName";
             this.clmPumpName.ReadOnly = true;
@@ -120,6 +121,7 @@ namespace QuoteSwift
             // 
             // clmPumpDescription
             // 
+            this.clmPumpDescription.DataPropertyName = "PumpDescription";
             this.clmPumpDescription.HeaderText = "Description";
             this.clmPumpDescription.Name = "clmPumpDescription";
             this.clmPumpDescription.ReadOnly = true;
@@ -127,6 +129,7 @@ namespace QuoteSwift
             // 
             // clmNewPumpPrice
             // 
+            this.clmNewPumpPrice.DataPropertyName = "NewPumpPrice";
             this.clmNewPumpPrice.HeaderText = "New Pump Price";
             this.clmNewPumpPrice.Name = "clmNewPumpPrice";
             this.clmNewPumpPrice.ReadOnly = true;


### PR DESCRIPTION
## Summary
- implement RemovePump and ExportInventory helpers in `ViewPumpViewModel`
- bind pump grid to view model list
- update form logic to use new helpers and avoid direct `ApplicationData` usage
- wire designer columns for binding

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace issue)*

------
https://chatgpt.com/codex/tasks/task_e_6876aebc1cfc8325950bf1a1ee2d8125