### PR TITLE
Bind address lists to DataGridViews

### DIFF
--- a/FrmViewBusinessAddresses.Designer.cs
+++ b/FrmViewBusinessAddresses.Designer.cs
@@ -50,6 +50,7 @@ namespace QuoteSwift
             this.DgvViewAllBusinessAddresses.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.DgvViewAllBusinessAddresses.AutoGenerateColumns = false;
             this.DgvViewAllBusinessAddresses.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             this.DgvViewAllBusinessAddresses.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
             this.DgvViewAllBusinessAddresses.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -68,6 +69,7 @@ namespace QuoteSwift
             // 
             // ClmAddressDescription
             // 
+            this.ClmAddressDescription.DataPropertyName = "AddressDescription";
             this.ClmAddressDescription.HeaderText = "Address Description";
             this.ClmAddressDescription.Name = "ClmAddressDescription";
             this.ClmAddressDescription.ReadOnly = true;
@@ -75,6 +77,7 @@ namespace QuoteSwift
             // 
             // ClmStreetNumber
             // 
+            this.ClmStreetNumber.DataPropertyName = "AddressStreetNumber";
             this.ClmStreetNumber.HeaderText = "Street Number";
             this.ClmStreetNumber.Name = "ClmStreetNumber";
             this.ClmStreetNumber.ReadOnly = true;
@@ -82,6 +85,7 @@ namespace QuoteSwift
             // 
             // ClmStreetName
             // 
+            this.ClmStreetName.DataPropertyName = "AddressStreetName";
             this.ClmStreetName.HeaderText = "Street Name";
             this.ClmStreetName.Name = "ClmStreetName";
             this.ClmStreetName.ReadOnly = true;
@@ -89,6 +93,7 @@ namespace QuoteSwift
             // 
             // ClmSuburb
             // 
+            this.ClmSuburb.DataPropertyName = "AddressSuburb";
             this.ClmSuburb.HeaderText = "Suburb";
             this.ClmSuburb.Name = "ClmSuburb";
             this.ClmSuburb.ReadOnly = true;
@@ -96,6 +101,7 @@ namespace QuoteSwift
             // 
             // ClmCity
             // 
+            this.ClmCity.DataPropertyName = "AddressCity";
             this.ClmCity.HeaderText = "City";
             this.ClmCity.Name = "ClmCity";
             this.ClmCity.ReadOnly = true;
@@ -103,6 +109,7 @@ namespace QuoteSwift
             // 
             // ClmAreaCode
             // 
+            this.ClmAreaCode.DataPropertyName = "AddressAreaCode";
             this.ClmAreaCode.HeaderText = "Area Code";
             this.ClmAreaCode.Name = "ClmAreaCode";
             this.ClmAreaCode.ReadOnly = true;

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Drawing;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace QuoteSwift
@@ -15,6 +14,11 @@ namespace QuoteSwift
         readonly Business business;
         readonly Customer customer;
 
+        void SetupBindings()
+        {
+            DgvViewAllBusinessAddresses.DataSource = viewModel.Addresses;
+        }
+
         public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
@@ -24,6 +28,7 @@ namespace QuoteSwift
             this.messageService = messageService;
             this.business = business;
             this.customer = customer;
+            SetupBindings();
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -47,7 +52,6 @@ namespace QuoteSwift
                     BtnCancel.Enabled = true;
                 }
 
-                LoadInformation();
             }
             else if (customer != null && customer.CustomerDeliveryAddressList != null) //View Customer Address
             {
@@ -59,8 +63,9 @@ namespace QuoteSwift
                     BtnCancel.Enabled = true;
                 }
 
-                LoadInformation();
             }
+
+            viewModel.UpdateData(business, customer);
 
             DgvViewAllBusinessAddresses.RowsDefaultCellStyle.BackColor = Color.Bisque;
             DgvViewAllBusinessAddresses.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
@@ -82,7 +87,7 @@ namespace QuoteSwift
                 form.ShowDialog();
             }
 
-            LoadInformation();
+            viewModel.UpdateData(business, customer);
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
@@ -108,7 +113,7 @@ namespace QuoteSwift
                         messageService.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
                     }
 
-                    LoadInformation();
+                    viewModel.UpdateData(business, customer);
                 }
             }
             else
