### PR TITLE
Enable view-model driven read-only state

### DIFF
--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace QuoteSwift
@@ -37,11 +36,12 @@ namespace QuoteSwift
 
         void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(AddBusinessViewModel.IsEditing) ||
-                e.PropertyName == nameof(AddBusinessViewModel.IsReadOnly) ||
-                e.PropertyName == nameof(AddBusinessViewModel.ChangeSpecificObject))
+            if (e.PropertyName == nameof(AddBusinessViewModel.ChangeSpecificObject) ||
+                e.PropertyName == nameof(AddBusinessViewModel.BusinessToChange))
             {
-                ApplyControlState();
+                btnAddBusiness.Visible = viewModel.ChangeSpecificObject || viewModel.BusinessToChange == null;
+                btnAddBusiness.Text = viewModel.ChangeSpecificObject ? "Update Business" : "Add Business";
+                updateBusinessInformationToolStripMenuItem.Enabled = !viewModel.ChangeSpecificObject && viewModel.BusinessToChange != null;
             }
         }
 
@@ -119,7 +119,6 @@ namespace QuoteSwift
             if (viewModel.CurrentBusiness.BusinessLegalDetails == null)
                 viewModel.CurrentBusiness.BusinessLegalDetails = new Legal("", "");
             SetupBindings();
-            ApplyControlState();
         }
 
         private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
@@ -134,20 +133,6 @@ namespace QuoteSwift
 
 
 
-        void ApplyControlState()
-        {
-            bool ro = viewModel.IsReadOnly;
-            ControlStateHelper.ApplyReadOnly(gbxBusinessAddress.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxBusinessInformation.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxEmailRelated.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxLegalInformation.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxPhoneRelated.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxPOBoxAddress.Controls, ro);
-
-            btnAddBusiness.Visible = viewModel.ChangeSpecificObject || viewModel.BusinessToChange == null;
-            btnAddBusiness.Text = viewModel.ChangeSpecificObject ? "Update Business" : "Add Business";
-            updateBusinessInformationToolStripMenuItem.Enabled = !viewModel.ChangeSpecificObject && viewModel.BusinessToChange != null;
-        }
 
         private void SetupBindings()
         {
@@ -181,7 +166,13 @@ namespace QuoteSwift
 
             mtxtEmail.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.EmailInput), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            ApplyControlState();
+            gbxBusinessAddress.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxBusinessInformation.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxEmailRelated.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxLegalInformation.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxPhoneRelated.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxPOBoxAddress.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+
             CommandBindings.Bind(btnAddBusiness, viewModel.SaveBusinessCommand);
             CommandBindings.Bind(btnAddAddress, viewModel.AddAddressCommand);
             CommandBindings.Bind(btnAddPOBoxAddress, viewModel.AddPOBoxAddressCommand);

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace QuoteSwift
@@ -43,6 +42,13 @@ namespace QuoteSwift
             mtxtCellphoneNumber.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.CellphoneInput), false, DataSourceUpdateMode.OnPropertyChanged);
 
             mtxtEmailAddress.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.EmailInput), false, DataSourceUpdateMode.OnPropertyChanged);
+
+            gbxCustomerInformation.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxCustomerAddress.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxEmailRelated.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxLegalInformation.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxPhoneRelated.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxPOBoxAddress.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
 
             CommandBindings.Bind(btnAddCustomer, viewModel.SaveCustomerCommand);
             CommandBindings.Bind(btnAddAddress, viewModel.AddAddressCommand);
@@ -227,7 +233,6 @@ namespace QuoteSwift
         private void ConvertToViewOnly()
         {
             viewModel.ChangeSpecificObject = false;
-            ApplyControlState();
 
             btnViewAddresses.Enabled = true;
             btnViewAll.Enabled = true;
@@ -242,7 +247,6 @@ namespace QuoteSwift
         private void ConvertToEdit()
         {
             viewModel.ChangeSpecificObject = true;
-            ApplyControlState();
 
             btnAddCustomer.Visible = true;
             btnAddCustomer.Text = "Update Customer";
@@ -253,16 +257,6 @@ namespace QuoteSwift
             updatedCustomerInformationToolStripMenuItem.Enabled = false;
         }
 
-        void ApplyControlState()
-        {
-            bool ro = viewModel.IsReadOnly;
-            ControlStateHelper.ApplyReadOnly(gbxCustomerInformation.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxCustomerAddress.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxEmailRelated.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxLegalInformation.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxPhoneRelated.Controls, ro);
-            ControlStateHelper.ApplyReadOnly(gbxPOBoxAddress.Controls, ro);
-        }
 
 
 


### PR DESCRIPTION
## Summary
- bind GroupBox Enabled states to `IsEditing` on AddBusiness and AddCustomer forms
- update property change handler in `frmAddBusiness`
- remove `ControlStateHelper` use from AddBusiness and AddCustomer forms

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_687e93dfc1c88325a6be680e22c823b8