### PR TITLE
Improve customer grid binding

### DIFF
--- a/MainProgramLibrary/Customer.cs
+++ b/MainProgramLibrary/Customer.cs
@@ -14,6 +14,7 @@ namespace QuoteSwift
         private BindingList<string> mCustomerCellphoneNumberList;
         private BindingList<string> mCustomerEmailList;
         private string mVendorNumber;
+        private string mPreviousQuoteDate;
 
         // lookup collections for quick searches and duplicate checks
         private Dictionary<string, Address> mDeliveryAddressMap;
@@ -34,6 +35,7 @@ namespace QuoteSwift
             mCustomerCellphoneNumberList = new BindingList<string>();
             mCustomerEmailList = new BindingList<string>();
             VendorNumber = "";
+            PreviousQuoteDate = "";
 
             mDeliveryAddressMap = new Dictionary<string, Address>();
             mPOBoxMap = new Dictionary<string, Address>();
@@ -108,6 +110,7 @@ namespace QuoteSwift
             }
 
             VendorNumber = c.VendorNumber;
+            PreviousQuoteDate = c.PreviousQuoteDate;
 
             mDeliveryAddressMap = new Dictionary<string, Address>();
             if (mCustomerDeliveryAddressList != null)
@@ -156,6 +159,11 @@ namespace QuoteSwift
         public HashSet<string> TelephoneNumbers => mTelephoneNumbers;
         public HashSet<string> CellphoneNumbers => mCellphoneNumbers;
         public HashSet<string> EmailAddresses => mEmailAddresses;
+        public string PreviousQuoteDate
+        {
+            get => mPreviousQuoteDate;
+            set => SetProperty(ref mPreviousQuoteDate, value);
+        }
 
         // helper methods to manage addresses while keeping the lookup collections in sync
         public void AddDeliveryAddress(Address address)

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -89,6 +89,10 @@ namespace QuoteSwift
                 Customers = new BindingList<Customer>(new List<Customer>(SelectedBusiness.BusinessCustomerList));
             else
                 Customers = new BindingList<Customer>();
+
+            if (Customers != null)
+                foreach (var c in Customers)
+                    c.PreviousQuoteDate = GetPreviousQuoteDate(c);
         }
 
         public Customer GetCustomer(string companyName)

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly ApplicationData appData;
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
+        readonly BindingSource customersBindingSource = new BindingSource();
         public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
@@ -19,6 +20,9 @@ namespace QuoteSwift
             this.serializationService = serializationService;
             this.appData = appData;
             this.messageService = messageService;
+            customersBindingSource.DataSource = viewModel;
+            customersBindingSource.DataMember = nameof(ViewCustomersViewModel.Customers);
+            DgvCustomerList.DataSource = customersBindingSource;
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -47,7 +51,6 @@ namespace QuoteSwift
             navigation.AddCustomer(container, customer, false);
 
             viewModel.RefreshCustomers();
-            RefreshBinding();
 
 
         }
@@ -59,16 +62,15 @@ namespace QuoteSwift
             Show();
 
             viewModel.RefreshCustomers();
-            RefreshBinding();
         }
 
         private void FrmViewCustomers_Load(object sender, EventArgs e)
         {
             viewModel.LoadData();
             LinkBusinessToSource(ref cbBusinessSelection);
-
-            RefreshBinding();
-
+            clmCustomerCompanyName.DataPropertyName = nameof(Customer.CustomerCompanyName);
+            clmPreviousQuoteDate.DataPropertyName = nameof(Customer.PreviousQuoteDate);
+            DgvCustomerList.AutoGenerateColumns = false;
             DgvCustomerList.RowsDefaultCellStyle.BackColor = Color.Bisque;
             DgvCustomerList.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
         }
@@ -82,8 +84,6 @@ namespace QuoteSwift
                 {
                     viewModel.RemoveCustomer(customer);
                     messageService.ShowInformation("Successfully deleted '" + customer.CustomerName + "' from the business list", "CONFIRMATION - Deletion Success");
-
-                    RefreshBinding();
                 }
             }
         }
@@ -95,16 +95,7 @@ namespace QuoteSwift
         *       and clutter free.                                                          
         */
 
-        void RefreshBinding()
-        {
-            DgvCustomerList.AutoGenerateColumns = false;
-            DgvCustomerList.DataSource = new BindingSource { DataSource = viewModel.Customers };
-            for (int i = 0; i < DgvCustomerList.Rows.Count; i++)
-            {
-                var cust = DgvCustomerList.Rows[i].DataBoundItem as Customer;
-                DgvCustomerList.Rows[i].Cells[clmPreviousQuoteDate.Name].Value = viewModel.GetPreviousQuoteDate(cust);
-            }
-        }
+        // Binding handled automatically via customersBindingSource
 
 
         private bool ReplaceCustomer(Customer Original, Customer New, Business Container)
@@ -150,7 +141,6 @@ namespace QuoteSwift
         private void CbBusinessSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
             viewModel.SelectBusiness(GetSelectedBusiness());
-            RefreshBinding();
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add PreviousQuoteDate property to Customer
- compute PreviousQuoteDate in `ViewCustomersViewModel.RefreshCustomers`
- bind customer grid with a BindingSource
- map columns in `FrmViewCustomers_Load`
- remove manual refresh code

## Testing
- `xbuild QuoteSwift.sln /target:Build /property:Configuration=Debug` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687e1afe806c8325947ca70188e2acae