### PR TITLE
Add management commands for emails and phone numbers

### DIFF
--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -15,6 +15,8 @@ namespace QuoteSwift
         public ICommand RemoveCellphoneCommand { get; }
         public ICommand UpdateTelephoneCommand { get; }
         public ICommand UpdateCellphoneCommand { get; }
+        public ICommand AddTelephoneCommand { get; }
+        public ICommand AddCellphoneCommand { get; }
 
 
         public ManagePhoneNumbersViewModel(IDataService service)
@@ -22,6 +24,8 @@ namespace QuoteSwift
             dataService = service;
             RemoveTelephoneCommand = new RelayCommand(n => RemoveTelephone(n as string));
             RemoveCellphoneCommand = new RelayCommand(n => RemoveCellphone(n as string));
+            AddTelephoneCommand = new RelayCommand(n => AddTelephone(n as string));
+            AddCellphoneCommand = new RelayCommand(n => AddCellphone(n as string));
             UpdateTelephoneCommand = new RelayCommand(p =>
             {
                 if (p is object[] arr && arr.Length == 2 && arr[0] is string oldN && arr[1] is string newN)
@@ -131,6 +135,24 @@ namespace QuoteSwift
                 Business.RemoveCellphoneNumber(number);
             else if (Customer != null)
                 Customer.RemoveCellphoneNumber(number);
+            RefreshNumbers();
+        }
+
+        public void AddTelephone(string number)
+        {
+            if (Business != null)
+                Business.AddTelephoneNumber(number);
+            else if (Customer != null)
+                Customer.AddTelephoneNumber(number);
+            RefreshNumbers();
+        }
+
+        public void AddCellphone(string number)
+        {
+            if (Business != null)
+                Business.AddCellphoneNumber(number);
+            else if (Customer != null)
+                Customer.AddCellphoneNumber(number);
             RefreshNumbers();
         }
 

--- a/frmManageAllEmails.Designer.cs
+++ b/frmManageAllEmails.Designer.cs
@@ -36,6 +36,8 @@ namespace QuoteSwift
             this.BtnCancel = new System.Windows.Forms.Button();
             this.btnRemoveAddress = new System.Windows.Forms.Button();
             this.BtnChangeAddressInfo = new System.Windows.Forms.Button();
+            this.txtNewEmail = new System.Windows.Forms.TextBox();
+            this.btnAddEmail = new System.Windows.Forms.Button();
             this.msManageEmailAddressesControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.DgvEmails)).BeginInit();
             this.SuspendLayout();
@@ -107,22 +109,43 @@ namespace QuoteSwift
             this.btnRemoveAddress.Click += new System.EventHandler(this.BtnRemoveAddress_Click);
             // 
             // BtnChangeAddressInfo
-            // 
+            //
             this.BtnChangeAddressInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.BtnChangeAddressInfo.Location = new System.Drawing.Point(370, 37);
             this.BtnChangeAddressInfo.Margin = new System.Windows.Forms.Padding(4);
             this.BtnChangeAddressInfo.Name = "BtnChangeAddressInfo";
             this.BtnChangeAddressInfo.Size = new System.Drawing.Size(234, 32);
-            this.BtnChangeAddressInfo.TabIndex = 6;
+            this.BtnChangeAddressInfo.TabIndex = 8;
             this.BtnChangeAddressInfo.Text = "Update Selected Email";
             this.BtnChangeAddressInfo.UseVisualStyleBackColor = true;
             this.BtnChangeAddressInfo.Click += new System.EventHandler(this.BtnChangeAddressInfo_Click);
