### PR TITLE
Centralize quote validation

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -21,7 +21,7 @@ namespace QuoteSwift
 
         public void CreateNewQuote(Quote quoteToChange = null, bool changeSpecificObject = false)
         {
-            var vm = new CreateQuoteViewModel(dataService);
+            var vm = new CreateQuoteViewModel(dataService, notificationService);
             using (var form = new FrmCreateQuote(vm, appData, quoteToChange, changeSpecificObject, messageService, serializationService))
                 form.ShowDialog();
             }

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -8,6 +8,7 @@ namespace QuoteSwift
     public class CreateQuoteViewModel : ViewModelBase
     {
         readonly IDataService dataService;
+        readonly INotificationService notificationService;
         Dictionary<string, Part> partList;
         BindingList<Pump> pumps;
         BindingList<Business> businesses;
@@ -17,6 +18,13 @@ namespace QuoteSwift
         Pump selectedPump;
         BindingList<Quote_Part> mandatoryParts = new BindingList<Quote_Part>();
         BindingList<Quote_Part> nonMandatoryParts = new BindingList<Quote_Part>();
+
+        string customerVatNumber;
+        string jobNumber;
+        string referenceNumber;
+        string prNumber;
+        string lineNumber;
+        string quoteNumber;
 
         BindingList<string> businessTelephoneNumbers = new BindingList<string>();
         BindingList<string> businessCellphoneNumbers = new BindingList<string>();
@@ -32,9 +40,10 @@ namespace QuoteSwift
         public ICommand AddQuoteCommand { get; }
 
 
-        public CreateQuoteViewModel(IDataService service)
+        public CreateQuoteViewModel(IDataService service, INotificationService notifier)
         {
             dataService = service;
+            notificationService = notifier;
             AddQuoteCommand = new RelayCommand(q => AddQuote(q as Quote));
         }
 
@@ -246,6 +255,42 @@ namespace QuoteSwift
             }
         }
 
+        public string CustomerVATNumber
+        {
+            get => customerVatNumber;
+            set => SetProperty(ref customerVatNumber, value);
+        }
+
+        public string JobNumber
+        {
+            get => jobNumber;
+            set => SetProperty(ref jobNumber, value);
+        }
+
+        public string ReferenceNumber
+        {
+            get => referenceNumber;
+            set => SetProperty(ref referenceNumber, value);
+        }
+
+        public string PRNumber
+        {
+            get => prNumber;
+            set => SetProperty(ref prNumber, value);
+        }
+
+        public string LineNumber
+        {
+            get => lineNumber;
+            set => SetProperty(ref lineNumber, value);
+        }
+
+        public string QuoteNumber
+        {
+            get => quoteNumber;
+            set => SetProperty(ref quoteNumber, value);
+        }
+
         public Pricing Pricing
         {
             get => pricing;
@@ -369,6 +414,47 @@ namespace QuoteSwift
                         return false;
                 }
             }
