### PR TITLE
Bind edit forms to view model properties

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -13,6 +13,17 @@ namespace QuoteSwift
             InitializeComponent();
             this.viewModel = viewModel;
             this.messageService = messageService;
+            SetupBindings();
+        }
+
+        void SetupBindings()
+        {
+            txtBusinessAddresssDescription.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.AddressDescription), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtStreetnumber.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.StreetNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtStreetName.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.StreetName), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtSuburb.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.Suburb), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtCity.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.City), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtAreaCode.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.AreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
@@ -24,29 +35,14 @@ namespace QuoteSwift
         {
             if (viewModel.Address != null)
             {
-                txtBusinessAddresssDescription.Text = viewModel.Address.AddressDescription;
-                mtxtStreetnumber.Text = viewModel.Address.AddressStreetNumber.ToString();
-                txtStreetName.Text = viewModel.Address.AddressStreetName;
-                txtSuburb.Text = viewModel.Address.AddressSuburb;
-                txtCity.Text = viewModel.Address.AddressCity;
-                mtxtAreaCode.Text = viewModel.Address.AddressAreaCode.ToString();
                 txtStreetName.Enabled = false;
             }
         }
 
         private void BtnUpdateAddress_Click(object sender, EventArgs e)
         {
-            Address updated = new Address
-            {
-                AddressDescription = txtBusinessAddresssDescription.Text,
-                AddressStreetNumber = ParsingService.ParseInt(mtxtStreetnumber.Text),
-                AddressStreetName = txtStreetName.Text,
-                AddressSuburb = txtSuburb.Text,
-                AddressCity = txtCity.Text,
-                AddressAreaCode = ParsingService.ParseInt(mtxtAreaCode.Text)
-            };
-
-            var result = viewModel.UpdateAddress(updated);
+            viewModel.UpdateAddressCommand.Execute(null);
+            var result = viewModel.LastResult;
             if (result.Success)
             {
                 messageService.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -14,12 +14,18 @@ namespace QuoteSwift
             InitializeComponent();
             this.viewModel = viewModel;
             this.messageService = messageService;
+            SetupBindings();
+        }
+
+        void SetupBindings()
+        {
+            mtxtEmail.DataBindings.Add("Text", viewModel, nameof(EditEmailAddressViewModel.CurrentEmail), false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
         private void BtnUpdateBusinessEmail_Click(object sender, EventArgs e)
         {
-            viewModel.CurrentEmail = mtxtEmail.Text;
-            var result = viewModel.UpdateEmail();
+            viewModel.UpdateEmailCommand.Execute(null);
+            var result = viewModel.LastResult;
             if (result.Success)
             {
                 messageService.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
@@ -31,8 +37,6 @@ namespace QuoteSwift
 
         private void FrmEditEmailAddress_Load(object sender, EventArgs e)
         {
-            mtxtEmail.Text = viewModel.CurrentEmail;
-
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -14,18 +14,22 @@ namespace QuoteSwift
             InitializeComponent();
             this.viewModel = viewModel;
             this.messageService = messageService;
+            SetupBindings();
+        }
+
+        void SetupBindings()
+        {
+            txtPhoneNumber.DataBindings.Add("Text", viewModel, nameof(EditPhoneNumberViewModel.CurrentNumber), false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
         private void FrmEditPhoneNumber_Load(object sender, EventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(viewModel.CurrentNumber))
-                txtPhoneNumber.Text = viewModel.CurrentNumber;
         }
 
         private void BtnUpdateNumber_Click(object sender, EventArgs e)
         {
-            viewModel.CurrentNumber = txtPhoneNumber.Text;
-            var result = viewModel.UpdateNumber();
+            viewModel.UpdateNumberCommand.Execute(null);
+            var result = viewModel.LastResult;
             if (result.Success)
             {
                 messageService.ShowInformation("The phone number was updated successfully.", "INFORMATION - Phone Number Updated Successfully");

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -8,6 +8,13 @@ namespace QuoteSwift
         readonly Business business;
         readonly Customer customer;
         readonly Address address;
+
+        string addressDescription = string.Empty;
+        int streetNumber;
+        string streetName = string.Empty;
+        string suburb = string.Empty;
+        string city = string.Empty;
+        int areaCode;
         OperationResult lastResult = OperationResult.Successful();
 
         public ICommand UpdateAddressCommand { get; }
@@ -25,15 +32,72 @@ namespace QuoteSwift
             }
         }
 
+        public string AddressDescription
+        {
+            get => addressDescription;
+            set => SetProperty(ref addressDescription, value);
+        }
+
+        public int StreetNumber
+        {
+            get => streetNumber;
+            set => SetProperty(ref streetNumber, value);
+        }
+
+        public string StreetName
+        {
+            get => streetName;
+            set => SetProperty(ref streetName, value);
+        }
+
+        public string Suburb
+        {
+            get => suburb;
+            set => SetProperty(ref suburb, value);
+        }
+
+        public string City
+        {
+            get => city;
+            set => SetProperty(ref city, value);
+        }
+
+        public int AreaCode
+        {
+            get => areaCode;
+            set => SetProperty(ref areaCode, value);
+        }
+
 
         public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null)
         {
             this.business = business;
             this.customer = customer;
             this.address = address;
-            UpdateAddressCommand = new RelayCommand(a =>
+
+            if (address != null)
             {
-                var r = UpdateAddress(a as Address);
+                AddressDescription = address.AddressDescription;
+                StreetNumber = address.AddressStreetNumber;
+                StreetName = address.AddressStreetName;
+                Suburb = address.AddressSuburb;
+                City = address.AddressCity;
+                AreaCode = address.AddressAreaCode;
+            }
+
+            UpdateAddressCommand = new RelayCommand(_ =>
+            {
+                var updated = new Address
+                {
+                    AddressDescription = AddressDescription,
+                    AddressStreetNumber = StreetNumber,
+                    AddressStreetName = StreetName,
+                    AddressSuburb = Suburb,
+                    AddressCity = City,
+                    AddressAreaCode = AreaCode
+                };
+
+                var r = UpdateAddress(updated);
                 LastResult = r;
             });
         }

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -9,6 +9,7 @@ namespace QuoteSwift
         readonly Customer customer;
         OperationResult lastResult = OperationResult.Successful();
         string originalEmail;
+        string currentEmail;
 
         public ICommand UpdateEmailCommand { get; }
 
@@ -39,7 +40,11 @@ namespace QuoteSwift
             }
         }
 
-        public string CurrentEmail { get; set; }
+        public string CurrentEmail
+        {
+            get => currentEmail;
+            set => SetProperty(ref currentEmail, value);
+        }
         public Business Business => business;
         public Customer Customer => customer;
         public string OriginalEmail => originalEmail;

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -9,6 +9,7 @@ namespace QuoteSwift
         readonly Customer customer;
         OperationResult lastResult = OperationResult.Successful();
         string originalNumber;
+        string currentNumber;
 
         public ICommand UpdateNumberCommand { get; }
 
@@ -42,7 +43,11 @@ namespace QuoteSwift
         public Business Business => business;
         public Customer Customer => customer;
         public string OriginalNumber => originalNumber;
-        public string CurrentNumber { get; set; }
+        public string CurrentNumber
+        {
+            get => currentNumber;
+            set => SetProperty(ref currentNumber, value);
+        }
 
         public OperationResult UpdateNumber()
         {


### PR DESCRIPTION
## Summary
- expose property setters in edit view models
- bind edit forms directly to view model properties
- execute view model commands from save buttons

## Testing
- `dotnet restore QuoteSwift.sln`
- `xbuild QuoteSwift.sln` *(fails: default XML namespace must be MSBuild namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687e21249a808325bdf802c4fffb60bd