### PR TITLE
Bind AddPart command with CommandBindings

### DIFF
--- a/Infrastructure/CommandBindings.cs
+++ b/Infrastructure/CommandBindings.cs
@@ -1,0 +1,21 @@
+using System.Windows.Forms;
+using System.Windows.Input;
+
+namespace QuoteSwift
+{
+    static class CommandBindings
+    {
+        public static void Bind(Button button, ICommand command)
+        {
+            if (button == null || command == null)
+                return;
+            button.Enabled = command.CanExecute(null);
+            command.CanExecuteChanged += (s, e) => button.Enabled = command.CanExecute(null);
+            button.Click += (s, e) =>
+            {
+                if (command.CanExecute(null))
+                    command.Execute(null);
+            };
+        }
+    }
+}

--- a/frmAddPart.Designer.cs
+++ b/frmAddPart.Designer.cs
@@ -223,7 +223,6 @@ namespace QuoteSwift
             this.btnAddPart.TabIndex = 8;
             this.btnAddPart.Text = "Add Part";
             this.btnAddPart.UseVisualStyleBackColor = true;
-            this.btnAddPart.Click += new System.EventHandler(this.BtnAddPart_Click);
             // 
             // btnCancel
             // 

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -40,6 +40,8 @@ namespace QuoteSwift
             cbAddToPumpSelection.ValueMember = nameof(Pump.PumpName);
             cbAddToPumpSelection.DataBindings.Add("SelectedItem", viewModel, nameof(AddPartViewModel.SelectedPump), false, DataSourceUpdateMode.OnPropertyChanged);
             NudQuantity.DataBindings.Add("Value", viewModel, nameof(AddPartViewModel.Quantity), false, DataSourceUpdateMode.OnPropertyChanged);
+
+            CommandBindings.Bind(btnAddPart, viewModel.SavePartCommand);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -52,40 +54,6 @@ namespace QuoteSwift
                     appData?.QuoteMap);
         }
 
-        private void BtnAddPart_Click(object sender, EventArgs e)
-        {
-
-            if (!viewModel.ValidateInput())
-                return;
-
-            bool updating = viewModel.ChangeSpecificObject;
-
-            viewModel.SavePartCommand.Execute(null);
-            if (!viewModel.LastOperationSuccessful)
-            {
-                messageService.ShowInformation("The provided new part information already has a part which has the same New Part Number or Original Part Number.\nPlease ensure that the provided Part Numbers' are distinct.", "INFORMATION - Part Already Listed");
-                return;
-            }
-
-            if (updating)
-            {
-                messageService.ShowInformation("Successfully updated the part", "CONFIRMATION - Update Successful");
-                viewModel.ChangeSpecificObject = false;
-                Close();
-            }
-            else
-            {
-                string info = viewModel.CurrentPart.MandatoryPart ?
-                    " successfully added to the mandatory part list." :
-                    " successfully added to the non-mandatory part list.";
-                messageService.ShowInformation(viewModel.CurrentPart.PartName + info, "INFORMATION - Part Added Success");
-                if (viewModel.SelectedPump != null)
-                {
-                    messageService.ShowInformation(viewModel.CurrentPart.PartName + " successfully added to " + viewModel.SelectedPump.PumpName + " pump the part list.", "INFORMATION - Part Added  To Pump Success");
-                }
-                ClearInput();
-            }
-        }
 
         private void FrmAddPart_Activated(object sender, EventArgs e)
         {
@@ -135,9 +103,7 @@ namespace QuoteSwift
         {
             if (messageService.RequestConfirmation("Are you sure you want to reset the current screen to it's default values?", "REQUEST - Screen Defaults Reset"))
             {
-                ClearInput();
-                NudQuantity.Enabled = false;
-                cbxMandatoryPart.Checked = false;
+                viewModel.ResetInput();
             }
         }
 
@@ -172,16 +138,6 @@ namespace QuoteSwift
         */
 
 
-        private void ClearInput()
-        {
-            mtxtNewPartNumber.ResetText();
-            mtxtOriginalPartNumber.ResetText();
-            mtxtPartDescription.ResetText();
-            mtxtPartName.ResetText();
-            mtxtPartPrice.ResetText();
-            cbxMandatoryPart.Checked = false;
-            NudQuantity.ResetText();
-        }
 
         void ApplyControlState()
         {


### PR DESCRIPTION
## Summary
- introduce `CommandBindings` helper for easy binding of `ICommand`
- handle validation and messaging directly inside `AddPartViewModel` command
- hook `btnAddPart` to command using new helper and drop old event handler
- remove unused `ClearInput` logic

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_687def33ccc08325abace74636af50b1