### PR TITLE
Refactor serialization operations into service

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -13,17 +13,18 @@ namespace QuoteSwift
         {
             IMessageService messenger = new MessageBoxService();
             IDataService dataService = new FileDataService(messenger);
+            ISerializationService serializationService = new FileSerializationService();
             var appData = new ApplicationData(dataService);
             appData.Load();
 
             INotificationService notifier = new MessageBoxNotificationService();
-            var navigation = new NavigationService(appData, notifier, messenger);
+            var navigation = new NavigationService(appData, notifier, messenger, serializationService);
             QuotesViewModel viewModel = new QuotesViewModel(dataService);
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new FrmViewQuotes(viewModel, navigation, messenger));
+            Application.Run(new FrmViewQuotes(viewModel, navigation, messenger, serializationService));
         }
     }
 }

--- a/Services/FileSerializationService.cs
+++ b/Services/FileSerializationService.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace QuoteSwift
+{
+    public class FileSerializationService : ISerializationService
+    {
+        public void SerializePartList(Dictionary<string, Part> partList)
+        {
+            MainProgramCode.SerializePartList(partList);
+        }
+
+        public void SerializePumpList(BindingList<Pump> pumpList)
+        {
+            MainProgramCode.SerializePumpList(pumpList);
+        }
+
+        public void SerializeBusinessList(BindingList<Business> businessList)
+        {
+            MainProgramCode.SerializeBusinessList(businessList);
+        }
+
+        public void SerializeQuoteList(SortedDictionary<string, Quote> quoteList)
+        {
+            MainProgramCode.SerializeQuoteList(quoteList);
+        }
+
+        public void ExportInventory(BindingList<Pump> pumpList, string filePath)
+        {
+            MainProgramCode.ExportInventory(pumpList, filePath);
+        }
+
+        public void CloseApplication(bool exitApp,
+            BindingList<Business> businessList,
+            BindingList<Pump> pumpList,
+            Dictionary<string, Part> partList,
+            SortedDictionary<string, Quote> quoteList)
+        {
+            MainProgramCode.CloseApplication(exitApp, businessList, pumpList, partList, quoteList);
+        }
+    }
+}

--- a/Services/ISerializationService.cs
+++ b/Services/ISerializationService.cs
@@ -1,0 +1,16 @@
+namespace QuoteSwift
+{
+    public interface ISerializationService
+    {
+        void SerializePartList(System.Collections.Generic.Dictionary<string, Part> partList);
+        void SerializePumpList(System.ComponentModel.BindingList<Pump> pumpList);
+        void SerializeBusinessList(System.ComponentModel.BindingList<Business> businessList);
+        void SerializeQuoteList(System.Collections.Generic.SortedDictionary<string, Quote> quoteList);
+        void ExportInventory(System.ComponentModel.BindingList<Pump> pumpList, string filePath);
+        void CloseApplication(bool exitApp,
+            System.ComponentModel.BindingList<Business> businessList,
+            System.ComponentModel.BindingList<Pump> pumpList,
+            System.Collections.Generic.Dictionary<string, Part> partList,
+            System.Collections.Generic.SortedDictionary<string, Quote> quoteList);
+    }
+}

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -8,11 +8,13 @@ namespace QuoteSwift
         readonly ApplicationData appData;
         readonly INotificationService notificationService;
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
 
-        public NavigationService(ApplicationData data, INotificationService notifier, IMessageService messenger)
+        public NavigationService(ApplicationData data, INotificationService notifier, IMessageService messenger, ISerializationService serializer)
         {
             dataService = new FileDataService(messenger);
             appData = data;
+            serializationService = serializer;
             notificationService = notifier;
             messageService = messenger;
         }
