### PR TITLE
Refactor component state handling

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -41,9 +41,9 @@ namespace QuoteSwift
             {
                 Text = Text.Replace("<<Business name>>", business.BusinessName);
 
-                if (!viewModel.ChangeSpecificObject)
+                if (viewModel.IsReadOnly)
                 {
-                    QuoteSwiftMainCode.ReadOnlyComponents(Controls);
+                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 
@@ -53,9 +53,9 @@ namespace QuoteSwift
             {
                 Text = Text.Replace("<<Business name>>", customer.CustomerName);
 
-                if (!viewModel.ChangeSpecificObject)
+                if (viewModel.IsReadOnly)
                 {
-                    QuoteSwiftMainCode.ReadOnlyComponents(Controls);
+                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 
@@ -115,6 +115,11 @@ namespace QuoteSwift
             {
                 messageService.ShowError("The current selection is invalid.\nPlease choose a valid address from the list.", "ERROR - Invalid Selection");
             }
+        }
+
+        void ApplyControlState()
+        {
+            ControlStateHelper.ApplyReadOnly(Controls, true);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/Infrastructure/ControlStateHelper.cs
+++ b/Infrastructure/ControlStateHelper.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    static class ControlStateHelper
+    {
+        public static void ApplyReadOnly(Control.ControlCollection controls, bool readOnly)
+        {
+            if (controls == null) return;
+
+            foreach (Panel pnl in controls.OfType<Panel>()) pnl.Enabled = !readOnly;
+            foreach (GroupBox gbx in controls.OfType<GroupBox>()) gbx.Enabled = !readOnly;
+            foreach (TextBox txt in controls.OfType<TextBox>()) txt.ReadOnly = readOnly;
+            foreach (MaskedTextBox mtxt in controls.OfType<MaskedTextBox>()) mtxt.ReadOnly = readOnly;
+            foreach (RichTextBox rtxt in controls.OfType<RichTextBox>()) rtxt.ReadOnly = readOnly;
+            foreach (ComboBox cb in controls.OfType<ComboBox>()) cb.Enabled = !readOnly;
+            foreach (DateTimePicker dtp in controls.OfType<DateTimePicker>()) dtp.Enabled = !readOnly;
+            foreach (NumericUpDown nud in controls.OfType<NumericUpDown>()) nud.ReadOnly = readOnly;
+            foreach (DataGridView dgv in controls.OfType<DataGridView>()) dgv.ReadOnly = readOnly;
+            foreach (Button btn in controls.OfType<Button>()) btn.Enabled = !readOnly;
+            foreach (CheckBox cbx in controls.OfType<CheckBox>()) cbx.Enabled = !readOnly;
+            foreach (QuoteSwift.Controls.NumericTextBox ntxt in controls.OfType<QuoteSwift.Controls.NumericTextBox>()) ntxt.Enabled = !readOnly;
+        }
+    }
+}

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -250,6 +250,7 @@
     <Compile Include="ViewModels\ViewPartsViewModel.cs" />
     <Compile Include="ViewModels\ViewPumpViewModel.cs" />
     <Compile Include="ExcelExporter.cs" />
+    <Compile Include="Infrastructure\ControlStateHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="FrmAddBusiness.resx">
       <DependentUpon>FrmAddBusiness.cs</DependentUpon>

--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -58,7 +58,22 @@ namespace QuoteSwift
         public HashSet<string> BusinessVatNumbers => businessVatNumbers;
         public HashSet<string> BusinessRegNumbers => businessRegNumbers;
         public Business BusinessToChange { get => businessToChange; set => businessToChange = value; }
-        public bool ChangeSpecificObject { get => changeSpecificObject; set => changeSpecificObject = value; }
+
+        public bool ChangeSpecificObject
+        {
+            get => changeSpecificObject;
+            set
+            {
+                if (changeSpecificObject != value)
+                {
+                    changeSpecificObject = value;
+                    OnPropertyChanged(nameof(ChangeSpecificObject));
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
+            }
+        }
+
+        public bool IsReadOnly => !changeSpecificObject;
 
         public Business CurrentBusiness
         {

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -73,10 +73,16 @@ namespace QuoteSwift
             get => changeSpecificObject;
             set
             {
-                changeSpecificObject = value;
-                OnPropertyChanged(nameof(ChangeSpecificObject));
+                if (changeSpecificObject != value)
+                {
+                    changeSpecificObject = value;
+                    OnPropertyChanged(nameof(ChangeSpecificObject));
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
             }
         }
+
+        public bool IsReadOnly => !changeSpecificObject;
 
         public Customer CurrentCustomer
         {

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -68,8 +68,18 @@ namespace QuoteSwift
         public bool ChangeSpecificObject
         {
             get => changeSpecificObject;
-            set => changeSpecificObject = value;
+            set
+            {
+                if (changeSpecificObject != value)
+                {
+                    changeSpecificObject = value;
+                    OnPropertyChanged(nameof(ChangeSpecificObject));
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
+            }
         }
+
+        public bool IsReadOnly => !changeSpecificObject;
 
         public BindingList<Part> Parts
         {

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -31,7 +31,23 @@ namespace QuoteSwift
         public Dictionary<string, Part> PartMap { get; private set; }
         public HashSet<string> RepairableItemNames { get; private set; }
         public Pump PumpToChange { get; set; }
-        public bool ChangeSpecificObject { get; set; }
+
+        bool changeSpecificObject;
+        public bool ChangeSpecificObject
+        {
+            get => changeSpecificObject;
+            set
+            {
+                if (changeSpecificObject != value)
+                {
+                    changeSpecificObject = value;
+                    OnPropertyChanged(nameof(ChangeSpecificObject));
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
+            }
+        }
+
+        public bool IsReadOnly => !changeSpecificObject;
 
 
         public AddPumpViewModel(IDataService service, INotificationService notifier)

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -6,6 +6,7 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         BindingList<Business> businesses;
+        bool changeSpecificObject;
 
 
         public ViewBusinessAddressesViewModel(IDataService service)
@@ -24,6 +25,22 @@ namespace QuoteSwift
                 OnPropertyChanged(nameof(Businesses));
             }
         }
+
+        public bool ChangeSpecificObject
+        {
+            get => changeSpecificObject;
+            set
+            {
+                if (changeSpecificObject != value)
+                {
+                    changeSpecificObject = value;
+                    OnPropertyChanged(nameof(ChangeSpecificObject));
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
+            }
+        }
+
+        public bool IsReadOnly => !changeSpecificObject;
 
         public void LoadData()
         {

--- a/ViewModels/ViewPOBoxAddressesViewModel.cs
+++ b/ViewModels/ViewPOBoxAddressesViewModel.cs
@@ -6,6 +6,7 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         BindingList<Business> businesses;
+        bool changeSpecificObject;
 
 
         public ViewPOBoxAddressesViewModel(IDataService service)
@@ -24,6 +25,22 @@ namespace QuoteSwift
                 OnPropertyChanged(nameof(Businesses));
             }
         }
+
+        public bool ChangeSpecificObject
+        {
+            get => changeSpecificObject;
+            set
+            {
+                if (changeSpecificObject != value)
+                {
+                    changeSpecificObject = value;
+                    OnPropertyChanged(nameof(ChangeSpecificObject));
+                    OnPropertyChanged(nameof(IsReadOnly));
+                }
+            }
+        }
+
+        public bool IsReadOnly => !changeSpecificObject;
 
         public void LoadData()
         {

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -191,12 +191,8 @@ namespace QuoteSwift
 
         private void ConvertToViewOnly()
         {
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxBusinessAddress.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxBusinessInformation.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxEmailRelated.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxLegalInformation.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxPhoneRelated.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxPOBoxAddress.Controls);
+            viewModel.ChangeSpecificObject = false;
+            ApplyControlState();
 
             btnViewAddresses.Enabled = true;
             btnViewAll.Enabled = true;
@@ -210,17 +206,24 @@ namespace QuoteSwift
 
         private void ConvertToEdit()
         {
-            QuoteSwiftMainCode.ReadWriteComponents(gbxBusinessAddress.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxBusinessInformation.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxEmailRelated.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxLegalInformation.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxPhoneRelated.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxPOBoxAddress.Controls);
+            viewModel.ChangeSpecificObject = true;
+            ApplyControlState();
 
             btnAddBusiness.Visible = true;
             btnAddBusiness.Text = "Update Business";
             Text = Text.Replace("Viewing " + viewModel.CurrentBusiness.BusinessName, "Updating " + viewModel.CurrentBusiness.BusinessName);
             updateBusinessInformationToolStripMenuItem.Enabled = false;
+        }
+
+        void ApplyControlState()
+        {
+            bool ro = viewModel.IsReadOnly;
+            ControlStateHelper.ApplyReadOnly(gbxBusinessAddress.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxBusinessInformation.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxEmailRelated.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxLegalInformation.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxPhoneRelated.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxPOBoxAddress.Controls, ro);
         }
 
         private void SetupBindings()

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -282,12 +282,8 @@ namespace QuoteSwift
 
         private void ConvertToViewOnly()
         {
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxCustomerInformation.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxCustomerAddress.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxEmailRelated.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxLegalInformation.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxPhoneRelated.Controls);
-            QuoteSwiftMainCode.ReadOnlyComponents(gbxPOBoxAddress.Controls);
+            viewModel.ChangeSpecificObject = false;
+            ApplyControlState();
 
             btnViewAddresses.Enabled = true;
             btnViewAll.Enabled = true;
@@ -301,12 +297,8 @@ namespace QuoteSwift
 
         private void ConvertToEdit()
         {
-            QuoteSwiftMainCode.ReadWriteComponents(gbxCustomerInformation.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxCustomerAddress.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxEmailRelated.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxLegalInformation.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxPhoneRelated.Controls);
-            QuoteSwiftMainCode.ReadWriteComponents(gbxPOBoxAddress.Controls);
+            viewModel.ChangeSpecificObject = true;
+            ApplyControlState();
 
             btnAddCustomer.Visible = true;
             btnAddCustomer.Text = "Update Customer";
@@ -315,6 +307,17 @@ namespace QuoteSwift
             if (viewModel.CustomerToChange != null)
                 Text = Text.Replace("Viewing " + viewModel.CustomerToChange.CustomerName, "Updating " + viewModel.CustomerToChange.CustomerName);
             updatedCustomerInformationToolStripMenuItem.Enabled = false;
+        }
+
+        void ApplyControlState()
+        {
+            bool ro = viewModel.IsReadOnly;
+            ControlStateHelper.ApplyReadOnly(gbxCustomerInformation.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxCustomerAddress.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxEmailRelated.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxLegalInformation.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxPhoneRelated.Controls, ro);
+            ControlStateHelper.ApplyReadOnly(gbxPOBoxAddress.Controls, ro);
         }
 
         private Business GetSelectedBusiness()

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -148,14 +148,16 @@ namespace QuoteSwift
         {
             if (viewModel.ChangeSpecificObject && viewModel.PartToChange != null)
             {
-                ReadWriteComponents();
+                viewModel.ChangeSpecificObject = true;
+                ApplyControlState();
                 btnAddPart.Text = "Update";
                 updatePartToolStripMenuItem.Enabled = false;
             }
             else if (!viewModel.ChangeSpecificObject && viewModel.PartToChange != null)
             {
+                viewModel.ChangeSpecificObject = false;
                 btnAddPart.Visible = false;
-                Read_OnlyComponents();
+                ApplyControlState();
                 updatePartToolStripMenuItem.Enabled = true;
             }
         }
@@ -179,30 +181,20 @@ namespace QuoteSwift
             NudQuantity.ResetText();
         }
 
-        private void Read_OnlyComponents()
+        void ApplyControlState()
         {
-            mtxtNewPartNumber.ReadOnly = true;
-            mtxtOriginalPartNumber.ReadOnly = true;
-            mtxtPartDescription.ReadOnly = true;
-            mtxtPartName.ReadOnly = true;
-            mtxtPartPrice.ReadOnly = true;
+            bool ro = viewModel.IsReadOnly;
+            mtxtNewPartNumber.ReadOnly = ro;
+            mtxtOriginalPartNumber.ReadOnly = ro;
+            mtxtPartDescription.ReadOnly = ro;
+            mtxtPartName.ReadOnly = ro;
+            mtxtPartPrice.ReadOnly = ro;
             cbAddToPumpSelection.Enabled = false;
             NudQuantity.Enabled = false;
-            cbxMandatoryPart.Enabled = false;
-        }
-
-        private void ReadWriteComponents()
-        {
-            mtxtNewPartNumber.ReadOnly = false;
-            mtxtOriginalPartNumber.ReadOnly = false;
-            mtxtPartDescription.ReadOnly = false;
-            mtxtPartName.ReadOnly = false;
-            mtxtPartPrice.ReadOnly = false;
-            cbAddToPumpSelection.Enabled = false;
-            NudQuantity.Enabled = false;
-            cbxMandatoryPart.Enabled = true;
-            btnAddPart.Visible = true;
-            btnAddPart.Text = "Update Part";
+            cbxMandatoryPart.Enabled = !ro;
+            btnAddPart.Visible = !ro;
+            if (!ro)
+                btnAddPart.Text = "Update Part";
         }
 
         private void UpdatePartToolStripMenuItem_Click(object sender, EventArgs e)
@@ -210,9 +202,9 @@ namespace QuoteSwift
             if (!viewModel.ChangeSpecificObject)
                 if (messageService.RequestConfirmation("You are currently only viewing " + viewModel.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
                 {
-                    ReadWriteComponents();
-                    updatePartToolStripMenuItem.Enabled = false;
                     viewModel.ChangeSpecificObject = true;
+                    ApplyControlState();
+                    updatePartToolStripMenuItem.Enabled = false;
                 }
         }
 

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -904,7 +904,7 @@ namespace QuoteSwift
 
         private void ConvertToReadOnly()
         {
-            QuoteSwiftMainCode.ReadOnlyComponents(Controls);
+            ApplyControlState(true);
 
             dgvMandatoryPartReplacement.ReadOnly = true;
             DgvNonMandatoryPartReplacement.ReadOnly = true;
@@ -925,11 +925,17 @@ namespace QuoteSwift
 
         private void ConvertToReadWrite()
         {
-            QuoteSwiftMainCode.ReadWriteComponents(Controls);
+            ApplyControlState(false);
 
             Text = Text.Replace(quoteToChange.QuoteCompany.BusinessName, quoteToChange.QuoteCompany.BusinessName);
             Text = Text.Replace("Viewing", "Creating New");
 
+        }
+
+        void ApplyControlState(bool readOnly)
+        {
+            ControlStateHelper.ApplyReadOnly(Controls, readOnly);
+            cbxPumpSelection.Enabled = !readOnly;
         }
 
         private void CreateNewQuoteUsingThisQuoteToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -86,15 +86,20 @@ namespace QuoteSwift
             LoadInformation();
         }
 
+        void ApplyControlState()
+        {
+            ControlStateHelper.ApplyReadOnly(Controls, true);
+        }
+
         private void FrmViewPOBoxAddresses_Load(object sender, EventArgs e)
         {
             if (business != null && business.BusinessPOBoxAddressList != null)
             {
                 Text = Text.Replace("<<Business name>>", business.BusinessName);
 
-                if (!viewModel.ChangeSpecificObject)
+                if (viewModel.IsReadOnly)
                 {
-                    QuoteSwiftMainCode.ReadOnlyComponents(Controls);
+                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 
@@ -104,9 +109,9 @@ namespace QuoteSwift
             {
                 Text = Text.Replace("<<Business name>>", customer.CustomerName);
 
-                if (!viewModel.ChangeSpecificObject)
+                if (viewModel.IsReadOnly)
                 {
-                    QuoteSwiftMainCode.ReadOnlyComponents(Controls);
+                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 


### PR DESCRIPTION
## Summary
- add `IsReadOnly` helpers on view-models
- centralize UI read-only logic in new `ControlStateHelper`
- update forms to use helper and view-model flags instead of `QuoteSwiftMainCode` static methods

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Release` *(fails: default XML namespace not MSBuild namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6876c13d65948325adfd0990700de0cd