### PR TITLE
Introduce file dialog service

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,7 @@ namespace QuoteSwift
             services.AddSingleton<ISerializationService, FileSerializationService>();
             services.AddSingleton<IDataService, FileDataService>();
             services.AddSingleton<INotificationService, MessageBoxNotificationService>();
+            services.AddSingleton<IFileDialogService, FileDialogService>();
             services.AddSingleton<ApplicationData>();
             services.AddSingleton<IExcelExportService, FileExcelExportService>();
             services.AddSingleton<INavigationService, NavigationService>();

--- a/Services/FileDialogService.cs
+++ b/Services/FileDialogService.cs
@@ -1,0 +1,18 @@
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    public class FileDialogService : IFileDialogService
+    {
+        public string ShowSaveFileDialog(string filter, string defaultExt, string fileName)
+        {
+            using (SaveFileDialog sfd = new SaveFileDialog())
+            {
+                sfd.Filter = filter;
+                sfd.DefaultExt = defaultExt;
+                sfd.FileName = fileName;
+                return sfd.ShowDialog() == DialogResult.OK ? sfd.FileName : null;
+            }
+        }
+    }
+}

--- a/Services/IFileDialogService.cs
+++ b/Services/IFileDialogService.cs
@@ -1,0 +1,7 @@
+namespace QuoteSwift
+{
+    public interface IFileDialogService
+    {
+        string ShowSaveFileDialog(string filter, string defaultExt, string fileName);
+    }
+}

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -10,8 +10,9 @@ namespace QuoteSwift
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
         readonly IExcelExportService excelExportService;
+        readonly IFileDialogService fileDialogService;
 
-        public NavigationService(ApplicationData data, IDataService service, INotificationService notifier, IMessageService messenger, ISerializationService serializer, IExcelExportService excelExporter)
+        public NavigationService(ApplicationData data, IDataService service, INotificationService notifier, IMessageService messenger, ISerializationService serializer, IExcelExportService excelExporter, IFileDialogService dialogService)
         {
             dataService = service;
             appData = data;
@@ -19,6 +20,7 @@ namespace QuoteSwift
             notificationService = notifier;
             messageService = messenger;
             excelExportService = excelExporter;
+            fileDialogService = dialogService;
         }
 
         public void CreateNewQuote(Quote quoteToChange = null, bool changeSpecificObject = false)
@@ -47,7 +49,7 @@ namespace QuoteSwift
 
         public void ViewAllPumps()
         {
-            var vm = new ViewPumpViewModel(dataService, serializationService, this, messageService);
+            var vm = new ViewPumpViewModel(dataService, serializationService, this, messageService, fileDialogService);
             vm.UpdateData(appData.PumpList);
             using (var form = new FrmViewPump(vm, this, messageService))
             {


### PR DESCRIPTION
## Summary
- abstract save dialogs behind `IFileDialogService`
- use `FileDialogService` in export operations
- register the new service on startup
- update view model and navigation to support the service

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: reference assemblies for .NET Framework v4.8 missing)*

------
https://chatgpt.com/codex/tasks/task_e_687faa1b9b288325b6728d8a9bf8dcb5