### PR TITLE
Add navigation commands to QuotesViewModel

### DIFF
--- a/Infrastructure/CommandBindings.cs
+++ b/Infrastructure/CommandBindings.cs
@@ -17,5 +17,18 @@ namespace QuoteSwift
                     command.Execute(null);
             };
         }
+
+        public static void Bind(ToolStripMenuItem item, ICommand command)
+        {
+            if (item == null || command == null)
+                return;
+            item.Enabled = command.CanExecute(null);
+            command.CanExecuteChanged += (s, e) => item.Enabled = command.CanExecute(null);
+            item.Click += (s, e) =>
+            {
+                if (command.CanExecute(null))
+                    command.Execute(null);
+            };
+        }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -33,7 +33,7 @@ namespace QuoteSwift
             var navigation = serviceProvider.GetRequiredService<INavigationService>();
             var messenger = serviceProvider.GetRequiredService<IMessageService>();
             var serializationService = serviceProvider.GetRequiredService<ISerializationService>();
-            QuotesViewModel viewModel = new QuotesViewModel(dataService);
+            QuotesViewModel viewModel = new QuotesViewModel(dataService, navigation, messenger);
             viewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
 
             Application.EnableVisualStyles();

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -32,7 +32,7 @@ namespace QuoteSwift
 
         public void ViewAllQuotes()
         {
-            var vm = new QuotesViewModel(dataService);
+            var vm = new QuotesViewModel(dataService, this, messageService);
             vm.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
             using (var form = new FrmViewQuotes(vm, this, messageService, serializationService))
             {

--- a/frmViewQuotes.Designer.cs
+++ b/frmViewQuotes.Designer.cs
@@ -83,21 +83,18 @@ namespace QuoteSwift
             this.manageBusinessesToolStripMenuItem.Name = "manageBusinessesToolStripMenuItem";
             this.manageBusinessesToolStripMenuItem.Size = new System.Drawing.Size(209, 24);
             this.manageBusinessesToolStripMenuItem.Text = "Manage Businesses";
-            this.manageBusinessesToolStripMenuItem.Click += new System.EventHandler(this.ManageBusinessesToolStripMenuItem_Click);
             // 
             // addNewBusinessToolStripMenuItem
             // 
             this.addNewBusinessToolStripMenuItem.Name = "addNewBusinessToolStripMenuItem";
             this.addNewBusinessToolStripMenuItem.Size = new System.Drawing.Size(205, 24);
             this.addNewBusinessToolStripMenuItem.Text = "Add New Business";
-            this.addNewBusinessToolStripMenuItem.Click += new System.EventHandler(this.AddNewBusinessToolStripMenuItem_Click);
             // 
             // ViewAllBusinessesToolStripMenuItem
             // 
             this.ViewAllBusinessesToolStripMenuItem.Name = "ViewAllBusinessesToolStripMenuItem";
             this.ViewAllBusinessesToolStripMenuItem.Size = new System.Drawing.Size(205, 24);
             this.ViewAllBusinessesToolStripMenuItem.Text = "View All Businesses";
-            this.ViewAllBusinessesToolStripMenuItem.Click += new System.EventHandler(this.ViewAllBusinessesToolStripMenuItem_Click);
             // 
             // manageCustomersToolStripMenuItem
             // 
@@ -107,21 +104,18 @@ namespace QuoteSwift
             this.manageCustomersToolStripMenuItem.Name = "manageCustomersToolStripMenuItem";
             this.manageCustomersToolStripMenuItem.Size = new System.Drawing.Size(209, 24);
             this.manageCustomersToolStripMenuItem.Text = "Manage Customers";
-            this.manageCustomersToolStripMenuItem.Click += new System.EventHandler(this.ManageCustomersToolStripMenuItem_Click);
             // 
             // addNewCustomerToolStripMenuItem
             // 
             this.addNewCustomerToolStripMenuItem.Name = "addNewCustomerToolStripMenuItem";
             this.addNewCustomerToolStripMenuItem.Size = new System.Drawing.Size(207, 24);
             this.addNewCustomerToolStripMenuItem.Text = "Add New Customer";
-            this.addNewCustomerToolStripMenuItem.Click += new System.EventHandler(this.AddNewCustomerToolStripMenuItem_Click);
             // 
             // viewAllCustomersToolStripMenuItem
             // 
             this.viewAllCustomersToolStripMenuItem.Name = "viewAllCustomersToolStripMenuItem";
             this.viewAllCustomersToolStripMenuItem.Size = new System.Drawing.Size(207, 24);
             this.viewAllCustomersToolStripMenuItem.Text = "View All Customers";
-            this.viewAllCustomersToolStripMenuItem.Click += new System.EventHandler(this.ViewAllCustomersToolStripMenuItem_Click);
             // 
             // managePumpsToolStripMenuItem
             // 
@@ -131,21 +125,18 @@ namespace QuoteSwift
             this.managePumpsToolStripMenuItem.Name = "managePumpsToolStripMenuItem";
             this.managePumpsToolStripMenuItem.Size = new System.Drawing.Size(209, 24);
             this.managePumpsToolStripMenuItem.Text = "Manage Pumps";
-            this.managePumpsToolStripMenuItem.Click += new System.EventHandler(this.ManagePumpsToolStripMenuItem_Click);
             // 
             // createNewPumpToolStripMenuItem
             // 
             this.createNewPumpToolStripMenuItem.Name = "createNewPumpToolStripMenuItem";
             this.createNewPumpToolStripMenuItem.Size = new System.Drawing.Size(197, 24);
             this.createNewPumpToolStripMenuItem.Text = "Create New Pump";
-            this.createNewPumpToolStripMenuItem.Click += new System.EventHandler(this.CreateNewPumpToolStripMenuItem_Click);
             // 
             // viewAllPumpsToolStripMenuItem
             // 
             this.viewAllPumpsToolStripMenuItem.Name = "viewAllPumpsToolStripMenuItem";
             this.viewAllPumpsToolStripMenuItem.Size = new System.Drawing.Size(197, 24);
             this.viewAllPumpsToolStripMenuItem.Text = "View All Pumps";
-            this.viewAllPumpsToolStripMenuItem.Click += new System.EventHandler(this.ViewAllPumpsToolStripMenuItem_Click);
             // 
             // managePumpPartsToolStripMenuItem
             // 
@@ -155,21 +146,18 @@ namespace QuoteSwift
             this.managePumpPartsToolStripMenuItem.Name = "managePumpPartsToolStripMenuItem";
             this.managePumpPartsToolStripMenuItem.Size = new System.Drawing.Size(209, 24);
             this.managePumpPartsToolStripMenuItem.Text = "Manage Pump Parts";
-            this.managePumpPartsToolStripMenuItem.Click += new System.EventHandler(this.ManagePumpPartsToolStripMenuItem_Click);
             // 
             // addNewPartToolStripMenuItem
             // 
             this.addNewPartToolStripMenuItem.Name = "addNewPartToolStripMenuItem";
             this.addNewPartToolStripMenuItem.Size = new System.Drawing.Size(169, 24);
             this.addNewPartToolStripMenuItem.Text = "Add New Part";
-            this.addNewPartToolStripMenuItem.Click += new System.EventHandler(this.AddNewPartToolStripMenuItem_Click);
             // 
             // viewAllPartsToolStripMenuItem
             // 
             this.viewAllPartsToolStripMenuItem.Name = "viewAllPartsToolStripMenuItem";
             this.viewAllPartsToolStripMenuItem.Size = new System.Drawing.Size(169, 24);
             this.viewAllPartsToolStripMenuItem.Text = "View All Parts";
-            this.viewAllPartsToolStripMenuItem.Click += new System.EventHandler(this.ViewAllPartsToolStripMenuItem_Click);
             // 
             // closeToolStripMenuItem
             // 
@@ -187,7 +175,6 @@ namespace QuoteSwift
             this.btnCreateNewQuote.TabIndex = 2;
             this.btnCreateNewQuote.Text = "Create New Quote";
             this.btnCreateNewQuote.UseVisualStyleBackColor = true;
-            this.btnCreateNewQuote.Click += new System.EventHandler(this.BtnCreateNewQuote_Click);
             // 
             // btnViewSelectedQuote
             // 
@@ -199,7 +186,6 @@ namespace QuoteSwift
             this.btnViewSelectedQuote.TabIndex = 4;
             this.btnViewSelectedQuote.Text = "View Selected Quote";
             this.btnViewSelectedQuote.UseVisualStyleBackColor = true;
-            this.btnViewSelectedQuote.Click += new System.EventHandler(this.BtnViewSelectedQuote_Click);
             // 
             // btnCreateNewQuoteOnSelection
             // 
@@ -211,7 +197,6 @@ namespace QuoteSwift
             this.btnCreateNewQuoteOnSelection.TabIndex = 5;
             this.btnCreateNewQuoteOnSelection.Text = "Create New Quote On Selection";
             this.btnCreateNewQuoteOnSelection.UseVisualStyleBackColor = true;
-            this.btnCreateNewQuoteOnSelection.Click += new System.EventHandler(this.BtnCreateNewQuoteOnSelection_Click);
             // 
             // dgvPreviousQuotes
             // 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Linq;
 using System.Windows.Forms;
-using System.Collections.Generic;
 
 namespace QuoteSwift
 {
@@ -24,31 +21,32 @@ namespace QuoteSwift
             this.messageService = messageService;
             quotesBindingSource.DataSource = viewModel.Quotes;
             dgvPreviousQuotes.DataSource = quotesBindingSource;
+            SetupBindings();
         }
 
-        private void BtnCreateNewQuote_Click(object sender, EventArgs e)
+        void SetupBindings()
         {
-            if (viewModel.BusinessList != null && viewModel.BusinessList.Count > 0 && viewModel.PumpList != null && viewModel.BusinessList[0].BusinessCustomerList != null)
-            {
-                Hide();
-                navigation.CreateNewQuote();
-                viewModel.LoadData();
-                try
-                {
-                    Show();
-                }
-                catch (Exception)
-                {
-                    // Do Nothing - Since this only happens when Application.Exit() is called.
-                }
-            }
-            else
-            {
-                messageService.ShowError("Please ensure that the following information is provided before creating a quote:\n" +
-                                          ">  Business Information.\n" +
-                                          ">  Business' Customer's Information.\n" +
-                                          ">  Pump Information.", "ERROR - Prerequisites Not Met");
-            }
+            SelectionBindings.BindSelectedItem(dgvPreviousQuotes, viewModel, nameof(QuotesViewModel.SelectedQuote));
+
+            CommandBindings.Bind(btnCreateNewQuote, viewModel.CreateQuoteCommand);
+            CommandBindings.Bind(btnViewSelectedQuote, viewModel.ViewQuoteCommand);
+            CommandBindings.Bind(btnCreateNewQuoteOnSelection, viewModel.CreateQuoteFromSelectionCommand);
+
+            CommandBindings.Bind(manageBusinessesToolStripMenuItem, viewModel.ViewBusinessesCommand);
+            CommandBindings.Bind(addNewBusinessToolStripMenuItem, viewModel.AddBusinessCommand);
+            CommandBindings.Bind(ViewAllBusinessesToolStripMenuItem, viewModel.ViewBusinessesCommand);
+
+            CommandBindings.Bind(manageCustomersToolStripMenuItem, viewModel.ViewCustomersCommand);
+            CommandBindings.Bind(addNewCustomerToolStripMenuItem, viewModel.AddCustomerCommand);
+            CommandBindings.Bind(viewAllCustomersToolStripMenuItem, viewModel.ViewCustomersCommand);
+
+            CommandBindings.Bind(managePumpsToolStripMenuItem, viewModel.ViewPumpsCommand);
+            CommandBindings.Bind(createNewPumpToolStripMenuItem, viewModel.CreatePumpCommand);
+            CommandBindings.Bind(viewAllPumpsToolStripMenuItem, viewModel.ViewPumpsCommand);
+
+            CommandBindings.Bind(managePumpPartsToolStripMenuItem, viewModel.ViewPartsCommand);
+            CommandBindings.Bind(addNewPartToolStripMenuItem, viewModel.AddPartCommand);
+            CommandBindings.Bind(viewAllPartsToolStripMenuItem, viewModel.ViewPartsCommand);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -60,187 +58,6 @@ namespace QuoteSwift
                     viewModel.PumpList,
                     viewModel.PartMap,
                     viewModel.QuoteMap);
-        }
-
-        private void ManagePumpsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.ViewAllPumps();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void CreateNewPumpToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.CreateNewPump();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void ViewAllPumpsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            managePumpsToolStripMenuItem.PerformClick();
-        }
-
-        private void AddNewCustomerToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.AddCustomer();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void ViewAllCustomersToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.ViewCustomers();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void ManageCustomersToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            viewAllCustomersToolStripMenuItem.PerformClick();
-        }
-
-        private void AddNewBusinessToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.AddBusiness();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void ViewAllBusinessesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.ViewBusinesses();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void ManageBusinessesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            ViewAllBusinessesToolStripMenuItem.PerformClick();
-        }
-
-        Quote GetSelectedQuote()
-        {
-            if (dgvPreviousQuotes.CurrentCell == null || dgvPreviousQuotes.CurrentRow == null)
-                return null;
-
-            int idx = dgvPreviousQuotes.CurrentCell.RowIndex;
-            if (idx < 0 || idx >= dgvPreviousQuotes.Rows.Count)
-                return null;
-
-            return dgvPreviousQuotes.Rows[idx].DataBoundItem as Quote;
-        }
-
-        private void BtnViewSelectedQuote_Click(object sender, EventArgs e)
-        {
-            if (viewModel.QuoteMap != null)
-            {
-                Quote selected = GetSelectedQuote();
-                if (selected != null)
-                {
-                    Hide();
-                    navigation.CreateNewQuote(selected, false);
-                    viewModel.LoadData();
-                    Show();
-                }
-            }
-        }
-
-        private void BtnCreateNewQuoteOnSelection_Click(object sender, EventArgs e)
-        {
-            if (viewModel.QuoteMap != null)
-            {
-                Quote selected = GetSelectedQuote();
-                if (selected != null)
-                {
-                    this.Hide();
-                    navigation.CreateNewQuote(selected, true);
-                    viewModel.LoadData();
-                    this.Show();
-                }
-            }
-        }
-
-        private void ViewAllPartsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.ViewAllParts();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
-            }
-        }
-
-        private void ManagePumpPartsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            viewAllPartsToolStripMenuItem.PerformClick();
-        }
-
-        private void AddNewPartToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.AddNewPart();
-            viewModel.LoadData();
-            try
-            {
-                Show();
-            }
-            catch (Exception)
-            {
-                // Do Nothing - Since this only happens when Application.Exit() is called.
             }
         }
 


### PR DESCRIPTION
## Summary
- inject navigation and messaging services into `QuotesViewModel`
- expose commands for creating/viewing quotes and navigating to other forms
- bind `FrmViewQuotes` controls to the new commands
- extend `CommandBindings` to support `ToolStripMenuItem`
- update program startup and navigation service for new constructor

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- `xbuild QuoteSwift.sln /nologo` *(fails: default XML namespace of project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687f5719d6d483259962f910a01e59bb