### PR TITLE
Refactor data logic into view models

### DIFF
--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -194,6 +194,24 @@ namespace QuoteSwift
             return true;
         }
 
+        public void RecordNewInformation()
+        {
+            if (PumpToChange == null || CurrentPump == null)
+                return;
+
+            if (PumpToChange.PumpName != CurrentPump.PumpName)
+                PumpToChange.PumpName = CurrentPump.PumpName;
+
+            if (PumpToChange.PumpDescription != CurrentPump.PumpDescription)
+                PumpToChange.PumpDescription = CurrentPump.PumpDescription;
+
+            if (PumpToChange.NewPumpPrice != CurrentPump.NewPumpPrice)
+                PumpToChange.NewPumpPrice = CurrentPump.NewPumpPrice;
+
+            PumpToChange.PartList = new BindingList<Pump_Part>(
+                SelectedMandatoryParts.Concat(SelectedNonMandatoryParts).ToList());
+        }
+
         public bool ValidateInput()
         {
             if (string.IsNullOrWhiteSpace(CurrentPump?.PumpName) || CurrentPump.PumpName.Length < 3)

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -132,18 +132,22 @@ namespace QuoteSwift
                             ? new BindingList<Customer>(new List<Customer>(selectedBusiness.BusinessCustomerList))
                             : new BindingList<Customer>();
                         SelectedCustomer = Customers.Count > 0 ? Customers[0] : null;
-                    }
-                    else
-                    {
-                        BusinessTelephoneNumbers = new BindingList<string>();
-                        BusinessCellphoneNumbers = new BindingList<string>();
+                        OnPropertyChanged(nameof(BusinessRegistrationNumberDisplay));
+                        OnPropertyChanged(nameof(BusinessVATNumberDisplay));
+                }
+                else
+                {
+                    BusinessTelephoneNumbers = new BindingList<string>();
+                    BusinessCellphoneNumbers = new BindingList<string>();
                         BusinessEmailAddresses = new BindingList<string>();
                         BusinessPOBoxes = new BindingList<Address>();
                         Customers = new BindingList<Customer>();
                         SelectedCustomer = null;
-                    }
+                        OnPropertyChanged(nameof(BusinessRegistrationNumberDisplay));
+                        OnPropertyChanged(nameof(BusinessVATNumberDisplay));
                 }
             }
+        }
         }
 
         public Customer SelectedCustomer
@@ -161,11 +165,15 @@ namespace QuoteSwift
                         CustomerPOBoxes = selectedCustomer.CustomerPOBoxAddress != null
                             ? new BindingList<Address>(new List<Address>(selectedCustomer.CustomerPOBoxAddress))
                             : new BindingList<Address>();
+                        CustomerVATNumber = selectedCustomer.CustomerLegalDetails?.VatNumber;
+                        OnPropertyChanged(nameof(CustomerVendorNumberDisplay));
                     }
                     else
                     {
                         CustomerDeliveryAddresses = new BindingList<Address>();
                         CustomerPOBoxes = new BindingList<Address>();
+                        CustomerVATNumber = string.Empty;
+                        OnPropertyChanged(nameof(CustomerVendorNumberDisplay));
                     }
                 }
             }
@@ -361,19 +369,46 @@ namespace QuoteSwift
         public Address SelectedBusinessPOBox
         {
             get => selectedBusinessPOBox;
-            set => SetProperty(ref selectedBusinessPOBox, value);
+            set
+            {
+                if (SetProperty(ref selectedBusinessPOBox, value))
+                {
+                    OnPropertyChanged(nameof(BusinessPOBoxNumberDisplay));
+                    OnPropertyChanged(nameof(BusinessPOBoxSuburbDisplay));
+                    OnPropertyChanged(nameof(BusinessPOBoxCityDisplay));
+                    OnPropertyChanged(nameof(BusinessPOBoxAreaCodeDisplay));
+                }
+            }
         }
 
         public Address SelectedCustomerPOBox
         {
             get => selectedCustomerPOBox;
-            set => SetProperty(ref selectedCustomerPOBox, value);
+            set
+            {
+                if (SetProperty(ref selectedCustomerPOBox, value))
+                {
+                    OnPropertyChanged(nameof(CustomerPOBoxStreetNameDisplay));
+                    OnPropertyChanged(nameof(CustomerPOBoxSuburbDisplay));
+                    OnPropertyChanged(nameof(CustomerPOBoxCityDisplay));
+                    OnPropertyChanged(nameof(CustomerPOBoxAreaCodeDisplay));
+                }
+            }
         }
 
         public Address SelectedCustomerDeliveryAddress
         {
             get => selectedCustomerDeliveryAddress;
-            set => SetProperty(ref selectedCustomerDeliveryAddress, value);
+            set
+            {
+                if (SetProperty(ref selectedCustomerDeliveryAddress, value))
+                {
+                    CustomerDeliveryDescription = value != null ?
+                        $"ATT: {value.AddressStreetName}\n{value.AddressSuburb}\n{value.AddressCity}" :
+                        string.Empty;
+                    OnPropertyChanged(nameof(CustomerDeliveryAddressDisplay));
+                }
+            }
         }
 
         public string BusinessTelephone
