### PR TITLE
Fix form closing handlers

### DIFF
--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -218,12 +218,13 @@ namespace QuoteSwift
 
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
             serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
+
+        }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -412,7 +412,6 @@ namespace QuoteSwift
 
         private void FrmAddPump_FormClosing(object sender, FormClosingEventArgs e)
         {
-            MainProgramCode.CloseApplication(true,
             serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,


### PR DESCRIPTION
## Summary
- remove leftover `MainProgramCode.CloseApplication` lines
- ensure each form closing event only calls `serializationService.CloseApplication`

## Testing
- `msbuild QuoteSwift.sln` *(fails: command not found)*
- `xbuild QuoteSwift.sln` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6878423ec6088325a8719da3db6fa2b9