### PR TITLE
Move quote creation to view model

### DIFF
--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -871,6 +871,43 @@ namespace QuoteSwift
             return true;
         }
 
+        public Quote CreateAndSaveQuote()
+        {
+            if (!ValidateInput())
+                return null;
+
+            Calculate();
+
+            var quote = CreateQuote(QuoteNumber,
+                                     QuoteCreationDate,
+                                     QuoteExpiryDate,
+                                     ReferenceNumber,
+                                     JobNumber,
+                                     PRNumber,
+                                     PaymentTerm,
+                                     SelectedBusinessPOBox,
+                                     SelectedCustomerPOBox,
+                                     LineNumber,
+                                     BusinessTelephone,
+                                     BusinessCellphone,
+                                     BusinessEmail,
+                                     (int)(PaymentTerm.Subtract(QuoteCreationDate).TotalDays),
+                                     Pricing);
+
+            if (quote == null)
+                return null;
+
+            if (!AddQuote(quote))
+            {
+                notificationService?.ShowError(
+                    "The provided quote number or Job number has been used in a previous quote.\nPlease ensure that the provided details are indeed correct.",
+                    "ERROR - Quote Number or Job Number Already Exists.");
+                return null;
+            }
+
+            return quote;
+        }
+
         public void ExportQuoteToTemplate(Quote quote)
         {
             excelExportService.ExportQuoteToExcel(quote);

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -47,28 +47,28 @@ namespace QuoteSwift
             }
             else
             {
-                NewQuote = CreateQuote();
-
+                viewModel.Pricing.Rebate = ParsingService.ParseDecimal(mtxtRebate.Text);
+                NewQuote = viewModel.CreateAndSaveQuote();
 
                 if (NewQuote != null)
                 {
-                    if (!viewModel.AddQuote(NewQuote))
-                    {
-                        messageService.ShowError("The provided quote number or Job number has been used in a previous quote.\nPlease ensure that the provided details are indeed correct.", "ERROR - Quote Number or Job Number Already Exists.");
-                        return;
-                    }
-
                     if (messageService.RequestConfirmation("The quote was successfully created. Would you like to export the quote an Excel document?", "REQUEST - Export Quote to Excel"))
                     {
                         ExportQuoteToTemplate(NewQuote);
                     }
-                    else messageService.ShowInformation("The quote was successfully added to the list of quotes.", "INFORMATION - Quote Added To List");
+                    else
+                    {
+                        messageService.ShowInformation("The quote was successfully added to the list of quotes.", "INFORMATION - Quote Added To List");
+                    }
 
                     quoteToChange = NewQuote;
                     ConvertToReadOnly();
                     createNewQuoteUsingThisQuoteToolStripMenuItem.Enabled = true;
                 }
-                else messageService.ShowError("The Quote could not be created successfully.", "ERROR - Quote Creation Unsuccessful");
+                else
+                {
+                    messageService.ShowError("The Quote could not be created successfully.", "ERROR - Quote Creation Unsuccessful");
+                }
             }
         }
 
@@ -325,31 +325,6 @@ namespace QuoteSwift
             }
         }
 
-        Quote CreateQuote()
-        {
-            if (!viewModel.ValidateInput()) return null;
-
-            viewModel.Pricing.Rebate = ParsingService.ParseDecimal(mtxtRebate.Text);
-            viewModel.Calculate();
-
-            var quote = viewModel.CreateQuote(viewModel.QuoteNumber,
-                                               viewModel.QuoteCreationDate,
-                                               viewModel.QuoteExpiryDate,
-                                               viewModel.ReferenceNumber,
-                                               viewModel.JobNumber,
-                                               viewModel.PRNumber,
-                                               viewModel.PaymentTerm,
-                                               viewModel.SelectedBusinessPOBox,
-                                               viewModel.SelectedCustomerPOBox,
-                                               viewModel.LineNumber,
-                                               viewModel.BusinessTelephone,
-                                               viewModel.BusinessCellphone,
-                                               viewModel.BusinessEmail,
-                                               (int)(viewModel.PaymentTerm.Subtract(viewModel.QuoteCreationDate).TotalDays),
-                                               viewModel.Pricing);
-
-            return quote;
-        }
 
         private void ExportQuoteToTemplate(Quote q)
         {


### PR DESCRIPTION
## Summary
- encapsulate quote creation logic in `CreateQuoteViewModel.CreateAndSaveQuote`
- simplify `FrmCreateQuote.BtnComplete_Click` to use the new method
- remove old private `CreateQuote` helper from the form

## Testing
- `msbuild QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687faa1d33808325b1a1192e3d1249b9