### PR TITLE
Convert LoadData wrappers to async

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -64,7 +64,7 @@ namespace QuoteSwift
         {
             var vm = serviceProvider.GetRequiredService<AddPumpViewModel>();
             vm.UpdateData(appData.PumpList, appData.PartList);
-            vm.LoadData();
+            vm.LoadDataAsync().GetAwaiter().GetResult();
             using (var form = new FrmAddPump(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
@@ -112,7 +112,7 @@ namespace QuoteSwift
         public void ViewCustomers()
         {
             var vm = serviceProvider.GetRequiredService<ViewCustomersViewModel>();
-            vm.LoadData();
+            vm.LoadDataAsync().GetAwaiter().GetResult();
             using (var form = new FrmViewCustomers(vm, this, appData, messageService, serializationService))
             {
                 form.ShowDialog();
@@ -123,7 +123,7 @@ namespace QuoteSwift
         {
             var vm = serviceProvider.GetRequiredService<AddBusinessViewModel>();
             vm.UpdateData(appData.BusinessList, businessToChange, changeSpecificObject);
-            vm.LoadData();
+            vm.LoadDataAsync().GetAwaiter().GetResult();
             using (var form = new FrmAddBusiness(vm, this, messageService, serializationService))
             {
                 form.ShowDialog();

--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -407,11 +407,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             BusinessList = await dataService.LoadBusinessListAsync();

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -390,11 +390,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             BusinessList = await dataService.LoadBusinessListAsync();

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -198,11 +198,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             PartMap = await dataService.LoadPartListAsync();

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -119,11 +119,6 @@ namespace QuoteSwift
 
         public BindingList<Pump_Part> SelectedNonMandatoryParts { get; }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             PumpList = await dataService.LoadPumpListAsync();

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -502,11 +502,6 @@ namespace QuoteSwift
                 $"ATT: {SelectedCustomerDeliveryAddress.AddressStreetName}\n{SelectedCustomerDeliveryAddress.AddressSuburb}\n{SelectedCustomerDeliveryAddress.AddressCity}" :
                 string.Empty;
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             PartList = await dataService.LoadPartListAsync();

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -44,17 +44,17 @@ namespace QuoteSwift
 
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
 
-            CreateQuoteCommand = new RelayCommand(_ => CreateQuote());
-            ViewQuoteCommand = new RelayCommand(_ => ViewQuote(), _ => SelectedQuote != null);
-            CreateQuoteFromSelectionCommand = new RelayCommand(_ => CreateQuoteFromSelection(), _ => SelectedQuote != null);
-            AddBusinessCommand = new RelayCommand(_ => { navigation?.AddBusiness(); LoadData(); });
-            ViewBusinessesCommand = new RelayCommand(_ => { navigation?.ViewBusinesses(); LoadData(); });
-            AddCustomerCommand = new RelayCommand(_ => { navigation?.AddCustomer(); LoadData(); });
-            ViewCustomersCommand = new RelayCommand(_ => { navigation?.ViewCustomers(); LoadData(); });
-            CreatePumpCommand = new RelayCommand(_ => { navigation?.CreateNewPump(); LoadData(); });
-            ViewPumpsCommand = new RelayCommand(_ => { navigation?.ViewAllPumps(); LoadData(); });
-            AddPartCommand = new RelayCommand(_ => { navigation?.AddNewPart(); LoadData(); });
-            ViewPartsCommand = new RelayCommand(_ => { navigation?.ViewAllParts(); LoadData(); });
+            CreateQuoteCommand = new AsyncRelayCommand(_ => CreateQuoteAsync());
+            ViewQuoteCommand = new AsyncRelayCommand(_ => ViewQuoteAsync(), _ => Task.FromResult(SelectedQuote != null));
+            CreateQuoteFromSelectionCommand = new AsyncRelayCommand(_ => CreateQuoteFromSelectionAsync(), _ => Task.FromResult(SelectedQuote != null));
+            AddBusinessCommand = new AsyncRelayCommand(async _ => { navigation?.AddBusiness(); await LoadDataAsync(); });
+            ViewBusinessesCommand = new AsyncRelayCommand(async _ => { navigation?.ViewBusinesses(); await LoadDataAsync(); });
+            AddCustomerCommand = new AsyncRelayCommand(async _ => { navigation?.AddCustomer(); await LoadDataAsync(); });
+            ViewCustomersCommand = new AsyncRelayCommand(async _ => { navigation?.ViewCustomers(); await LoadDataAsync(); });
+            CreatePumpCommand = new AsyncRelayCommand(async _ => { navigation?.CreateNewPump(); await LoadDataAsync(); });
+            ViewPumpsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllPumps(); await LoadDataAsync(); });
+            AddPartCommand = new AsyncRelayCommand(async _ => { navigation?.AddNewPart(); await LoadDataAsync(); });
+            ViewPartsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllParts(); await LoadDataAsync(); });
         }
 
 
@@ -121,11 +121,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             PartMap = await dataService.LoadPartListAsync();
@@ -160,12 +155,12 @@ namespace QuoteSwift
                 dataService.SaveParts(PartMap);
         }
 
-        void CreateQuote()
+        async Task CreateQuoteAsync()
         {
             if (BusinessList != null && BusinessList.Count > 0 && PumpList != null && BusinessList[0].BusinessCustomerList != null)
             {
                 navigation?.CreateNewQuote();
-                LoadData();
+                await LoadDataAsync();
             }
             else
             {
@@ -178,21 +173,21 @@ namespace QuoteSwift
             }
         }
 
-        void ViewQuote()
+        async Task ViewQuoteAsync()
         {
             if (SelectedQuote != null)
             {
                 navigation?.CreateNewQuote(SelectedQuote, false);
-                LoadData();
+                await LoadDataAsync();
             }
         }
 
-        void CreateQuoteFromSelection()
+        async Task CreateQuoteFromSelectionAsync()
         {
             if (SelectedQuote != null)
             {
                 navigation?.CreateNewQuote(SelectedQuote, true);
-                LoadData();
+                await LoadDataAsync();
             }
         }
 

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -29,11 +29,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             Businesses = await dataService.LoadBusinessListAsync();

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -62,11 +62,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             Businesses = await dataService.LoadBusinessListAsync();

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -30,8 +30,8 @@ namespace QuoteSwift
             nonMandatoryParts = new BindingList<Part>();
             allParts = new BindingList<Part>();
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
-            AddPartCommand = new RelayCommand(_ => AddPart());
-            UpdatePartCommand = new RelayCommand(_ => UpdatePart(), _ => SelectedPart != null);
+            AddPartCommand = new AsyncRelayCommand(_ => AddPartAsync());
+            UpdatePartCommand = new AsyncRelayCommand(_ => UpdatePartAsync(), _ => Task.FromResult(SelectedPart != null));
             RemovePartCommand = new RelayCommand(_ => RemoveSelectedPart(), _ => SelectedPart != null);
             SaveChangesCommand = new RelayCommand(_ => SaveChanges());
         }