+            //
+            // txtNewEmail
+            //
+            this.txtNewEmail.Location = new System.Drawing.Point(18, 37);
+            this.txtNewEmail.Margin = new System.Windows.Forms.Padding(4);
+            this.txtNewEmail.Name = "txtNewEmail";
+            this.txtNewEmail.Size = new System.Drawing.Size(344, 24);
+            this.txtNewEmail.TabIndex = 6;
+            //
+            // btnAddEmail
+            //
+            this.btnAddEmail.Location = new System.Drawing.Point(370, 75);
+            this.btnAddEmail.Margin = new System.Windows.Forms.Padding(4);
+            this.btnAddEmail.Name = "btnAddEmail";
+            this.btnAddEmail.Size = new System.Drawing.Size(234, 32);
+            this.btnAddEmail.TabIndex = 7;
+            this.btnAddEmail.Text = "Add Email";
+            this.btnAddEmail.UseVisualStyleBackColor = true;
+            this.btnAddEmail.Click += new System.EventHandler(this.BtnAddEmail_Click);
             // 
             // FrmManageAllEmails
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(622, 359);
+            this.Controls.Add(this.btnAddEmail);
+            this.Controls.Add(this.txtNewEmail);
             this.Controls.Add(this.BtnChangeAddressInfo);
             this.Controls.Add(this.btnRemoveAddress);
             this.Controls.Add(this.BtnCancel);
@@ -151,6 +174,8 @@ namespace QuoteSwift
         private System.Windows.Forms.Button BtnCancel;
         private System.Windows.Forms.Button btnRemoveAddress;
         private System.Windows.Forms.Button BtnChangeAddressInfo;
+        private System.Windows.Forms.TextBox txtNewEmail;
+        private System.Windows.Forms.Button btnAddEmail;
         private System.Windows.Forms.DataGridViewTextBoxColumn clmEmailAddresses;
     }
 }

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -85,6 +85,19 @@ namespace QuoteSwift
             LoadInformation();
         }
 
+        private void BtnAddEmail_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtNewEmail.Text))
+            {
+                messageService.ShowError("The provided email address is invalid.", "ERROR - Invalid Email Address");
+                return;
+            }
+            viewModel.AddEmailCommand.Execute(txtNewEmail.Text);
+            messageService.ShowInformation($"Successfully added '{txtNewEmail.Text}' to the email address list", "CONFIRMATION - Addition Success");
+            txtNewEmail.Clear();
+            LoadInformation();
+        }
+
         string GetEmailSelection()
         {
             if (DgvEmails.CurrentCell == null || DgvEmails.CurrentRow == null)

--- a/frmManagingPhoneNumbers.Designer.cs
+++ b/frmManagingPhoneNumbers.Designer.cs
@@ -42,6 +42,10 @@ namespace QuoteSwift
             this.BtnCancel = new System.Windows.Forms.Button();
             this.BtnUpdateCellphoneNumber = new System.Windows.Forms.Button();
             this.BtnUpdateTelephoneNumber = new System.Windows.Forms.Button();
+            this.txtNewTelephone = new System.Windows.Forms.TextBox();
+            this.txtNewCellphone = new System.Windows.Forms.TextBox();
+            this.btnAddTelephone = new System.Windows.Forms.Button();
+            this.btnAddCellphone = new System.Windows.Forms.Button();
             this.msManagePhoneNumbersControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgvTelephoneNumbers)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvCellphoneNumbers)).BeginInit();
@@ -190,12 +194,54 @@ namespace QuoteSwift
             this.BtnUpdateTelephoneNumber.Text = "Update Selected Phone Number";
             this.BtnUpdateTelephoneNumber.UseVisualStyleBackColor = true;
             this.BtnUpdateTelephoneNumber.Click += new System.EventHandler(this.BtnUpdateTelephoneNumber_Click);
