### PR TITLE
Refactor forms to remove ApplicationData dependency

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -9,7 +9,6 @@ namespace QuoteSwift
 
         readonly ViewBusinessAddressesViewModel viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
         readonly Business business;
         readonly Customer customer;
@@ -28,12 +27,11 @@ namespace QuoteSwift
             CommandBindings.Bind(BtnRemoveSelected, viewModel.RemoveSelectedAddressCommand);
         }
 
-        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
+        public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            appData = data;
             this.messageService = messageService;
             this.business = business;
             this.customer = customer;
@@ -44,7 +42,7 @@ namespace QuoteSwift
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                appData.SaveAll();
+                navigation?.SaveAllData();
                 Application.Exit();
             }
         }
@@ -91,7 +89,7 @@ namespace QuoteSwift
             }
 
             var vm = new EditBusinessAddressViewModel(business, customer, address);
-            using (var form = new FrmEditBusinessAddress(vm, appData))
+            using (var form = new FrmEditBusinessAddress(vm, messageService))
             {
                 form.ShowDialog();
             }
@@ -130,7 +128,7 @@ namespace QuoteSwift
 
         private void FrmViewBusinessAddresses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            appData.SaveAll();
+            navigation?.SaveAllData();
         }
 
 

--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -21,5 +21,6 @@ namespace QuoteSwift
         void EditBusinessAddress(Business business = null, Customer customer = null, Address address = null);
         void EditBusinessEmailAddress(Business business = null, Customer customer = null, string email = "");
         void EditPhoneNumber(Business business = null, Customer customer = null, string number = "");
+        void SaveAllData();
     }
 }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -97,7 +97,7 @@ namespace QuoteSwift
         {
             var vm = new AddCustomerViewModel(dataService, notificationService);
             vm.UpdateData(appData.BusinessList, customerToChange, changeSpecificObject);
-            using (var form = new FrmAddCustomer(vm, this, appData, businessToChange, messageService, serializationService))
+            using (var form = new FrmAddCustomer(vm, this, businessToChange, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -119,7 +119,7 @@ namespace QuoteSwift
             var vm = new AddBusinessViewModel(dataService);
             vm.UpdateData(appData.BusinessList, businessToChange, changeSpecificObject);
             vm.LoadData();
-            using (var form = new FrmAddBusiness(vm, this, appData, messageService, serializationService))
+            using (var form = new FrmAddBusiness(vm, this, messageService, serializationService))
             {
                 form.ShowDialog();
             }
@@ -141,7 +141,7 @@ namespace QuoteSwift
         {
             var vm = new ViewBusinessAddressesViewModel(dataService);
             vm.UpdateData(business, customer);
-            using (var form = new FrmViewBusinessAddresses(vm, this, appData, business, customer, messageService))
+            using (var form = new FrmViewBusinessAddresses(vm, this, business, customer, messageService))
             {
                 form.ShowDialog();
             }
@@ -202,6 +202,11 @@ namespace QuoteSwift
             {
                 form.ShowDialog();
             }
+        }
+
+        public void SaveAllData()
+        {
+            appData.SaveAll();
         }
     }
 }

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -10,16 +10,14 @@ namespace QuoteSwift
 
         readonly AddBusinessViewModel viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
 
-        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            this.appData = appData;
             this.serializationService = serializationService;
             this.messageService = messageService;
 
@@ -30,11 +28,10 @@ namespace QuoteSwift
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
+            {
+                navigation?.SaveAllData();
+                Application.Exit();
+            }
         }
 
         private void BtnAddBusiness_Click(object sender, EventArgs e)
@@ -234,12 +231,7 @@ namespace QuoteSwift
 
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
         {
-            serializationService.CloseApplication(true,
-                appData?.BusinessList,
-                appData?.PumpList,
-                appData?.PartList,
-                appData?.QuoteMap);
-
+            navigation?.SaveAllData();
         }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -10,18 +10,16 @@ namespace QuoteSwift
 
         readonly AddCustomerViewModel viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
 
         Business Container;
 
-        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, Business container = null, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, Business container = null, IMessageService messageService = null, ISerializationService serializationService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            this.appData = appData;
             this.serializationService = serializationService;
             this.messageService = messageService;
             this.Container = container;
@@ -35,12 +33,9 @@ namespace QuoteSwift
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
-        }
+                navigation?.SaveAllData();
+                Application.Exit();
+            }
 
         private void BtnAddCustomer_Click(object sender, EventArgs e)
         {
@@ -233,13 +228,10 @@ namespace QuoteSwift
 
         private void FrmAddCustomer_FormClosing(object sender, FormClosingEventArgs e)
         {
-            serializationService.CloseApplication(true,
-                appData?.BusinessList,
-                appData?.PumpList,
-                appData?.PartList,
-                appData?.QuoteMap);
+            navigation?.SaveAllData();
+        }
 
-        /** Form Specific Functions And Procedures: 
+        /** Form Specific Functions And Procedures:
        *
        * Note: Not all Functions or Procedures below are used more than once
        *       Some of them are only to keep the above events readable 


### PR DESCRIPTION
## Summary
- update navigation interface with a `SaveAllData` helper
- implement `SaveAllData` in `NavigationService`
- refactor `FrmViewBusinessAddresses`, `frmAddBusiness`, and `frmAddCustomer` to use navigation for saving instead of `ApplicationData`

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Release` *(fails: default XML namespace of project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687e4257c17c832587006b3d0d9d6ab2