### PR TITLE
Refactor forms to use navigation service

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -88,11 +88,7 @@ namespace QuoteSwift
                 return;
             }
 
-            var vm = new EditBusinessAddressViewModel(business, customer, address);
-            using (var form = new FrmEditBusinessAddress(vm, messageService))
-            {
-                form.ShowDialog();
-            }
+            navigation?.EditBusinessAddress(business, customer, address);
 
             viewModel.UpdateData(business, customer);
         }

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -161,7 +161,7 @@ namespace QuoteSwift
         {
             var vm = new ManageEmailsViewModel(dataService);
             vm.UpdateData(business, customer);
-            using (var form = new FrmManageAllEmails(vm, messageService))
+            using (var form = new FrmManageAllEmails(vm, this, messageService))
             {
                 form.ShowDialog();
             }
@@ -171,7 +171,7 @@ namespace QuoteSwift
         {
             var vm = new ManagePhoneNumbersViewModel(dataService);
             vm.UpdateData(business, customer);
-            using (var form = new FrmManagingPhoneNumbers(vm, messageService))
+            using (var form = new FrmManagingPhoneNumbers(vm, this, messageService))
             {
                 form.ShowDialog();
             }

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -9,11 +9,13 @@ namespace QuoteSwift
 
         readonly ManageEmailsViewModel viewModel;
         readonly IMessageService messageService;
+        readonly INavigationService navigation;
 
-        public FrmManageAllEmails(ManageEmailsViewModel viewModel, IMessageService messageService = null)
+        public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
+            this.navigation = navigation;
             this.messageService = messageService;
             SetupBindings();
         }
@@ -66,11 +68,7 @@ namespace QuoteSwift
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
         {
             string email = viewModel.SelectedEmail?.Address ?? string.Empty;
-            var vm = new EditEmailAddressViewModel(viewModel.Business, viewModel.Customer, email);
-            using (var form = new FrmEditEmailAddress(vm, messageService))
-            {
-                form.ShowDialog();
-            }
+            navigation?.EditBusinessEmailAddress(viewModel.Business, viewModel.Customer, email);
         }
 
 

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -9,11 +9,13 @@ namespace QuoteSwift
 
         readonly ManagePhoneNumbersViewModel viewModel;
         readonly IMessageService messageService;
+        readonly INavigationService navigation;
 
-        public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, IMessageService messageService = null)
+        public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
+            this.navigation = navigation;
             this.messageService = messageService;
             SetupBindings();
         }
@@ -49,20 +51,12 @@ namespace QuoteSwift
             if (viewModel.Business != null && viewModel.Business.BusinessCellphoneNumberList != null)
             {
                 string oldNumber = viewModel.SelectedCellphoneNumber?.Number ?? string.Empty;
-                var vm = new EditPhoneNumberViewModel(viewModel.Business, null, oldNumber, messageService);
-                using (var form = new FrmEditPhoneNumber(vm, messageService))
-                {
-                    form.ShowDialog();
-                }
+                navigation?.EditPhoneNumber(viewModel.Business, null, oldNumber);
             }
             else if (viewModel.Customer != null && viewModel.Customer.CustomerCellphoneNumberList != null)
             {
                 string oldNumber = viewModel.SelectedCellphoneNumber?.Number ?? string.Empty;
-                var vm = new EditPhoneNumberViewModel(null, viewModel.Customer, oldNumber, messageService);
-                using (var form = new FrmEditPhoneNumber(vm, messageService))
-                {
-                    form.ShowDialog();
-                }
+                navigation?.EditPhoneNumber(null, viewModel.Customer, oldNumber);
             }
         }
 
@@ -71,20 +65,12 @@ namespace QuoteSwift
             if (viewModel.Business != null && viewModel.Business.BusinessTelephoneNumberList != null)
             {
                 string oldNumber = viewModel.SelectedTelephoneNumber?.Number ?? string.Empty;
-                var vm = new EditPhoneNumberViewModel(viewModel.Business, null, oldNumber, messageService);
-                using (var form = new FrmEditPhoneNumber(vm, messageService))
-                {
-                    form.ShowDialog();
-                }
+                navigation?.EditPhoneNumber(viewModel.Business, null, oldNumber);
             }
             else if (viewModel.Customer != null && viewModel.Customer.CustomerTelephoneNumberList != null)
             {
                 string oldNumber = viewModel.SelectedTelephoneNumber?.Number ?? string.Empty;
-                var vm = new EditPhoneNumberViewModel(null, viewModel.Customer, oldNumber, messageService);
-                using (var form = new FrmEditPhoneNumber(vm, messageService))
-                {
-                    form.ShowDialog();
-                }
+                navigation?.EditPhoneNumber(null, viewModel.Customer, oldNumber);
             }
         }
 

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -65,11 +65,7 @@ namespace QuoteSwift
                 return;
             }
 
-            var vm = new EditBusinessAddressViewModel(business, customer, address);
-            using (var form = new FrmEditBusinessAddress(vm, appData))
-            {
-                form.ShowDialog();
-            }
+            navigation?.EditBusinessAddress(business, customer, address);
 
             viewModel.UpdateData(business, customer);
         }


### PR DESCRIPTION
## Summary
- inject `INavigationService` into phone/email management forms
- call navigation methods instead of creating edit forms directly
- pass navigation service from `NavigationService` when opening management forms

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace of the project must be MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687e61fdba3483259c7e5701d897098c