### PR TITLE
Move SaveAll logic to view models

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,7 +23,7 @@ namespace QuoteSwift
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new FrmViewQuotes(viewModel, navigation, appData, messenger));
+            Application.Run(new FrmViewQuotes(viewModel, navigation, messenger));
         }
     }
 }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -31,7 +31,7 @@ namespace QuoteSwift
         {
             var vm = new QuotesViewModel(dataService);
             vm.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
-            using (var form = new FrmViewQuotes(vm, this, appData, messageService))
+            using (var form = new FrmViewQuotes(vm, this, messageService))
             {
                 form.ShowDialog();
             }
@@ -45,8 +45,8 @@ namespace QuoteSwift
         public void ViewAllPumps()
         {
             var vm = new ViewPumpViewModel(dataService);
-            vm.LoadData();
-            using (var form = new FrmViewPump(vm, this, appData, messageService))
+            vm.UpdateData(appData.PumpList);
+            using (var form = new FrmViewPump(vm, this, messageService))
             {
                 form.ShowDialog();
             }

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -105,5 +105,17 @@ namespace QuoteSwift
             Quotes = new BindingList<Quote>(QuoteMap?.Values.ToList() ?? new List<Quote>());
         }
 
+        public void SaveChanges()
+        {
+            if (QuoteMap != null)
+                dataService.SaveQuotes(QuoteMap);
+            if (BusinessList != null)
+                dataService.SaveBusinesses(BusinessList);
+            if (PumpList != null)
+                dataService.SavePumps(PumpList);
+            if (PartMap != null)
+                dataService.SaveParts(PartMap);
+        }
+
     }
 }

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -81,5 +81,11 @@ namespace QuoteSwift
             MainProgramCode.ExportInventory(Pumps, filePath);
         }
 
+        public void SaveChanges()
+        {
+            if (Pumps != null)
+                dataService.SavePumps(Pumps);
+        }
+
     }
 }

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -10,25 +10,21 @@ namespace QuoteSwift // Repair Quote Swift
 
         readonly ViewPumpViewModel viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
 
-        public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
+        public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            appData = data;
             this.messageService = messageService;
-            if (appData != null)
-                viewModel.UpdateData(appData.PumpList);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                appData.SaveAll();
+                viewModel.SaveChanges();
                 Application.Exit();
             }
         }
@@ -137,7 +133,7 @@ namespace QuoteSwift // Repair Quote Swift
 
         private void FrmViewPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            appData.SaveAll();
+            viewModel.SaveChanges();
         }
 
         /*********************************************************************************/

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -11,15 +11,13 @@ namespace QuoteSwift
 
         readonly QuotesViewModel viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
 
-        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
+        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            appData = data;
             this.messageService = messageService;
         }
 
@@ -29,7 +27,7 @@ namespace QuoteSwift
             {
                 Hide();
                 navigation.CreateNewQuote();
-                viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+                viewModel.LoadData();
                 try
                 {
                     Show();
@@ -64,7 +62,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.ViewAllPumps();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -79,7 +77,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.CreateNewPump();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -99,7 +97,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.AddCustomer();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -114,7 +112,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.ViewCustomers();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -134,7 +132,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.AddBusiness();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -149,7 +147,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.ViewBusinesses();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -186,7 +184,7 @@ namespace QuoteSwift
                 {
                     Hide();
                     navigation.CreateNewQuote(selected, false);
-                    viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+                    viewModel.LoadData();
                     Show();
                 }
             }
@@ -201,7 +199,7 @@ namespace QuoteSwift
                 {
                     this.Hide();
                     navigation.CreateNewQuote(selected, true);
-                    viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+                    viewModel.LoadData();
                     this.Show();
                 }
             }
@@ -211,7 +209,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.ViewAllParts();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -231,7 +229,7 @@ namespace QuoteSwift
         {
             Hide();
             navigation.AddNewPart();
-            viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
+            viewModel.LoadData();
             try
             {
                 Show();
@@ -252,11 +250,7 @@ namespace QuoteSwift
         readonly int count = 0;
         private void FrmViewQuotes_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
-                viewModel.BusinessList,
-                viewModel.PumpList,
-                viewModel.PartMap,
-                viewModel.QuoteMap);
+            viewModel.SaveChanges();
         }
 
         void LoadDataGrid()


### PR DESCRIPTION
## Summary
- stop passing `ApplicationData` into `FrmViewPump` and `FrmViewQuotes`
- persist changes through new `SaveChanges` methods on related view models
- update navigation and program startup for new form constructors

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace issue)*

------
https://chatgpt.com/codex/tasks/task_e_6877472ca8048325b54c7db96a95cce0