### PR TITLE
Bind grids directly to view model lists

### DIFF
--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -26,7 +26,8 @@ namespace QuoteSwift
             this.messageService = messageService;
             if (appData != null)
                 viewModel.UpdateData(appData.PartList);
-            partsBindingSource.DataSource = viewModel.AllParts;
+            partsBindingSource.DataSource = viewModel;
+            partsBindingSource.DataMember = nameof(ViewPartsViewModel.AllParts);
             dgvAllParts.DataSource = partsBindingSource;
         }
 

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -19,7 +19,8 @@ namespace QuoteSwift // Repair Quote Swift
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
-            pumpBindingSource.DataSource = viewModel.Pumps;
+            pumpBindingSource.DataSource = viewModel;
+            pumpBindingSource.DataMember = nameof(ViewPumpViewModel.Pumps);
             dgvPumpList.DataSource = pumpBindingSource;
         }
 
@@ -34,11 +35,9 @@ namespace QuoteSwift // Repair Quote Swift
 
         private void BtnUpdateSelectedPump_Click(object sender, EventArgs e)
         {
-            if (dgvPumpList.SelectedCells.Count > 0)
+            Pump selected = GetSelectedPump();
+            if (selected != null)
             {
-                int iGridSelection = dgvPumpList.CurrentCell.RowIndex;
-
-                var pToChange = viewModel.Pumps.ElementAt(iGridSelection);
                 Hide();
                 navigation.CreateNewPump();
                 Show();


### PR DESCRIPTION
## Summary
- bind `FrmViewParts` grid to `ViewPartsViewModel.AllParts`
- bind `FrmViewPump` grid to `ViewPumpViewModel.Pumps`
- use `DataBoundItem` when updating selected pump

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_687813f51dec832589e31420e0f1fb99