+            return true;
+        }
+
+        public bool ValidateInput()
+        {
+            if (string.IsNullOrWhiteSpace(CustomerVATNumber) || CustomerVATNumber.Length < 3)
+            {
+                notificationService?.ShowError("Please provide a valid Customer VAT Number", "ERROR - Invalid Quote Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(JobNumber) || JobNumber.Length < 3)
+            {
+                notificationService?.ShowError("Please provide a valid Job Number", "ERROR - Invalid Quote Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(ReferenceNumber) || ReferenceNumber.Length < 3)
+            {
+                notificationService?.ShowError("Please provide a valid Reference Number", "ERROR - Invalid Quote Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(PRNumber) || PRNumber.Length < 3)
+            {
+                notificationService?.ShowError("Please provide a valid PR Number", "ERROR - Invalid Quote Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(LineNumber))
+            {
+                notificationService?.ShowError("Please provide a valid Line Number", "ERROR - Invalid Quote Input");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(QuoteNumber) || QuoteNumber.Length < 8)
+            {
+                notificationService?.ShowError("Please provide a valid Quote Number", "ERROR - Invalid Quote Input");
+                return false;
+            }
+
             return true;
         }
 

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -409,6 +409,13 @@ namespace QuoteSwift
             nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
             DgvNonMandatoryPartReplacement.DataSource = nonMandatorySource;
 
+            txtCustomerVATNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerVATNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtJobNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.JobNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtReferenceNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.ReferenceNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtPRNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.PRNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtLineNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.LineNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtQuoteNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.QuoteNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+
             UpdatePricingDisplay();
         }
 
@@ -496,46 +503,6 @@ namespace QuoteSwift
             LoadCustomerPOBoxAddress();
         }
 
-        private bool ValidInput()
-        {
-            if (txtCustomerVATNumber.Text.Length < 3)
-            {
-                messageService.ShowError("Please provide a valid Customer VAT Number", "ERROR - Invalid Quote Input");
-                return false;
-            }
-
-            if (txtJobNumber.Text.Length < 3)
-            {
-                messageService.ShowError("Please provide a valid Job Number", "ERROR - Invalid Quote Input");
-                return false;
-            }
-
-            if (txtReferenceNumber.Text.Length < 3)
-            {
-                messageService.ShowError("Please provide a valid Reference Number", "ERROR - Invalid Quote Input");
-                return false;
-            }
-
-            if (txtPRNumber.Text.Length < 3)
-            {
-                messageService.ShowError("Please provide a valid PR Number", "ERROR - Invalid Quote Input");
-                return false;
-            }
-
-            if (txtLineNumber.Text.Length == 0)
-            {
-                messageService.ShowError("Please provide a valid Line Number", "ERROR - Invalid Quote Input");
-                return false;
-            }
-
-            if (txtQuoteNumber.Text.Length < 8)
-            {
-                messageService.ShowError("Please provide a valid Quote Number", "ERROR - Invalid Quote Input");
-                return false;
-            }
-
-            return true;
-        }
 
         private void CbxUseAutomaticNumberingScheme_CheckedChanged(object sender, EventArgs e)
         {
@@ -552,21 +519,21 @@ namespace QuoteSwift
 
         Quote CreateQuote()
         {
-            if (!ValidInput()) return null;
+            if (!viewModel.ValidateInput()) return null;
 
             viewModel.Pricing.Rebate = ParsingService.ParseDecimal(mtxtRebate.Text);
             viewModel.Calculate();
 
-            var quote = viewModel.CreateQuote(txtQuoteNumber.Text,
+            var quote = viewModel.CreateQuote(viewModel.QuoteNumber,
                                                dtpQuoteCreationDate.Value,
                                                dtpQuoteExpiryDate.Value,
-                                               txtReferenceNumber.Text,
-                                               txtJobNumber.Text,
-                                               txtPRNumber.Text,
+                                               viewModel.ReferenceNumber,
+                                               viewModel.JobNumber,
+                                               viewModel.PRNumber,
                                                dtpPaymentTerm.Value,
                                                GetBusinesssPOBoxAddressSelection(viewModel.SelectedBusiness),
                                                GetCustomerPOBoxAddressSelection(viewModel.SelectedCustomer),
-                                               txtLineNumber.Text,
+                                               viewModel.LineNumber,
                                                cbxBusinessTelephoneNumberSelection.Text,
                                                cbxBusinessCellphoneNumberSelection.Text,
                                                cbxBusinessEmailAddressSelection.Text,


### PR DESCRIPTION
## Summary
- move quote validation into `CreateQuoteViewModel`
- expose new text fields on the view model
- bind form fields to the view model and validate through it
- pass `INotificationService` to `CreateQuoteViewModel`

## Testing
- `dotnet msbuild QuoteSwift.sln` *(fails: Could not locate `System.Windows.Forms`)*

------
https://chatgpt.com/codex/tasks/task_e_6877761d3158832595e7b2c6cd8f91f5