### PR TITLE
Refactor forms to use view model commands

### DIFF
--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -53,6 +53,7 @@ namespace QuoteSwift
 
         public ICommand AddQuoteCommand { get; }
         public ICommand LoadDataCommand { get; }
+        public ICommand ExportQuoteCommand { get; }
 
 
         public CreateQuoteViewModel(IDataService service, INotificationService notifier, IExcelExportService excelExporter)
@@ -62,6 +63,7 @@ namespace QuoteSwift
             excelExportService = excelExporter;
             AddQuoteCommand = new RelayCommand(q => AddQuote(q as Quote));
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
+            ExportQuoteCommand = new RelayCommand(q => ExportQuoteToTemplate(q as Quote));
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -6,15 +6,30 @@ namespace QuoteSwift
     public class ViewBusinessesViewModel : ViewModelBase
     {
         readonly IDataService dataService;
+        readonly INavigationService navigation;
+        readonly IMessageService messageService;
         BindingList<Business> businesses;
+        Business selectedBusiness;
 
         public ICommand LoadDataCommand { get; }
+        public ICommand AddBusinessCommand { get; }
+        public ICommand UpdateBusinessCommand { get; }
 
 
-        public ViewBusinessesViewModel(IDataService service)
+        public ViewBusinessesViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
         {
             dataService = service;
+            this.navigation = navigation;
+            this.messageService = messageService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
+            AddBusinessCommand = new RelayCommand(_ => navigation?.AddBusiness());
+            UpdateBusinessCommand = new RelayCommand(_ =>
+            {
+                if (SelectedBusiness != null)
+                    navigation?.AddBusiness(SelectedBusiness, false);
+                else
+                    messageService?.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
+            }, _ => SelectedBusiness != null);
         }
 
         public IDataService DataService => dataService;
@@ -26,6 +41,18 @@ namespace QuoteSwift
             {
                 businesses = value;
                 OnPropertyChanged(nameof(Businesses));
+            }
+        }
+
+        public Business SelectedBusiness
+        {
+            get => selectedBusiness;
+            set
+            {
+                if (SetProperty(ref selectedBusiness, value))
+                {
+                    ((RelayCommand)UpdateBusinessCommand).RaiseCanExecuteChanged();
+                }
             }
         }
 

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -9,17 +9,32 @@ namespace QuoteSwift
     public class ViewCustomersViewModel : ViewModelBase
     {
         readonly IDataService dataService;
+        readonly INavigationService navigation;
+        readonly IMessageService messageService;
         BindingList<Business> businesses;
         SortedDictionary<string, Quote> quoteMap;
         Business selectedBusiness;
         BindingList<Customer> customers;
+        Customer selectedCustomer;
         public ICommand LoadDataCommand { get; }
+        public ICommand AddCustomerCommand { get; }
+        public ICommand UpdateCustomerCommand { get; }
 
 
-        public ViewCustomersViewModel(IDataService service)
+        public ViewCustomersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
         {
             dataService = service;
+            this.navigation = navigation;
+            this.messageService = messageService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
+            AddCustomerCommand = new RelayCommand(_ => navigation?.AddCustomer());
+            UpdateCustomerCommand = new RelayCommand(_ =>
+            {
+                if (SelectedCustomer != null)
+                    navigation?.AddCustomer(SelectedBusiness, SelectedCustomer, false);
+                else
+                    messageService?.ShowError("Please select a valid customer, the current selection is invalid", "ERROR - Invalid Customer Selection");
+            }, _ => SelectedCustomer != null);
         }
 
         public BindingList<Business> Businesses
@@ -59,6 +74,18 @@ namespace QuoteSwift
             {
                 customers = value;
                 OnPropertyChanged(nameof(Customers));
+            }
+        }
+
+        public Customer SelectedCustomer
+        {
+            get => selectedCustomer;
+            set
+            {
+                if (SetProperty(ref selectedCustomer, value))
+                {
+                    ((RelayCommand)UpdateCustomerCommand).RaiseCanExecuteChanged();
+                }
             }
         }
 

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -329,7 +329,7 @@ namespace QuoteSwift
         private void ExportQuoteToTemplate(Quote q)
         {
             UseWaitCursor = true;
-            viewModel.ExportQuoteToTemplate(q);
+            viewModel.ExportQuoteCommand.Execute(q);
             UseWaitCursor = false;
         }
 

--- a/frmViewAllBusinesses.Designer.cs
+++ b/frmViewAllBusinesses.Designer.cs
@@ -69,7 +69,6 @@ namespace QuoteSwift
             this.btnAddBusiness.TabIndex = 1;
             this.btnAddBusiness.Text = "Add Business";
             this.btnAddBusiness.UseVisualStyleBackColor = true;
-            this.btnAddBusiness.Click += new System.EventHandler(this.BtnAddBusiness_Click);
             // 
             // DgvBusinessList
             // 
@@ -99,7 +98,6 @@ namespace QuoteSwift
             this.btnUpdateBusiness.TabIndex = 3;
             this.btnUpdateBusiness.Text = "View Selected Business";
             this.btnUpdateBusiness.UseVisualStyleBackColor = true;