@@ -131,43 +136,7 @@ namespace QuoteSwift
 
         Address GetAddressSelection()
         {
-            if (DgvViewAllBusinessAddresses.CurrentCell == null || DgvViewAllBusinessAddresses.CurrentRow == null)
-                return null;
-
-            int iGridSelection = DgvViewAllBusinessAddresses.CurrentCell.RowIndex;
-            if (iGridSelection < 0 || iGridSelection >= DgvViewAllBusinessAddresses.Rows.Count)
-                return null;
-
-            string SearchName = DgvViewAllBusinessAddresses.Rows[iGridSelection].Cells[0].Value?.ToString();
-            if (string.IsNullOrEmpty(SearchName))
-                return null;
-
-            if (business != null && business.BusinessAddressList != null)
-            {
-                return business.BusinessAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-            }
-            else if (customer != null && customer.CustomerDeliveryAddressList != null)
-            {
-                return customer.CustomerDeliveryAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-            }
-
-            return null;
-        }
-
-        private void LoadInformation()
-        {
-            DgvViewAllBusinessAddresses.Rows.Clear();
-            if (business != null && business.BusinessAddressList != null)
-                for (int i = 0; i < business.BusinessAddressList.Count; i++)
-                    DgvViewAllBusinessAddresses.Rows.Add(business.BusinessAddressList[i].AddressDescription, business.BusinessAddressList[i].AddressStreetNumber,
-                                                         business.BusinessAddressList[i].AddressStreetName, business.BusinessAddressList[i].AddressSuburb,
-                                                         business.BusinessAddressList[i].AddressCity, business.BusinessAddressList[i].AddressAreaCode);
-
-            if (customer != null && customer.CustomerDeliveryAddressList != null)
-                for (int i = 0; i < customer.CustomerDeliveryAddressList.Count; i++)
-                    DgvViewAllBusinessAddresses.Rows.Add(customer.CustomerDeliveryAddressList[i].AddressDescription, customer.CustomerDeliveryAddressList[i].AddressStreetNumber,
-                                                         customer.CustomerDeliveryAddressList[i].AddressStreetName, customer.CustomerDeliveryAddressList[i].AddressSuburb,
-                                                         customer.CustomerDeliveryAddressList[i].AddressCity, customer.CustomerDeliveryAddressList[i].AddressAreaCode);
+            return DgvViewAllBusinessAddresses.CurrentRow?.DataBoundItem as Address;
         }
 
 

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -140,7 +140,7 @@ namespace QuoteSwift
         public void ViewBusinessesAddresses(Business business = null, Customer customer = null)
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
-            vm.LoadData();
+            vm.UpdateData(business, customer);
             using (var form = new FrmViewBusinessAddresses(vm, this, appData, business, customer, messageService))
             {
                 form.ShowDialog();
@@ -150,7 +150,7 @@ namespace QuoteSwift
         public void ViewBusinessesPOBoxAddresses(Business business = null, Customer customer = null)
         {
             var vm = new ViewPOBoxAddressesViewModel(dataService);
-            vm.LoadData();
+            vm.UpdateData(business, customer);
             using (var form = new FrmViewPOBoxAddresses(vm, this, appData, business, customer, messageService))
             {
                 form.ShowDialog();

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -1,31 +1,42 @@
 using System.ComponentModel;
-using System.Threading.Tasks;
 
 namespace QuoteSwift
 {
     public class ViewBusinessAddressesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
-        BindingList<Business> businesses;
+        readonly BindingList<Address> addresses = new BindingList<Address>();
+        Business business;
+        Customer customer;
         bool changeSpecificObject;
-        public ICommand LoadDataCommand { get; }
 
 
         public ViewBusinessAddressesViewModel(IDataService service)
         {
             dataService = service;
-            LoadDataCommand = new AsyncRelayCommand(_ => LoadDataAsync());
         }
 
         public IDataService DataService => dataService;
 
-        public BindingList<Business> Businesses
+        public BindingList<Address> Addresses => addresses;
+
+        public Business Business
         {
-            get => businesses;
+            get => business;
             private set
             {
-                businesses = value;
-                OnPropertyChanged(nameof(Businesses));
+                business = value;
+                OnPropertyChanged(nameof(Business));
+            }
+        }
+
+        public Customer Customer
+        {
+            get => customer;
+            private set
+            {
+                customer = value;
+                OnPropertyChanged(nameof(Customer));
             }
         }
 
@@ -45,14 +56,26 @@ namespace QuoteSwift
 
         public bool IsReadOnly => !changeSpecificObject;
 
-        public void LoadData()
+        public void UpdateData(Business business = null, Customer customer = null)
         {
-            LoadDataAsync().GetAwaiter().GetResult();
+            Business = business;
+            Customer = customer;
+            RefreshAddresses();
         }
 
-        public async Task LoadDataAsync()
+        void RefreshAddresses()
         {
-            Businesses = await dataService.LoadBusinessListAsync();
+            addresses.Clear();
+            if (Business != null && Business.BusinessAddressList != null)
+            {
+                foreach (var a in Business.BusinessAddressList)
+                    addresses.Add(a);
+            }
+            else if (Customer != null && Customer.CustomerDeliveryAddressList != null)
+            {
+                foreach (var a in Customer.CustomerDeliveryAddressList)
+                    addresses.Add(a);
+            }
         }
 
     }

--- a/ViewModels/ViewPOBoxAddressesViewModel.cs
+++ b/ViewModels/ViewPOBoxAddressesViewModel.cs
@@ -1,31 +1,42 @@
 using System.ComponentModel;
-using System.Threading.Tasks;
 
 namespace QuoteSwift
 {
     public class ViewPOBoxAddressesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
-        BindingList<Business> businesses;
+        readonly BindingList<Address> addresses = new BindingList<Address>();
+        Business business;
+        Customer customer;
         bool changeSpecificObject;
-        public ICommand LoadDataCommand { get; }
 
 
         public ViewPOBoxAddressesViewModel(IDataService service)
         {
             dataService = service;
-            LoadDataCommand = new AsyncRelayCommand(_ => LoadDataAsync());
         }
 
         public IDataService DataService => dataService;
 
-        public BindingList<Business> Businesses
+        public BindingList<Address> Addresses => addresses;
+
+        public Business Business
         {
-            get => businesses;
+            get => business;
             private set
             {
-                businesses = value;
-                OnPropertyChanged(nameof(Businesses));
+                business = value;
+                OnPropertyChanged(nameof(Business));
+            }
+        }
+
+        public Customer Customer
+        {
+            get => customer;
+            private set
+            {
+                customer = value;
+                OnPropertyChanged(nameof(Customer));
             }
         }
 
@@ -45,14 +56,26 @@ namespace QuoteSwift
 
         public bool IsReadOnly => !changeSpecificObject;
 
-        public void LoadData()
+        public void UpdateData(Business business = null, Customer customer = null)
         {
-            LoadDataAsync().GetAwaiter().GetResult();
+            Business = business;
+            Customer = customer;
+            RefreshAddresses();
         }
 
-        public async Task LoadDataAsync()
+        void RefreshAddresses()
         {
-            Businesses = await dataService.LoadBusinessListAsync();
+            addresses.Clear();
+            if (Business != null && Business.BusinessPOBoxAddressList != null)
+            {
+                foreach (var a in Business.BusinessPOBoxAddressList)
+                    addresses.Add(a);
+            }
+            else if (Customer != null && Customer.CustomerPOBoxAddress != null)
+            {
+                foreach (var a in Customer.CustomerPOBoxAddress)
+                    addresses.Add(a);
+            }
         }
 
     }

--- a/frmViewPOBoxAddresses.Designer.cs
+++ b/frmViewPOBoxAddresses.Designer.cs
@@ -68,6 +68,7 @@ namespace QuoteSwift
             this.dgvPOBoxAddresses.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.dgvPOBoxAddresses.AutoGenerateColumns = false;
             this.dgvPOBoxAddresses.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             this.dgvPOBoxAddresses.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
             this.dgvPOBoxAddresses.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -121,6 +122,7 @@ namespace QuoteSwift
             // 
             // clmDescription
             // 
+            this.clmDescription.DataPropertyName = "AddressDescription";
             this.clmDescription.HeaderText = "Address Description";
             this.clmDescription.Name = "clmDescription";
             this.clmDescription.ReadOnly = true;
@@ -128,6 +130,7 @@ namespace QuoteSwift
             // 
             // clmNumber
             // 
+            this.clmNumber.DataPropertyName = "AddressStreetNumber";
             this.clmNumber.HeaderText = "Street Number";
             this.clmNumber.Name = "clmNumber";
             this.clmNumber.ReadOnly = true;
@@ -135,6 +138,7 @@ namespace QuoteSwift
             // 
             // clmSuburb
             // 
+            this.clmSuburb.DataPropertyName = "AddressSuburb";
             this.clmSuburb.HeaderText = "Suburb";
             this.clmSuburb.Name = "clmSuburb";
             this.clmSuburb.ReadOnly = true;
@@ -142,6 +146,7 @@ namespace QuoteSwift
             // 
             // clmCity
             // 
+            this.clmCity.DataPropertyName = "AddressCity";
             this.clmCity.HeaderText = "City";
             this.clmCity.Name = "clmCity";
             this.clmCity.ReadOnly = true;
@@ -149,6 +154,7 @@ namespace QuoteSwift
             // 
             // clmAreaCode
             // 
+            this.clmAreaCode.DataPropertyName = "AddressAreaCode";
             this.clmAreaCode.HeaderText = "Area Code";
             this.clmAreaCode.Name = "clmAreaCode";
             this.clmAreaCode.ReadOnly = true;

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Drawing;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace QuoteSwift
@@ -15,6 +14,11 @@ namespace QuoteSwift
         readonly Business business;
         readonly Customer customer;
 
+        void SetupBindings()
+        {
+            dgvPOBoxAddresses.DataSource = viewModel.Addresses;
+        }
+
         public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
@@ -24,6 +28,7 @@ namespace QuoteSwift
             this.messageService = messageService;
             this.business = business;
             this.customer = customer;
+            SetupBindings();
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -53,7 +58,7 @@ namespace QuoteSwift
                         messageService.ShowInformation("Successfully deleted '" + SelectedAddress.AddressDescription + "' from the address list", "CONFIRMATION - Deletion Success");
                     }
 
-                    LoadInformation();
+                    viewModel.UpdateData(business, customer);
                 }
             }
             else
