### PR TITLE
Refactor selection helpers

### DIFF
--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Windows.Input;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace QuoteSwift
 {
@@ -93,6 +94,16 @@ namespace QuoteSwift
                 businessList = value;
                 OnPropertyChanged(nameof(BusinessList));
             }
+        }
+
+        public Business GetBusinessByName(string name)
+        {
+            if (BusinessList != null && !string.IsNullOrWhiteSpace(name))
+            {
+                return BusinessList.FirstOrDefault(b => b.BusinessName == name);
+            }
+
+            return null;
         }
 
         public void ClearCurrentCustomer()

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -256,6 +256,33 @@ namespace QuoteSwift
             }
         }
 
+        public Address GetBusinessPOBoxByDescription(string description)
+        {
+            if (SelectedBusiness != null && SelectedBusiness.BusinessPOBoxAddressList != null && !string.IsNullOrWhiteSpace(description))
+            {
+                return SelectedBusiness.BusinessPOBoxAddressList.SingleOrDefault(p => p.AddressDescription == description);
+            }
+            return null;
+        }
+
+        public Address GetCustomerPOBoxByDescription(string description)
+        {
+            if (SelectedCustomer != null && SelectedCustomer.CustomerPOBoxAddress != null && !string.IsNullOrWhiteSpace(description))
+            {
+                return SelectedCustomer.CustomerPOBoxAddress.SingleOrDefault(p => p.AddressDescription == description);
+            }
+            return null;
+        }
+
+        public Address GetCustomerDeliveryAddressByDescription(string description)
+        {
+            if (SelectedCustomer != null && SelectedCustomer.CustomerDeliveryAddressList != null && !string.IsNullOrWhiteSpace(description))
+            {
+                return SelectedCustomer.CustomerDeliveryAddressList.SingleOrDefault(p => p.AddressDescription == description);
+            }
+            return null;
+        }
+
         public string CustomerVATNumber
         {
             get => customerVatNumber;

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -46,7 +46,7 @@ namespace QuoteSwift
         {
             if (viewModel.ValidateBusiness() && !viewModel.ChangeSpecificObject)
             {
-                Business linkBusiness = GetSelectedBusiness();
+                Business linkBusiness = viewModel.GetBusinessByName(cbBusinessSelection.Text);
                 viewModel.CurrentCustomer.CustomerName = string.Empty;
                 viewModel.CurrentCustomer.CustomerLegalDetails = new Legal(mtxtRegistrationNumber.Text, mtxtVATNumber.Text);
                 viewModel.CurrentCustomer.VendorNumber = mtxtVendorNumber.Text;
@@ -68,7 +68,7 @@ namespace QuoteSwift
                 viewModel.CurrentCustomer.CustomerLegalDetails = new Legal(mtxtRegistrationNumber.Text, mtxtVATNumber.Text);
                 viewModel.CurrentCustomer.VendorNumber = mtxtVendorNumber.Text;
 
-                Business container = GetSelectedBusiness();
+                Business container = viewModel.GetBusinessByName(cbBusinessSelection.Text);
                 viewModel.UpdateCustomerCommand.Execute(new object[] { container, oldName });
                 if (viewModel.LastOperationSuccessful)
                 {
@@ -83,9 +83,9 @@ namespace QuoteSwift
         private void FrmAddCustomer_Load(object sender, EventArgs e)
         {
             viewModel.LoadData();
-            if (appData.BusinessList != null)
+            if (viewModel.BusinessList != null)
             {
-                BindingSource source = new BindingSource { DataSource = appData.BusinessList };
+                BindingSource source = new BindingSource { DataSource = viewModel.BusinessList };
                 cbBusinessSelection.DataSource = source.DataSource;
                 cbBusinessSelection.DisplayMember = "BusinessName";
                 cbBusinessSelection.ValueMember = "BusinessName";
@@ -340,15 +340,7 @@ namespace QuoteSwift
             ControlStateHelper.ApplyReadOnly(gbxPOBoxAddress.Controls, ro);
         }
 
-        private Business GetSelectedBusiness()
-        {
-            if (cbBusinessSelection.Text.Length > 0 && appData.BusinessList != null)
-            {
-                return appData.BusinessList.FirstOrDefault(b => b.BusinessName == cbBusinessSelection.Text);
-            }
 
-            return null;
-        }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -185,34 +185,7 @@ namespace QuoteSwift
         }
 
 
-        private Address GetBusinesssPOBoxAddressSelection(Business b)
-        {
-            string SearchName = CbxPOBoxSelection.Text;
 
-            if (b.BusinessPOBoxAddressList != null) return b.BusinessPOBoxAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-
-            return null;
-        }
-
-        private Address GetCustomerPOBoxAddressSelection(Customer c)
-        {
-            if (c != null)
-            {
-                string SearchName = CbxCustomerPOBoxSelection.Text;
-
-                if (c.CustomerPOBoxAddress != null) return c.CustomerPOBoxAddress.SingleOrDefault(p => p.AddressDescription == SearchName);
-            }
-            return null;
-        }
-
-        private Address GetCustomerDeliveryAddress()
-        {
-            string SearchName = cbxCustomerDeliveryAddress.Text;
-
-            if (viewModel.SelectedCustomer != null && viewModel.SelectedCustomer.CustomerDeliveryAddressList != null) return viewModel.SelectedCustomer.CustomerDeliveryAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-
-            return null;
-        }
 
         private void LinkBusinessTelephone(Business b, ref ComboBox cb)
         {
@@ -450,7 +423,7 @@ namespace QuoteSwift
 
         private void LoadBusinessPOBoxAddress()
         {
-            Address Selection = GetBusinesssPOBoxAddressSelection(viewModel.SelectedBusiness);
+            Address Selection = viewModel.GetBusinessPOBoxByDescription(CbxPOBoxSelection.Text);
             if (Selection != null)
             {
                 lblBusinessPOBoxNumber.Text = "Street Name: " + Selection.AddressStreetName;
@@ -462,7 +435,7 @@ namespace QuoteSwift
         }
         private void LoadCustomerPOBoxAddress()
         {
-            Address Selection = GetCustomerPOBoxAddressSelection(viewModel.SelectedCustomer);
+            Address Selection = viewModel.GetCustomerPOBoxByDescription(CbxCustomerPOBoxSelection.Text);
             if (Selection != null)
             {
                 lblCustomerPOBoxStreetName.Text = "P.O.Box Number " + Selection.AddressStreetNumber.ToString();
@@ -481,7 +454,7 @@ namespace QuoteSwift
 
         private void LoadCustomerDeliveryAddress()
         {
-            Address Selection = GetCustomerDeliveryAddress();
+            Address Selection = viewModel.GetCustomerDeliveryAddressByDescription(cbxCustomerDeliveryAddress.Text);
             if (Selection != null)
             {
                 rtxCustomerDeliveryDescripton.Clear();
@@ -531,8 +504,8 @@ namespace QuoteSwift
                                                viewModel.JobNumber,
                                                viewModel.PRNumber,
                                                dtpPaymentTerm.Value,
-                                               GetBusinesssPOBoxAddressSelection(viewModel.SelectedBusiness),
-                                               GetCustomerPOBoxAddressSelection(viewModel.SelectedCustomer),
+                                               viewModel.GetBusinessPOBoxByDescription(CbxPOBoxSelection.Text),
+                                               viewModel.GetCustomerPOBoxByDescription(CbxCustomerPOBoxSelection.Text),
                                                viewModel.LineNumber,
                                                cbxBusinessTelephoneNumberSelection.Text,
                                                cbxBusinessCellphoneNumberSelection.Text,


### PR DESCRIPTION
## Summary
- move Business selection logic into `AddCustomerViewModel`
- move PO box and address helpers into `CreateQuoteViewModel`
- use new view model helpers in forms

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace of csproj must be MSBuild namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687843cab1008325bf72e331c64df27a