-            this.btnUpdateBusiness.Click += new System.EventHandler(this.BtnUpdateBusiness_Click);
             // 
             // BtnRemoveSelected
             // 

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -27,6 +27,9 @@ namespace QuoteSwift
             businessBindingSource.DataSource = viewModel;
             businessBindingSource.DataMember = nameof(ViewBusinessesViewModel.Businesses);
             DgvBusinessList.DataSource = businessBindingSource;
+            SelectionBindings.BindSelectedItem(DgvBusinessList, viewModel, nameof(ViewBusinessesViewModel.SelectedBusiness));
+            CommandBindings.Bind(btnUpdateBusiness, viewModel.UpdateBusinessCommand);
+            CommandBindings.Bind(btnAddBusiness, viewModel.AddBusinessCommand);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -35,27 +38,9 @@ namespace QuoteSwift
                 Application.Exit();
         }
 
-        private void BtnUpdateBusiness_Click(object sender, EventArgs e)
-        {
-
-            Business Business = GetBusinessSelection();
-
-            if (Business == null)
-            {
-                messageService.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
-                return;
-            }
-
-            navigation.AddBusiness(Business, false);
-
-        }
-
-        private void BtnAddBusiness_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.AddBusiness();
-            Show();
-        }
+        // Legacy button handlers kept for reference; functionality now provided via commands
+        private void BtnUpdateBusiness_Click(object sender, EventArgs e) { }
+        private void BtnAddBusiness_Click(object sender, EventArgs e) { }
 
         private void FrmViewAllBusinesses_Load(object sender, EventArgs e)
         {

--- a/frmViewCustomers.Designer.cs
+++ b/frmViewCustomers.Designer.cs
@@ -88,7 +88,6 @@ namespace QuoteSwift
             this.btnUpdateSelectedCustomer.TabIndex = 3;
             this.btnUpdateSelectedCustomer.Text = "View Selected Customer";
             this.btnUpdateSelectedCustomer.UseVisualStyleBackColor = true;
-            this.btnUpdateSelectedCustomer.Click += new System.EventHandler(this.BtnUpdateSelectedCustomer_Click);
             // 
             // btnAddCustomer
             // 
@@ -99,7 +98,6 @@ namespace QuoteSwift
             this.btnAddCustomer.TabIndex = 1;
             this.btnAddCustomer.Text = "Add Customer";
             this.btnAddCustomer.UseVisualStyleBackColor = true;
-            this.btnAddCustomer.Click += new System.EventHandler(this.BtnAddCustomer_Click);
             // 
             // btnRemoveSelectedCustomer
             // 

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -20,9 +20,17 @@ namespace QuoteSwift
             this.serializationService = serializationService;
             this.appData = appData;
             this.messageService = messageService;
+            SetupBindings();
+        }
+
+        void SetupBindings()
+        {
             customersBindingSource.DataSource = viewModel;
             customersBindingSource.DataMember = nameof(ViewCustomersViewModel.Customers);
             DgvCustomerList.DataSource = customersBindingSource;
+            SelectionBindings.BindSelectedItem(DgvCustomerList, viewModel, nameof(ViewCustomersViewModel.SelectedCustomer));
+            CommandBindings.Bind(btnUpdateSelectedCustomer, viewModel.UpdateCustomerCommand);
+            CommandBindings.Bind(btnAddCustomer, viewModel.AddCustomerCommand);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -37,32 +45,9 @@ namespace QuoteSwift
         }
 
 
-        private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e)
-        {
-            Customer customer = GetCustomerSelection();
-            Business container = viewModel.SelectedBusiness;
-
-            if (customer == null)
-            {
-                messageService.ShowError("Please select a valid customer, the current selection is invalid", "ERROR - Invalid Customer Selection");
-                return;
-            }
-
-            navigation.AddCustomer(container, customer, false);
-
-            viewModel.RefreshCustomers();
-
-
-        }
-
-        private void BtnAddCustomer_Click(object sender, EventArgs e)
-        {
-            Hide();
-            navigation.AddCustomer();
-            Show();
-
-            viewModel.RefreshCustomers();
-        }
+        // Legacy button handlers kept for reference; functionality now provided via commands
+        private void BtnUpdateSelectedCustomer_Click(object sender, EventArgs e) { }
+        private void BtnAddCustomer_Click(object sender, EventArgs e) { }
 
         private async void FrmViewCustomers_Load(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- created `ExportQuoteCommand` in `CreateQuoteViewModel`
- introduced navigation commands in `ViewBusinessesViewModel` and `ViewCustomersViewModel`
- bound `frmViewAllBusinesses` and `frmViewCustomers` buttons to commands
- removed direct service calls from forms

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`
- ❌ `msbuild QuoteSwift.sln /t:Build /p:Configuration=Release` (msbuild not available)

------
https://chatgpt.com/codex/tasks/task_e_687fcaeac9f083258bf1122db6c98950