@@ -83,7 +88,7 @@ namespace QuoteSwift
                 form.ShowDialog();
             }
 
-            LoadInformation();
+            viewModel.UpdateData(business, customer);
         }
 
         void ApplyControlState()
@@ -103,7 +108,6 @@ namespace QuoteSwift
                     BtnCancel.Enabled = true;
                 }
 
-                LoadInformation();
             }
             else if (customer != null && customer.CustomerPOBoxAddress != null)
             {
@@ -115,8 +119,9 @@ namespace QuoteSwift
                     BtnCancel.Enabled = true;
                 }
 
-                LoadInformation();
             }
+
+            viewModel.UpdateData(business, customer);
 
             dgvPOBoxAddresses.RowsDefaultCellStyle.BackColor = Color.Bisque;
             dgvPOBoxAddresses.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
@@ -131,43 +136,7 @@ namespace QuoteSwift
 
         Address GetAddressSelection()
         {
-            if (dgvPOBoxAddresses.CurrentCell == null || dgvPOBoxAddresses.CurrentRow == null)
-                return null;
-
-            int iGridSelection = dgvPOBoxAddresses.CurrentCell.RowIndex;
-            if (iGridSelection < 0 || iGridSelection >= dgvPOBoxAddresses.Rows.Count)
-                return null;
-
-            string SearchName = dgvPOBoxAddresses.Rows[iGridSelection].Cells[0].Value?.ToString();
-            if (string.IsNullOrEmpty(SearchName))
-                return null;
-
-            if (business != null && business.BusinessPOBoxAddressList != null)
-            {
-                return business.BusinessPOBoxAddressList.SingleOrDefault(p => p.AddressDescription == SearchName);
-            }
-            else if (customer != null && customer.CustomerPOBoxAddress != null)
-            {
-                return customer.CustomerPOBoxAddress.SingleOrDefault(p => p.AddressDescription == SearchName);
-            }
-
-            return null;
-        }
-
-        void LoadInformation()
-        {
-            dgvPOBoxAddresses.Rows.Clear();
-            if (business != null && business.BusinessPOBoxAddressList != null)
-                for (int i = 0; i < business.BusinessPOBoxAddressList.Count; i++)
-                    dgvPOBoxAddresses.Rows.Add(business.BusinessPOBoxAddressList[i].AddressDescription, business.BusinessPOBoxAddressList[i].AddressStreetNumber,
-                                                         business.BusinessPOBoxAddressList[i].AddressSuburb, business.BusinessPOBoxAddressList[i].AddressCity,
-                                                         business.BusinessPOBoxAddressList[i].AddressAreaCode);
-
-            if (customer != null && customer.CustomerPOBoxAddress != null)
-                for (int i = 0; i < customer.CustomerPOBoxAddress.Count; i++)
-                    dgvPOBoxAddresses.Rows.Add(customer.CustomerPOBoxAddress[i].AddressDescription, customer.CustomerPOBoxAddress[i].AddressStreetNumber,
-                                                         customer.CustomerPOBoxAddress[i].AddressSuburb, customer.CustomerPOBoxAddress[i].AddressCity,
-                                                         customer.CustomerPOBoxAddress[i].AddressAreaCode);
+            return dgvPOBoxAddresses.CurrentRow?.DataBoundItem as Address;
         }
 
 


### PR DESCRIPTION
## Summary
- expose address lists from ViewBusinessAddressesViewModel and ViewPOBoxAddressesViewModel
- bind DataGridView controls in address forms to these lists
- refresh lists via UpdateData instead of manual row filling
- adjust NavigationService to use the new UpdateData APIs

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln -t:Build -p:Configuration=Release` *(fails: Assets file not found then Windows Forms reference missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e263cb2848325b7ec9fcd7d5835e1