@@ -67,11 +67,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             PartList = await dataService.LoadPartListAsync();
@@ -98,18 +93,18 @@ namespace QuoteSwift
             allParts.Remove(part);
         }
 
-        void AddPart()
+        async Task AddPartAsync()
         {
             navigation?.AddNewPart();
-            LoadData();
+            await LoadDataAsync();
         }
 
-        void UpdatePart()
+        async Task UpdatePartAsync()
         {
             if (SelectedPart != null)
             {
                 navigation?.AddNewPart(SelectedPart, false);
-                LoadData();
+                await LoadDataAsync();
             }
         }
 

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -77,11 +77,6 @@ namespace QuoteSwift
             }
         }
 
-        public void LoadData()
-        {
-            LoadDataAsync().GetAwaiter().GetResult();
-        }
-
         public async Task LoadDataAsync()
         {
             Pumps = await dataService.LoadPumpListAsync();

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -70,9 +70,9 @@ namespace QuoteSwift
             viewModel.ViewPhoneNumbersCommand.Execute(null);
         }
 
-        private void FrmAddBusiness_Load(object sender, EventArgs e)
+        private async void FrmAddBusiness_Load(object sender, EventArgs e)
         {
-            viewModel.LoadData();
+            await viewModel.LoadDataAsync();
             if (viewModel.BusinessToChange != null && viewModel.ChangeSpecificObject) // Change Existing Business Info
             {
                 viewModel.CurrentBusiness = viewModel.BusinessToChange;

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -70,9 +70,9 @@ namespace QuoteSwift
             }
 
 
-        private void FrmAddCustomer_Load(object sender, EventArgs e)
+        private async void FrmAddCustomer_Load(object sender, EventArgs e)
         {
-            viewModel.LoadData();
+            await viewModel.LoadDataAsync();
             if (viewModel.BusinessList != null)
             {
                 BindingSource source = new BindingSource { DataSource = viewModel.BusinessList };

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -33,7 +33,6 @@ namespace QuoteSwift
             this.serializationService = serializationService;
             this.quoteToChange = quoteToChange;
             this.changeSpecificObject = changeSpecificObject;
-            this.viewModel.LoadData();
             SetupBindings();
         }
 
@@ -93,8 +92,9 @@ namespace QuoteSwift
             UpdatePricingDisplay();
         }
 
-        private void FrmCreateQuote_Load(object sender, EventArgs e)
+        private async void FrmCreateQuote_Load(object sender, EventArgs e)
         {
+            await viewModel.LoadDataAsync();
             if (!changeSpecificObject && quoteToChange != null) // View Quote
             {
                 LoadFromPassedObject();

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -64,9 +64,9 @@ namespace QuoteSwift
             viewModel.RefreshCustomers();
         }
 
-        private void FrmViewCustomers_Load(object sender, EventArgs e)
+        private async void FrmViewCustomers_Load(object sender, EventArgs e)
         {
-            viewModel.LoadData();
+            await viewModel.LoadDataAsync();
             LinkBusinessToSource(ref cbBusinessSelection);
             clmCustomerCompanyName.DataPropertyName = nameof(Customer.CustomerCompanyName);
             clmPreviousQuoteDate.DataPropertyName = nameof(Customer.PreviousQuoteDate);

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -62,9 +62,9 @@ namespace QuoteSwift
         }
 
         bool columnsConfigured = false;
-        private void FrmViewQuotes_Load(object sender, EventArgs e)
+        private async void FrmViewQuotes_Load(object sender, EventArgs e)
         {
-            viewModel.LoadData();
+            await viewModel.LoadDataAsync();
             quotesBindingSource.DataSource = viewModel.Quotes;
             ConfigureColumns();
         }


### PR DESCRIPTION
## Summary
- remove `LoadData` wrappers from view models
- await `LoadDataAsync` in forms
- use `AsyncRelayCommand` for quote and part operations
- call async load methods from navigation service

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_687fc3f90b2c8325afb8ee0de4e9f25a