@@ -417,6 +452,55 @@ namespace QuoteSwift
             get => paymentTerm;
             set => SetProperty(ref paymentTerm, value);
         }
+
+        public string BusinessPOBoxNumberDisplay =>
+            SelectedBusinessPOBox != null ?
+                $"P.O.Box Number {SelectedBusinessPOBox.AddressStreetNumber}" : string.Empty;
+
+        public string BusinessPOBoxSuburbDisplay =>
+            SelectedBusinessPOBox != null ?
+                $"Suburb: {SelectedBusinessPOBox.AddressSuburb}" : string.Empty;
+
+        public string BusinessPOBoxCityDisplay =>
+            SelectedBusinessPOBox != null ?
+                $"City: {SelectedBusinessPOBox.AddressCity}" : string.Empty;
+
+        public string BusinessPOBoxAreaCodeDisplay =>
+            SelectedBusinessPOBox != null ?
+                $"Area Code: {SelectedBusinessPOBox.AddressAreaCode}" : string.Empty;
+
+        public string CustomerPOBoxStreetNameDisplay =>
+            SelectedCustomerPOBox != null ?
+                $"P.O.Box Number {SelectedCustomerPOBox.AddressStreetNumber}" : string.Empty;
+
+        public string CustomerPOBoxSuburbDisplay =>
+            SelectedCustomerPOBox != null ?
+                $"Suburb: {SelectedCustomerPOBox.AddressSuburb}" : string.Empty;
+
+        public string CustomerPOBoxCityDisplay =>
+            SelectedCustomerPOBox != null ?
+                $"City: {SelectedCustomerPOBox.AddressCity}" : string.Empty;
+
+        public string CustomerPOBoxAreaCodeDisplay =>
+            SelectedCustomerPOBox != null ?
+                $"Area Code: {SelectedCustomerPOBox.AddressAreaCode}" : string.Empty;
+
+        public string BusinessRegistrationNumberDisplay =>
+            SelectedBusiness != null ?
+                $"Registration Number: {SelectedBusiness.BusinessLegalDetails.RegistrationNumber}" : string.Empty;
+
+        public string BusinessVATNumberDisplay =>
+            SelectedBusiness != null ?
+                $"VAT Number: {SelectedBusiness.BusinessLegalDetails.VatNumber}" : string.Empty;
+
+        public string CustomerVendorNumberDisplay =>
+            SelectedCustomer != null ?
+                $"Vendor Number: {SelectedCustomer.VendorNumber}" : string.Empty;
+
+        public string CustomerDeliveryAddressDisplay =>
+            SelectedCustomerDeliveryAddress != null ?
+                $"ATT: {SelectedCustomerDeliveryAddress.AddressStreetName}\n{SelectedCustomerDeliveryAddress.AddressSuburb}\n{SelectedCustomerDeliveryAddress.AddressCity}" :
+                string.Empty;
 
         public void LoadData()
         {

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -194,17 +194,6 @@ namespace QuoteSwift
                 }
         }
 
-        void RecordNewInformation()
-        {
-            if (mtxtPumpName.Text != viewModel.PumpToChange.PumpName) viewModel.PumpToChange.PumpName = mtxtPumpName.Text;
-
-            if (mtxtPumpDescription.Text != viewModel.PumpToChange.PumpDescription) viewModel.PumpToChange.PumpDescription = mtxtPumpDescription.Text;
-
-            if (NewPumpValueInput() != viewModel.PumpToChange.NewPumpPrice) viewModel.PumpToChange.NewPumpPrice = NewPumpValueInput();
-
-            viewModel.PumpToChange.PartList = new BindingList<Pump_Part>(viewModel.SelectedMandatoryParts.Concat(viewModel.SelectedNonMandatoryParts).ToList());
-        }
-
         decimal NewPumpValueInput()
         {
             decimal.TryParse(mtxtNewPumpPrice.Text, out decimal TempNewPumpPrice);

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -122,10 +122,6 @@ namespace QuoteSwift
                 mandatorySource.DataSource = viewModel.MandatoryParts;
                 nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
                 UpdatePricingDisplay();
-                LoadBusinessPOBoxAddress();
-                LoadBusinessLegalDatails();
-                LoadCustomerDeliveryAddress();
-                LoadCustomerPOBoxAddress();
                 if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
                     viewModel.QuoteNumber = viewModel.NextQuoteNumber;
 
@@ -152,26 +148,18 @@ namespace QuoteSwift
 
         private void CbxCustomerSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LoadCustomerDetails();
-            LoadCustomerPOBoxAddress();
         }
 
         private void CbxBusinessSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LoadSelectedBusinessInformation();
-            LoadBusinessPOBoxAddress();
-            LoadBusinessLegalDatails();
-            LoadCustomerPOBoxAddress();
         }
 
         private void CbxPOBoxSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LoadBusinessPOBoxAddress();
         }
 
         private void CbxCustomerDeliveryAddress_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LoadCustomerDeliveryAddress();
         }
 
         private void DgvMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
@@ -190,11 +178,7 @@ namespace QuoteSwift
 
 
 
