### PR TITLE
Derive ViewModelBase from ObservableObject

### DIFF
--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -1,14 +1,9 @@
-using System.ComponentModel;
-
 namespace QuoteSwift
 {
-    public class ViewModelBase : INotifyPropertyChanged
+    /// <summary>
+    /// Base class for all view models providing notification helpers.
+    /// </summary>
+    public class ViewModelBase : ObservableObject
     {
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
     }
 }


### PR DESCRIPTION
## Summary
- hook up `ViewModelBase` to `ObservableObject`
- remove duplicate property change logic

## Testing
- `dotnet build QuoteSwift.sln -c Debug` *(fails: System.Windows.Forms reference missing)*

------
https://chatgpt.com/codex/tasks/task_e_687770e0cd548325babfa6679013ae8c