+            //
+            // txtNewTelephone
+            //
+            this.txtNewTelephone.Location = new System.Drawing.Point(18, 37);
+            this.txtNewTelephone.Margin = new System.Windows.Forms.Padding(4);
+            this.txtNewTelephone.Name = "txtNewTelephone";
+            this.txtNewTelephone.Size = new System.Drawing.Size(250, 24);
+            this.txtNewTelephone.TabIndex = 0;
+            //
+            // txtNewCellphone
+            //
+            this.txtNewCellphone.Location = new System.Drawing.Point(609, 37);
+            this.txtNewCellphone.Margin = new System.Windows.Forms.Padding(4);
+            this.txtNewCellphone.Name = "txtNewCellphone";
+            this.txtNewCellphone.Size = new System.Drawing.Size(250, 24);
+            this.txtNewCellphone.TabIndex = 2;
+            //
+            // btnAddTelephone
+            //
+            this.btnAddTelephone.Location = new System.Drawing.Point(18, 69);
+            this.btnAddTelephone.Margin = new System.Windows.Forms.Padding(4);
+            this.btnAddTelephone.Name = "btnAddTelephone";
+            this.btnAddTelephone.Size = new System.Drawing.Size(250, 30);
+            this.btnAddTelephone.TabIndex = 1;
+            this.btnAddTelephone.Text = "Add Phone";
+            this.btnAddTelephone.UseVisualStyleBackColor = true;
+            this.btnAddTelephone.Click += new System.EventHandler(this.BtnAddTelephone_Click);
+            //
+            // btnAddCellphone
+            //
+            this.btnAddCellphone.Location = new System.Drawing.Point(609, 69);
+            this.btnAddCellphone.Margin = new System.Windows.Forms.Padding(4);
+            this.btnAddCellphone.Name = "btnAddCellphone";
+            this.btnAddCellphone.Size = new System.Drawing.Size(250, 30);
+            this.btnAddCellphone.TabIndex = 3;
+            this.btnAddCellphone.Text = "Add Phone";
+            this.btnAddCellphone.UseVisualStyleBackColor = true;
+            this.btnAddCellphone.Click += new System.EventHandler(this.BtnAddCellphone_Click);
             // 
             // FrmManagingPhoneNumbers
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1161, 381);
+            this.Controls.Add(this.btnAddCellphone);
+            this.Controls.Add(this.btnAddTelephone);
+            this.Controls.Add(this.txtNewCellphone);
+            this.Controls.Add(this.txtNewTelephone);
             this.Controls.Add(this.BtnUpdateTelephoneNumber);
             this.Controls.Add(this.BtnUpdateCellphoneNumber);
             this.Controls.Add(this.BtnCancel);
@@ -234,6 +280,10 @@ namespace QuoteSwift
         private System.Windows.Forms.Button btnRemoveCellNumber;
         private System.Windows.Forms.Button BtnCancel;
         private System.Windows.Forms.Button BtnUpdateCellphoneNumber;
+        private System.Windows.Forms.TextBox txtNewTelephone;
+        private System.Windows.Forms.TextBox txtNewCellphone;
+        private System.Windows.Forms.Button btnAddTelephone;
+        private System.Windows.Forms.Button btnAddCellphone;
         private System.Windows.Forms.DataGridViewTextBoxColumn clmTelephoneNumbers;
         private System.Windows.Forms.DataGridViewTextBoxColumn ClmCellphoneNumbers;
         private System.Windows.Forms.Button BtnUpdateTelephoneNumber;

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -148,6 +148,34 @@ namespace QuoteSwift
             }
         }
 
+        private void BtnAddTelephone_Click(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(txtNewTelephone.Text))
+            {
+                viewModel.AddTelephoneCommand.Execute(txtNewTelephone.Text);
+                txtNewTelephone.Clear();
+                LoadInformation();
+            }
+            else
+            {
+                messageService.ShowError("Please enter a valid phone number.", "ERROR - Invalid Number");
+            }
+        }
+
+        private void BtnAddCellphone_Click(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(txtNewCellphone.Text))
+            {
+                viewModel.AddCellphoneCommand.Execute(txtNewCellphone.Text);
+                txtNewCellphone.Clear();
+                LoadInformation();
+            }
+            else
+            {
+                messageService.ShowError("Please enter a valid phone number.", "ERROR - Invalid Number");
+            }
+        }
+
         private void BtnCancel_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();


### PR DESCRIPTION
## Summary
- extend `ManagePhoneNumbersViewModel` with add commands
- add UI elements for adding emails and phone numbers
- wire up buttons to new view-model commands

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68789e2970408325b0f0d72c46827266