@@ -20,8 +22,7 @@ namespace QuoteSwift
         public void CreateNewQuote(Quote quoteToChange = null, bool changeSpecificObject = false)
         {
             var vm = new CreateQuoteViewModel(dataService);
-            using (var form = new FrmCreateQuote(vm, appData, quoteToChange, changeSpecificObject, messageService))
-            {
+            using (var form = new FrmCreateQuote(vm, appData, quoteToChange, changeSpecificObject, messageService, serializationService))
                 form.ShowDialog();
             }
             appData.SaveAll();
@@ -31,7 +32,7 @@ namespace QuoteSwift
         {
             var vm = new QuotesViewModel(dataService);
             vm.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
-            using (var form = new FrmViewQuotes(vm, this, messageService))
+            using (var form = new FrmViewQuotes(vm, this, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -44,7 +45,7 @@ namespace QuoteSwift
 
         public void ViewAllPumps()
         {
-            var vm = new ViewPumpViewModel(dataService);
+            var vm = new ViewPumpViewModel(dataService, serializationService);
             vm.UpdateData(appData.PumpList);
             using (var form = new FrmViewPump(vm, this, messageService))
             {
@@ -57,7 +58,7 @@ namespace QuoteSwift
             var vm = new AddPumpViewModel(dataService, notificationService);
             vm.UpdateData(appData.PumpList, appData.PartList);
             vm.LoadData();
-            using (var form = new FrmAddPump(vm, this, appData, messageService))
+            using (var form = new FrmAddPump(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -70,7 +71,7 @@ namespace QuoteSwift
         {
             var vm = new ViewPartsViewModel(dataService);
             vm.UpdateData(appData.PartList);
-            using (var form = new FrmViewParts(vm, this, appData, messageService))
+            using (var form = new FrmViewParts(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -80,7 +81,7 @@ namespace QuoteSwift
         {
             var vm = new AddPartViewModel(dataService, notificationService);
             vm.UpdateData(appData.PartList, appData.PumpList, partToChange, changeSpecificObject);
-            using (var form = new FrmAddPart(vm, this, appData, messageService))
+            using (var form = new FrmAddPart(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -94,7 +95,7 @@ namespace QuoteSwift
         {
             var vm = new AddCustomerViewModel(dataService, notificationService, messageService);
             vm.UpdateData(appData.BusinessList, customerToChange, changeSpecificObject);
-            using (var form = new FrmAddCustomer(vm, this, appData, businessToChange, messageService))
+            using (var form = new FrmAddCustomer(vm, this, appData, businessToChange, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -105,7 +106,7 @@ namespace QuoteSwift
         {
             var vm = new ViewCustomersViewModel(dataService);
             vm.LoadData();
-            using (var form = new FrmViewCustomers(vm, this, appData, messageService))
+            using (var form = new FrmViewCustomers(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -116,7 +117,7 @@ namespace QuoteSwift
             var vm = new AddBusinessViewModel(dataService, messageService);
             vm.UpdateData(appData.BusinessList, businessToChange, changeSpecificObject);
             vm.LoadData();
-            using (var form = new FrmAddBusiness(vm, this, appData, messageService))
+            using (var form = new FrmAddBusiness(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
             }

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -9,12 +9,14 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         BindingList<Pump> pumps;
+        readonly ISerializationService serializationService;
         HashSet<string> repairableItemNames;
 
 
-        public ViewPumpViewModel(IDataService service)
+        public ViewPumpViewModel(IDataService service, ISerializationService serializer)
         {
             dataService = service;
+            serializationService = serializer;
         }
 
         public IDataService DataService => dataService;
@@ -78,7 +80,7 @@ namespace QuoteSwift
             if (string.IsNullOrEmpty(filePath))
                 throw new ArgumentNullException(nameof(filePath));
 
-            MainProgramCode.ExportInventory(Pumps, filePath);
+            serializationService.ExportInventory(Pumps, filePath);
         }
 
         public void SaveChanges()

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -12,20 +12,22 @@ namespace QuoteSwift
         readonly INavigationService navigation;
         readonly ApplicationData appData;
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
 
-        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null)
+        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.appData = appData;
+            this.serializationService = serializationService;
             this.messageService = messageService;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
@@ -181,11 +183,11 @@ namespace QuoteSwift
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
         {
             MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-        }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -12,15 +12,17 @@ namespace QuoteSwift
         readonly INavigationService navigation;
         readonly ApplicationData appData;
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
 
         Business Container;
 
-        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, Business container = null, IMessageService messageService = null)
+        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, Business container = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.appData = appData;
+            this.serializationService = serializationService;
             this.messageService = messageService;
             this.Container = container;
             viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
@@ -33,12 +35,11 @@ namespace QuoteSwift
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
                     appData?.QuoteMap);
-            }
         }
 
         private void BtnAddCustomer_Click(object sender, EventArgs e)
@@ -214,12 +215,11 @@ namespace QuoteSwift
 
         private void FrmAddCustomer_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-        }
 
         /** Form Specific Functions And Procedures: 
        *

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -11,14 +11,16 @@ namespace QuoteSwift
         readonly INavigationService navigation;
 
         readonly ApplicationData appData;
+        readonly ISerializationService serializationService;
         readonly IMessageService messageService;
 
-        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
+        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.serializationService = serializationService;
             this.messageService = messageService;
             viewModel.Initialize();
             SetupBindings();
@@ -43,7 +45,7 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
@@ -213,12 +215,11 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmAddPart_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
+                appData?.QuoteMap);
                 appData?.QuoteMap);
         }
 

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -12,14 +12,16 @@ namespace QuoteSwift
         readonly AddPumpViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly ISerializationService serializationService;
         readonly IMessageService messageService;
 
-        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
+        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
             appData = data;
+            this.serializationService = serializationService;
             this.messageService = messageService;
             if (data != null)
                 viewModel.UpdateData(data.PumpList, data.PartList, viewModel.PumpToChange, viewModel.ChangeSpecificObject,
@@ -29,12 +31,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
                     appData?.QuoteMap);
-        }
 
         private void BtnAddPump_Click(object sender, EventArgs e)
         {
@@ -412,14 +413,11 @@ namespace QuoteSwift
         private void FrmAddPump_FormClosing(object sender, FormClosingEventArgs e)
         {
             MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-        }
-
-        /*********************************************************************************/
-
 
     }
 }

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -15,6 +15,7 @@ namespace QuoteSwift
         readonly CreateQuoteViewModel viewModel;
         readonly ApplicationData appData;
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
         Quote quoteToChange;
         bool changeSpecificObject;
         public Quote NewQuote;
@@ -23,12 +24,13 @@ namespace QuoteSwift
         readonly BindingSource nonMandatorySource = new BindingSource();
 
 
-        public FrmCreateQuote(CreateQuoteViewModel viewModel, ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false, IMessageService messageService = null)
+        public FrmCreateQuote(CreateQuoteViewModel viewModel, ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             appData = data;
             this.messageService = messageService;
+            this.serializationService = serializationService;
             this.quoteToChange = quoteToChange;
             this.changeSpecificObject = changeSpecificObject;
             this.viewModel.LoadData();
@@ -78,12 +80,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
                     appData?.QuoteMap);
-        }
 
         private void CbxPumpSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -777,12 +778,11 @@ namespace QuoteSwift
 
         private void FrmCreateQuote_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-        }
     }
 
 }

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -9,13 +9,15 @@ namespace QuoteSwift
         readonly ViewCustomersViewModel viewModel;
         readonly INavigationService navigation;
         readonly ApplicationData appData;
+        readonly ISerializationService serializationService;
         readonly IMessageService messageService;
-
+        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
         public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            this.serializationService = serializationService;
             this.appData = appData;
             this.messageService = messageService;
         }
@@ -23,12 +25,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
                     appData?.QuoteMap);
-        }
 
         private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e)
         {
@@ -162,12 +163,11 @@ namespace QuoteSwift
 
         private void FrmViewCustomers_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-        }
 
         /**********************************************************************************/
     }

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -12,13 +12,15 @@ namespace QuoteSwift
         readonly INavigationService navigation;
 
         readonly ApplicationData appData;
+        readonly ISerializationService serializationService;
         readonly IMessageService messageService;
-
+        public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
         public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            this.serializationService = serializationService;
             appData = data;
             this.messageService = messageService;
             if (appData != null)
@@ -28,12 +30,11 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     appData?.BusinessList,
                     appData?.PumpList,
                     appData?.PartList,
                     appData?.QuoteMap);
-        }
 
         private void BtnAddPart_Click(object sender, EventArgs e)
         {
@@ -132,14 +133,9 @@ namespace QuoteSwift
         }
 
         private void FrmViewParts_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            MainProgramCode.CloseApplication(true,
+            serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-        }
-
-        /*********************************************************************************/
-    }
 }

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -12,12 +12,14 @@ namespace QuoteSwift
         readonly QuotesViewModel viewModel;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
 
-        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+        public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
+            this.serializationService = serializationService;
             this.messageService = messageService;
         }
 
@@ -50,12 +52,11 @@ namespace QuoteSwift
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                MainProgramCode.CloseApplication(true,
+                serializationService.CloseApplication(true,
                     viewModel.BusinessList,
                     viewModel.PumpList,
                     viewModel.PartMap,
                     viewModel.QuoteMap);
-            }
         }
 
         private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add new `ISerializationService` interface and `FileSerializationService` implementation
- inject `ISerializationService` through `NavigationService`
- update forms and `ViewPumpViewModel` to use injected serialization service instead of `MainProgramCode`
- register the service in `Program.cs`

## Testing
- `xbuild QuoteSwift.sln /verbosity:minimal` *(fails: default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6877559c320883259a2b8db01787acf1