### PR TITLE
Fix constructor and closing brackets in frmViewCustomers

### DIFF
--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -12,7 +12,6 @@ namespace QuoteSwift
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
         public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
-        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -30,6 +29,9 @@ namespace QuoteSwift
                     appData?.PumpList,
                     appData?.PartList,
                     appData?.QuoteMap);
+
+        }
+
 
         private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e)
         {
@@ -168,6 +170,7 @@ namespace QuoteSwift
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
+        }
 
         /**********************************************************************************/
     }


### PR DESCRIPTION
## Summary
- drop erroneous constructor overload
- close event handlers properly

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877612f93248325981b66555c11c586