### PR TITLE
Refactor serialization helpers

### DIFF
--- a/MainProgramLibrary/MainProgramCode.cs
+++ b/MainProgramLibrary/MainProgramCode.cs
@@ -1,22 +1,12 @@
 using System;
-using System.Windows.Forms;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Globalization;
-
-using Newtonsoft.Json;
-using System.Text;
 using System.Collections.Generic;
-
+using System.Linq;
 
 namespace QuoteSwift
 {
     public static class MainProgramCode
     {
         //Get Last Quote
-
         public static Quote GetLastQuote(SortedDictionary<string, Quote> quotes)
         {
             if (quotes != null && quotes.Count > 0)
@@ -39,372 +29,9 @@ namespace QuoteSwift
             return null;
         }
 
-        /** Serialization Methods: */
-
-        //Read file into byte Array
-
-        public static byte[] RetreiveData(string FileName)
-        {
-            string StorePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\" + FileName;
-            byte[] Data = null;
-            try
-            {
-                Data = File.ReadAllBytes(StorePath);
-                return Data;
-            }
-            catch (FileNotFoundException)
-            {
-            }
-            catch
-            {
-                throw;
-            }
-
-            return null;
-        }
-
-
-        //Store Byte Array to Directory
-
-        public static bool SaveData(string FileName, byte[] StoreData)
-        {
-            string StorePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\" + FileName;
-
-            try
-            {
-                if (File.Exists(StorePath)) File.Delete(StorePath);
-                BinaryWriter FileWriter = new BinaryWriter(File.OpenWrite(StorePath));
-                FileWriter.Write(StoreData);
-                FileWriter.Flush();
-                FileWriter.Close();
-            }
-            catch
-            {
-                return false;
-            }
-            return true;
-        }
-
-        // Serialize to JSON
-
-        public static byte[] JsonSerialize<T>(T record) where T : class
-        {
-            if (record == null) return null;
-
-            try
-            {
-                string json = JsonConvert.SerializeObject(record);
-                return Encoding.UTF8.GetBytes(json);
-            }
-            catch
-            {
-                throw;
-            }
-        }
-
-        // De-serialize from JSON
-
-        public static T JsonDeserialize<T>(byte[] data) where T : class
-        {
-            if (data == null) return null;
-
-            try
-            {
-                string json = Encoding.UTF8.GetString(data);
-                return JsonConvert.DeserializeObject<T>(json);
-            }
-            catch
-            {
-                throw;
-            }
-        }
-
-        //Serialize Part list:
-
-        public static byte[] SerializePartListData(Dictionary<string, Part> PartList)
-        {
-            byte[] tempByte;
-            try
-            {
-                tempByte = MainProgramCode.JsonSerialize<Dictionary<string, Part>>(PartList);
-            }
-            catch
-            {
-                throw;
-            }
-
-            return tempByte;
-        }
-
-        //De-serialize Part list:
-
-        public static Dictionary<string, Part> DeserializePartList(byte[] tempByte)
-        {
-            try
-            {
-                return MainProgramCode.JsonDeserialize<Dictionary<string, Part>>(tempByte);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Serialize and store Part List
-
-        public static void SerializePartList(Dictionary<string, Part> partList)
-        {
-            if (partList != null && partList.Count > 0)
-            {
-                byte[] ToStore = MainProgramCode.SerializePartListData(partList);
-                MainProgramCode.SaveData("Parts.json", ToStore);
-            }
-        }
-
-        // Serialize Pump List Method
-
-        public static byte[] SerializePumpListData(BindingList<Pump> PumpPartList)
-        {
-            byte[] tempByte;
-            try
-            {
-                tempByte = MainProgramCode.JsonSerialize<BindingList<Pump>>(PumpPartList);
-            }
-            catch
-            {
-                throw;
-            }
-
-            return tempByte;
-        }
-
-        // De-serialize Pump List Method
-
-        public static BindingList<Pump> DeserializePumpList(byte[] tempByte)
-        {
-            try
-            {
-                return MainProgramCode.JsonDeserialize<BindingList<Pump>>(tempByte);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Serialize and store Pump List
-
-        public static void SerializePumpList(BindingList<Pump> pumpList)
-        {
-            if (pumpList != null && pumpList.Count > 0)
-            {
-                byte[] ToStore = MainProgramCode.SerializePumpListData(pumpList);
-                MainProgramCode.SaveData("PumpList.json", ToStore);
-            }
-        }
-
-
-        // Serialize Business List Method
-
-        public static byte[] SerializeBusinessListData(BindingList<Business> BusinessList)
-        {
-            byte[] tempByte;
-            try
-            {
-                tempByte = MainProgramCode.JsonSerialize<BindingList<Business>>(BusinessList);
-            }
-            catch
-            {
-                throw;
-            }
-
-            return tempByte;
-        }
-
-        // De-serialize Business List Method
-
-        public static BindingList<Business> DeserializeBusinessList(byte[] tempByte)
-        {
-            try
-            {
-                return MainProgramCode.JsonDeserialize<BindingList<Business>>(tempByte);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Serialize and store Business List
-
-        public static void SerializeBusinessList(BindingList<Business> businessList)
-        {
-            if (businessList != null && businessList.Count > 0)
-            {
-                byte[] ToStore = MainProgramCode.SerializeBusinessListData(businessList);
-                MainProgramCode.SaveData("BusinessList.json", ToStore);
-            }
-        }
-
-        // Serialize Quote List Method
-
-        public static byte[] SerializeQuoteListData(SortedDictionary<string, Quote> QuoteList)
-        {
-            byte[] tempByte;
-            try
-            {
-                tempByte = MainProgramCode.JsonSerialize<SortedDictionary<string, Quote>>(QuoteList);
-            }
-            catch
-            {
-                throw;
-            }
-
-            return tempByte;
-        }
-
-        // De-serialize Quote List Method
-
-        public static SortedDictionary<string, Quote> DeserializeQuoteList(byte[] tempByte)
-        {
-            try
-            {
-                return MainProgramCode.JsonDeserialize<SortedDictionary<string, Quote>>(tempByte);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Serialize and store Quote List
-
-        public static void SerializeQuoteList(SortedDictionary<string, Quote> quoteList)
-        {
-            if (quoteList != null && quoteList.Count > 0)
-            {
-                byte[] ToStore = MainProgramCode.SerializeQuoteListData(quoteList);
-                MainProgramCode.SaveData("QuoteList.json", ToStore);
-            }
-        }
-
-        // Serialize Quote To Export
-
-        public static void ExportQuote(ref Quote q)
-        {
-            if (q != null)
-            {
-                byte[] tempByte;
-                try
-                {
-                    tempByte = MainProgramCode.JsonSerialize<Quote>(q);
-                }
-                catch
-                {
-                    throw;
-                }
-                MainProgramCode.SaveData("ExportToExcel\\ExportQuote.json", tempByte);
-            }
-        }
-
-        // De-serialize Quote To Export To Excel
-
-        /****************************************************/
-
-        public static Quote DeserializeQuote(byte[] tempByte)
-        {
-            try
-            {
-                return JsonDeserialize<Quote>(tempByte);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        // Export pump and part inventory to CSV
-        public static void ExportInventory(BindingList<Pump> pumpList, string filePath)
-        {
-            if (filePath == null)
-                throw new ArgumentNullException(nameof(filePath));
-
-            using (var writer = new StreamWriter(filePath, false, Encoding.UTF8))
-            {
-                writer.WriteLine("PumpName,PumpDescription,PumpPrice,PartOriginalNumber,PartName,PartDescription,PartNewNumber,PartPrice,Mandatory,Quantity");
-
-                if (pumpList != null)
-                {
-                    foreach (var pump in pumpList)
-                    {
-                        if (pump.PartList == null) continue;
-                        foreach (var pp in pump.PartList)
-                        {
-                            var part = pp.PumpPart;
-                            writer.WriteLine(string.Join(",",
-                                CsvEscape(pump.PumpName),
-                                CsvEscape(pump.PumpDescription),
-                                pump.NewPumpPrice.ToString(CultureInfo.InvariantCulture),
-                                CsvEscape(part?.OriginalItemPartNumber),
-                                CsvEscape(part?.PartName),
-                                CsvEscape(part?.PartDescription),
-                                CsvEscape(part?.NewPartNumber),
-                                part?.PartPrice.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-                                part?.MandatoryPart.ToString() ?? string.Empty,
-                                pp.PumpPartQuantity.ToString(CultureInfo.InvariantCulture)));
-                        }
-                    }
-                }
-            }
-        }
-
-        private static string CsvEscape(string value)
-        {
-            if (string.IsNullOrEmpty(value)) return string.Empty;
-            if (value.Contains("\"")) value = value.Replace("\"", "\"\"");
-            if (value.Contains(",") || value.Contains("\n") || value.Contains("\r"))
-                return $"\"{value}\"";
-            return value;
-        }
-
-        
-
-
-
-        //Procedure Handling The Closing Of The Application
-        public static void CloseApplication(bool exitApp,
-            BindingList<Business> businessList,
-            BindingList<Pump> pumpList,
-            Dictionary<string, Part> partList,
-            SortedDictionary<string, Quote> quoteList)
-        {
-            if (exitApp)
-            {
-                try
-                {
-                    SerializePartList(partList);
-                    SerializePumpList(pumpList);
-                    SerializeBusinessList(businessList);
-                    SerializeQuoteList(quoteList);
-                }
-                catch (Exception ex)
-                {
-                    while (ex != null)
-                    {
-                        ex = ex.InnerException;
-                    }
-                }
-                finally
-                {
-                    Application.Exit();
-                }
-            }
-        }
-
         /** Parse String Inputs: */
 
         // Parse Float:
-
         public static float ParseFloat(string t)
         {
             float.TryParse(t, out float temp);
@@ -412,7 +39,6 @@ namespace QuoteSwift
         }
 
         // Parse Decimal:
-
         public static decimal ParseDecimal(string t)
         {
             decimal.TryParse(t, out decimal temp);
@@ -420,7 +46,6 @@ namespace QuoteSwift
         }
 
         // Parse Boole:
-
         public static bool ParseBoolean(string t)
         {
             bool.TryParse(t, out bool temp);
@@ -428,13 +53,11 @@ namespace QuoteSwift
         }
 
         // Parse Int:
-
         public static int ParseInt(string t)
         {
             int.TryParse(t, out int temp);
             return temp;
         }
-
 
         /*************************/
 

--- a/Services/FileDataService.cs
+++ b/Services/FileDataService.cs
@@ -9,9 +9,11 @@ namespace QuoteSwift
     public class FileDataService : IDataService
     {
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
 
-        public FileDataService(IMessageService messenger = null)
+        public FileDataService(ISerializationService serializer, IMessageService messenger = null)
         {
+            serializationService = serializer;
             messageService = messenger;
         }
 
@@ -23,7 +25,7 @@ namespace QuoteSwift
         public async Task<Dictionary<string, Part>> LoadPartListAsync()
         {
             byte[] bytes = await RetrieveDataAsync("Parts.json").ConfigureAwait(false);
-            return bytes != null && bytes.Length > 0 ? MainProgramCode.DeserializePartList(bytes) : new Dictionary<string, Part>();
+            return bytes != null && bytes.Length > 0 ? FileSerializationService.DeserializePartList(bytes) : new Dictionary<string, Part>();
         }
 
         public BindingList<Pump> LoadPumpList()
@@ -34,7 +36,7 @@ namespace QuoteSwift
         public async Task<BindingList<Pump>> LoadPumpListAsync()
         {
             byte[] bytes = await RetrieveDataAsync("PumpList.json").ConfigureAwait(false);
-            return bytes != null && bytes.Length > 0 ? new BindingList<Pump>(MainProgramCode.DeserializePumpList(bytes)) : new BindingList<Pump>();
+            return bytes != null && bytes.Length > 0 ? new BindingList<Pump>(FileSerializationService.DeserializePumpList(bytes)) : new BindingList<Pump>();
         }
 
         public BindingList<Business> LoadBusinessList()
@@ -45,7 +47,7 @@ namespace QuoteSwift
         public async Task<BindingList<Business>> LoadBusinessListAsync()
         {
             byte[] bytes = await RetrieveDataAsync("BusinessList.json").ConfigureAwait(false);
-            return bytes != null && bytes.Length > 0 ? new BindingList<Business>(MainProgramCode.DeserializeBusinessList(bytes)) : new BindingList<Business>();
+            return bytes != null && bytes.Length > 0 ? new BindingList<Business>(FileSerializationService.DeserializeBusinessList(bytes)) : new BindingList<Business>();
         }
 
         public SortedDictionary<string, Quote> LoadQuoteMap()
@@ -56,27 +58,27 @@ namespace QuoteSwift
         public async Task<SortedDictionary<string, Quote>> LoadQuoteMapAsync()
         {
             byte[] bytes = await RetrieveDataAsync("QuoteList.json").ConfigureAwait(false);
-            return bytes != null && bytes.Length > 0 ? MainProgramCode.DeserializeQuoteList(bytes) : new SortedDictionary<string, Quote>();
+            return bytes != null && bytes.Length > 0 ? FileSerializationService.DeserializeQuoteList(bytes) : new SortedDictionary<string, Quote>();
         }
 
         public void SaveParts(Dictionary<string, Part> parts)
         {
-            MainProgramCode.SerializePartList(parts);
+            serializationService.SerializePartList(parts);
         }
 
         public void SavePumps(BindingList<Pump> pumps)
         {
-            MainProgramCode.SerializePumpList(pumps);
+            serializationService.SerializePumpList(pumps);
         }
 
         public void SaveBusinesses(BindingList<Business> businesses)
         {
-            MainProgramCode.SerializeBusinessList(businesses);
+            serializationService.SerializeBusinessList(businesses);
         }
 
         public void SaveQuotes(SortedDictionary<string, Quote> quotes)
         {
-            MainProgramCode.SerializeQuoteList(quotes);
+            serializationService.SerializeQuoteList(quotes);
         }
 
         byte[] RetrieveData(string fileName)

--- a/Services/FileSerializationService.cs
+++ b/Services/FileSerializationService.cs
@@ -1,5 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Windows.Forms;
+using Newtonsoft.Json;
 
 namespace QuoteSwift
 {
@@ -7,27 +14,43 @@ namespace QuoteSwift
     {
         public void SerializePartList(Dictionary<string, Part> partList)
         {
-            MainProgramCode.SerializePartList(partList);
+            if (partList != null && partList.Count > 0)
+            {
+                byte[] data = SerializePartListData(partList);
+                SaveData("Parts.json", data);
+            }
         }
 
         public void SerializePumpList(BindingList<Pump> pumpList)
         {
-            MainProgramCode.SerializePumpList(pumpList);
+            if (pumpList != null && pumpList.Count > 0)
+            {
+                byte[] data = SerializePumpListData(pumpList);
+                SaveData("PumpList.json", data);
+            }
         }
 
         public void SerializeBusinessList(BindingList<Business> businessList)
         {
-            MainProgramCode.SerializeBusinessList(businessList);
+            if (businessList != null && businessList.Count > 0)
+            {
+                byte[] data = SerializeBusinessListData(businessList);
+                SaveData("BusinessList.json", data);
+            }
         }
 
         public void SerializeQuoteList(SortedDictionary<string, Quote> quoteList)
         {
-            MainProgramCode.SerializeQuoteList(quoteList);
+            if (quoteList != null && quoteList.Count > 0)
+            {
+                byte[] data = SerializeQuoteListData(quoteList);
+                SaveData("QuoteList.json", data);
+            }
         }
 
         public void ExportInventory(BindingList<Pump> pumpList, string filePath)
         {
-            MainProgramCode.ExportInventory(pumpList, filePath);
+            ExportInventoryCsv(pumpList, filePath);
         }
 
         public void CloseApplication(bool exitApp,
@@ -36,7 +59,176 @@ namespace QuoteSwift
             Dictionary<string, Part> partList,
             SortedDictionary<string, Quote> quoteList)
         {
-            MainProgramCode.CloseApplication(exitApp, businessList, pumpList, partList, quoteList);
+            if (exitApp)
+            {
+                try
+                {
+                    SerializePartList(partList);
+                    SerializePumpList(pumpList);
+                    SerializeBusinessList(businessList);
+                    SerializeQuoteList(quoteList);
+                }
+                catch (Exception ex)
+                {
+                    while (ex != null)
+                    {
+                        ex = ex.InnerException;
+                    }
+                }
+                finally
+                {
+                    Application.Exit();
+                }
+            }
+        }
+
+        // Static helpers
+        public static byte[] SerializePartListData(Dictionary<string, Part> list)
+        {
+            return JsonSerialize(list);
+        }
+
+        public static Dictionary<string, Part> DeserializePartList(byte[] data)
+        {
+            return JsonDeserialize<Dictionary<string, Part>>(data);
+        }
+
+        public static byte[] SerializePumpListData(BindingList<Pump> list)
+        {
+            return JsonSerialize(list);
+        }
+
+        public static BindingList<Pump> DeserializePumpList(byte[] data)
+        {
+            return JsonDeserialize<BindingList<Pump>>(data);
+        }
+
+        public static byte[] SerializeBusinessListData(BindingList<Business> list)
+        {
+            return JsonSerialize(list);
+        }
+
+        public static BindingList<Business> DeserializeBusinessList(byte[] data)
+        {
+            return JsonDeserialize<BindingList<Business>>(data);
+        }
+
+        public static byte[] SerializeQuoteListData(SortedDictionary<string, Quote> list)
+        {
+            return JsonSerialize(list);
+        }
+
+        public static SortedDictionary<string, Quote> DeserializeQuoteList(byte[] data)
+        {
+            return JsonDeserialize<SortedDictionary<string, Quote>>(data);
+        }
+
+        public static void ExportInventoryCsv(BindingList<Pump> pumpList, string filePath)
+        {
+            if (filePath == null)
+                throw new ArgumentNullException(nameof(filePath));
+
+            using (var writer = new StreamWriter(filePath, false, Encoding.UTF8))
+            {
+                writer.WriteLine("PumpName,PumpDescription,PumpPrice,PartOriginalNumber,PartName,PartDescription,PartNewNumber,PartPrice,Mandatory,Quantity");
+
+                if (pumpList != null)
+                {
+                    foreach (var pump in pumpList)
+                    {
+                        if (pump.PartList == null) continue;
+                        foreach (var pp in pump.PartList)
+                        {
+                            var part = pp.PumpPart;
+                            writer.WriteLine(string.Join(",",
+                                CsvEscape(pump.PumpName),
+                                CsvEscape(pump.PumpDescription),
+                                pump.NewPumpPrice.ToString(CultureInfo.InvariantCulture),
+                                CsvEscape(part?.OriginalItemPartNumber),
+                                CsvEscape(part?.PartName),
+                                CsvEscape(part?.PartDescription),
+                                CsvEscape(part?.NewPartNumber),
+                                part?.PartPrice.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+                                part?.MandatoryPart.ToString() ?? string.Empty,
+                                pp.PumpPartQuantity.ToString(CultureInfo.InvariantCulture)));
+                        }
+                    }
+                }
+            }
+        }
+
+        static string CsvEscape(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+            if (value.Contains("\"")) value = value.Replace("\"", "\"\"");
+            if (value.Contains(",") || value.Contains("\n") || value.Contains("\r"))
+                return $"\"{value}\"";
+            return value;
+        }
+
+        public static bool SaveData(string fileName, byte[] data)
+        {
+            string storePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\" + fileName;
+
+            try
+            {
+                if (File.Exists(storePath)) File.Delete(storePath);
+                using (BinaryWriter writer = new BinaryWriter(File.OpenWrite(storePath)))
+                {
+                    writer.Write(data);
+                    writer.Flush();
+                }
+            }
+            catch
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public static byte[] RetrieveData(string fileName)
+        {
+            string storePath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\" + fileName;
+            try
+            {
+                return File.ReadAllBytes(storePath);
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch
+            {
+                throw;
+            }
+            return null;
+        }
+
+        public static byte[] JsonSerialize<T>(T record) where T : class
+        {
+            if (record == null) return null;
+            try
+            {
+                string json = JsonConvert.SerializeObject(record);
+                return Encoding.UTF8.GetBytes(json);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        public static T JsonDeserialize<T>(byte[] data) where T : class
+        {
+            if (data == null) return null;
+            try
+            {
+                string json = Encoding.UTF8.GetString(data);
+                return JsonConvert.DeserializeObject<T>(json);
+            }
+            catch
+            {
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- centralize JSON helper functions and CSV export logic in `FileSerializationService`
- update `FileDataService` to depend on `ISerializationService`
- simplify `MainProgramCode` to only domain utilities

## Testing
- `msbuild QuoteSwift.sln /t:Build /p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f87f369188325ac005d640189a6ec