-        void LoadSelectedBusinessInformation()
-        {
-            LoadBusinessPOBoxAddress();
-            LoadBusinessLegalDatails();
-        }
+
 
         private void SetupBindings()
         {
@@ -273,6 +257,19 @@ namespace QuoteSwift
             cbxBusinessCellphoneNumberSelection.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessCellphone), false, DataSourceUpdateMode.OnPropertyChanged);
             cbxBusinessEmailAddressSelection.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessEmail), false, DataSourceUpdateMode.OnPropertyChanged);
 
+            lblBusinessPOBoxNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblBusinessPOBoxSuburb.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxSuburbDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblBusinessPOBoxCity.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxCityDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblBusinessPOBoxAreaCode.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxAreaCodeDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblBusinessRegistrationNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessRegistrationNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblBusinessVATNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessVATNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+
+            lblCustomerPOBoxStreetName.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxStreetNameDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblCustomerPOBoxSuburb.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxSuburbDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblCustomerPOBoxCity.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxCityDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblCustomerPOBoxAreaCode.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxAreaCodeDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            lblCustomerVendorNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerVendorNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+
             CbxPOBoxSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedBusinessPOBox), false, DataSourceUpdateMode.OnPropertyChanged);
             CbxCustomerPOBoxSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedCustomerPOBox), false, DataSourceUpdateMode.OnPropertyChanged);
             cbxCustomerDeliveryAddress.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedCustomerDeliveryAddress), false, DataSourceUpdateMode.OnPropertyChanged);
@@ -309,59 +306,8 @@ namespace QuoteSwift
             dtpPaymentTerm.Value = dtpQuoteCreationDate.Value.AddMonths(1);
         }
 
-        private void LoadBusinessPOBoxAddress()
-        {
-            Address Selection = viewModel.SelectedBusinessPOBox;
-            if (Selection != null)
-            {
-                lblBusinessPOBoxNumber.Text = "Street Name: " + Selection.AddressStreetName;
-                lblBusinessPOBoxNumber.Text = "P.O.Box Number " + Selection.AddressStreetNumber.ToString();
-                lblBusinessPOBoxSuburb.Text = "Suburb: " + Selection.AddressSuburb;
-                lblBusinessPOBoxCity.Text = "City: " + Selection.AddressCity;
-                lblBusinessPOBoxAreaCode.Text = "Area Code: " + Selection.AddressAreaCode.ToString();
-            }
-        }
-        private void LoadCustomerPOBoxAddress()
-        {
-            Address Selection = viewModel.SelectedCustomerPOBox;
-            if (Selection != null)
-            {
-                lblCustomerPOBoxStreetName.Text = "P.O.Box Number " + Selection.AddressStreetNumber.ToString();
-                lblCustomerPOBoxSuburb.Text = "Suburb: " + Selection.AddressSuburb;
-                lblCustomerPOBoxCity.Text = "City: " + Selection.AddressCity;
-                lblCustomerPOBoxAreaCode.Text = "Area Code: " + Selection.AddressAreaCode.ToString();
-            }
-        }
-
-        private void LoadBusinessLegalDatails()
-        {
-            Business Selection = viewModel.SelectedBusiness;
-            lblBusinessRegistrationNumber.Text = "Registration Number: " + Selection.BusinessLegalDetails.RegistrationNumber;
-            lblBusinessVATNumber.Text = "VAT Number: " + Selection.BusinessLegalDetails.VatNumber;
-        }
-
-        private void LoadCustomerDeliveryAddress()
-        {
-            Address Selection = viewModel.SelectedCustomerDeliveryAddress;
-            if (Selection != null)
-            {
-                rtxCustomerDeliveryDescripton.Clear();
-                rtxCustomerDeliveryDescripton.Text = "ATT: " + Selection.AddressStreetName.ToString() +
-                                                     "\n" + Selection.AddressSuburb +
-                                                     "\n" + Selection.AddressCity;
-            }
-        }
-
-        private void LoadCustomerDetails()
-        {
-            LoadCustomerDeliveryAddress();
-            lblCustomerVendorNumber.Text = "Vendor Number: " + viewModel.SelectedCustomer.VendorNumber;
-            txtCustomerVATNumber.Text = viewModel.SelectedCustomer.CustomerLegalDetails.VatNumber;
-        }
-
         private void CbxCustomerPOBoxSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LoadCustomerPOBoxAddress();
         }
 
 
@@ -419,10 +365,6 @@ namespace QuoteSwift
             mandatorySource.DataSource = viewModel.MandatoryParts;
             nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
             UpdatePricingDisplay();
-            LoadBusinessPOBoxAddress();
-            LoadBusinessLegalDatails();
-            LoadCustomerPOBoxAddress();
-            LoadCustomerDeliveryAddress();
         }
 
         private void ConvertToReadOnly()


### PR DESCRIPTION
## Summary
- moved pump update helper to `AddPumpViewModel`
- exposed PO box, legal and delivery info via properties in `CreateQuoteViewModel`
- removed old data loader logic from forms and bound labels directly to view models

## Testing
- `dotnet build QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f82a116e08325aa84f9cd9079612a