### PR TITLE
Move PO Box save logic into navigation service

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -156,7 +156,7 @@ namespace QuoteSwift
         {
             var vm = serviceProvider.GetRequiredService<ViewPOBoxAddressesViewModel>();
             vm.UpdateData(business, customer);
-            using (var form = new FrmViewPOBoxAddresses(vm, this, appData, business, customer, messageService))
+            using (var form = new FrmViewPOBoxAddresses(vm, this, business, customer, messageService))
             {
                 form.ShowDialog();
             }

--- a/ViewModels/ViewPOBoxAddressesViewModel.cs
+++ b/ViewModels/ViewPOBoxAddressesViewModel.cs
@@ -6,6 +6,7 @@ namespace QuoteSwift
     public class ViewPOBoxAddressesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
+        readonly INavigationService navigation;
         readonly BindingList<Address> addresses = new BindingList<Address>();
         Business business;
         Customer customer;
@@ -13,14 +14,17 @@ namespace QuoteSwift
         Address selectedAddress;
 
         public ICommand RemoveSelectedAddressCommand { get; }
+        public ICommand SaveChangesCommand { get; }
 
 
-        public ViewPOBoxAddressesViewModel(IDataService service)
+        public ViewPOBoxAddressesViewModel(IDataService service, INavigationService navigation = null)
         {
             dataService = service;
+            this.navigation = navigation;
             RemoveSelectedAddressCommand = new RelayCommand(
                 _ => RemoveAddress(SelectedAddress),
                 _ => SelectedAddress != null);
+            SaveChangesCommand = new RelayCommand(_ => navigation?.SaveAllData());
         }
 
         public IDataService DataService => dataService;

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -9,7 +9,6 @@ namespace QuoteSwift
 
         readonly ViewPOBoxAddressesViewModel viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
         readonly Business business;
         readonly Customer customer;
@@ -28,12 +27,11 @@ namespace QuoteSwift
             CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedAddressCommand);
         }
 
-        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, Business business = null, Customer customer = null, IMessageService messageService = null)
+        public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, Business business = null, Customer customer = null, IMessageService messageService = null)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            appData = data;
             this.messageService = messageService;
             this.business = business;
             this.customer = customer;
@@ -44,7 +42,7 @@ namespace QuoteSwift
         {
             if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
             {
-                appData.SaveAll();
+                navigation?.SaveAllData();
                 Application.Exit();
             }
         }
@@ -126,7 +124,7 @@ namespace QuoteSwift
 
         private void FrmViewPOBoxAddresses_FormClosing(object sender, FormClosingEventArgs e)
         {
-            appData.SaveAll();
+            navigation?.SaveAllData();
         }
 
         /**********************************************************************************/


### PR DESCRIPTION
## Summary
- add `SaveChangesCommand` to `ViewPOBoxAddressesViewModel`
- use `NavigationService.SaveAllData` from FrmViewPOBoxAddresses
- update NavigationService to call new form constructor

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace issue)*

------
https://chatgpt.com/codex/tasks/task_e_687fc8b0e4b88325bd4020b906076668