### PR TITLE
Introduce BaseForm and unify form closing logic

### DIFF
--- a/BaseForm.cs
+++ b/BaseForm.cs
@@ -1,0 +1,27 @@
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    public abstract class BaseForm : Form
+    {
+        protected readonly IMessageService messageService;
+        protected readonly INavigationService navigation;
+
+        protected BaseForm(IMessageService messageService = null, INavigationService navigation = null)
+        {
+            this.messageService = messageService;
+            this.navigation = navigation;
+        }
+
+        protected virtual void OnClose()
+        {
+            navigation?.SaveAllData();
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            OnClose();
+            base.OnFormClosing(e);
+        }
+    }
+}

--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmViewBusinessAddresses : Form
+    public partial class FrmViewBusinessAddresses : BaseForm
     {
 
         readonly ViewBusinessAddressesViewModel viewModel;
@@ -29,6 +29,7 @@ namespace QuoteSwift
         }
 
         public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, Business business = null, Customer customer = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -113,10 +114,6 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmViewBusinessAddresses_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            navigation?.SaveAllData();
-        }
 
 
         /**********************************************************************************/

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -131,6 +131,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseForm.cs" />
     <Compile Include="FrmAddBusiness.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmAddBusiness : Form
+    public partial class FrmAddBusiness : BaseForm
     {
 
         readonly AddBusinessViewModel viewModel;
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly ISerializationService serializationService;
 
         public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -96,10 +97,6 @@ namespace QuoteSwift
             SetupBindings();
         }
 
-        private void FrmAddBusiness_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            navigation?.SaveAllData();
-        }
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmAddCustomer : Form
+    public partial class FrmAddCustomer : BaseForm
     {
 
         readonly AddCustomerViewModel viewModel;
@@ -15,6 +15,7 @@ namespace QuoteSwift
         Business Container;
 
         public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, Business container = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -143,10 +144,6 @@ namespace QuoteSwift
 
 
 
-        private void FrmAddCustomer_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            navigation?.SaveAllData();
-        }
 
         /** Form Specific Functions And Procedures:
        *

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace QuoteSwift
 {
-    public partial class FrmAddPump : Form
+    public partial class FrmAddPump : BaseForm
     {
         readonly AddPumpViewModel viewModel;
         readonly INavigationService navigation;
@@ -18,6 +18,7 @@ namespace QuoteSwift
         readonly BindingSource nonMandatorySource = new BindingSource();
 
         public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -220,13 +221,13 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmAddPump_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnClose()
         {
             serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-
+        }
     }
 }

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -10,7 +10,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmCreateQuote : Form
+    public partial class FrmCreateQuote : BaseForm
     {
         readonly CreateQuoteViewModel viewModel;
         readonly ApplicationData appData;
@@ -25,6 +25,7 @@ namespace QuoteSwift
 
 
         public FrmCreateQuote(CreateQuoteViewModel viewModel, ApplicationData data, Quote quoteToChange = null, bool changeSpecificObject = false, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -393,13 +394,13 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmCreateQuote_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnClose()
         {
             serializationService.CloseApplication(true,
                 appData?.BusinessList,
                 appData?.PumpList,
                 appData?.PartList,
                 appData?.QuoteMap);
-    }
+        }
 
 }

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmViewCustomers : Form
+    public partial class FrmViewCustomers : BaseForm
     {
         readonly ViewCustomersViewModel viewModel;
         readonly INavigationService navigation;
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly IMessageService messageService;
         readonly BindingSource customersBindingSource = new BindingSource();
         public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -138,7 +139,7 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmViewCustomers_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnClose()
         {
             serializationService.CloseApplication(true,
                 appData?.BusinessList,

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmViewPOBoxAddresses : Form
+    public partial class FrmViewPOBoxAddresses : BaseForm
     {
 
         readonly ViewPOBoxAddressesViewModel viewModel;
@@ -28,6 +28,7 @@ namespace QuoteSwift
         }
 
         public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, Business business = null, Customer customer = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -122,10 +123,6 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmViewPOBoxAddresses_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            navigation?.SaveAllData();
-        }
 
         /**********************************************************************************/
     }

--- a/frmViewParts.cs
+++ b/frmViewParts.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmViewParts : Form
+    public partial class FrmViewParts : BaseForm
     {
 
         readonly ViewPartsViewModel viewModel;
@@ -16,6 +16,7 @@ namespace QuoteSwift
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
         public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -87,7 +88,7 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmViewParts_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnClose()
         {
             if (viewModel.SaveChangesCommand.CanExecute(null))
                 viewModel.SaveChangesCommand.Execute(null);

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift // Repair Quote Swift
 {
-    public partial class FrmViewPump : Form
+    public partial class FrmViewPump : BaseForm
     {
 
         readonly ViewPumpViewModel viewModel;
@@ -32,6 +32,7 @@ namespace QuoteSwift // Repair Quote Swift
         }
 
         public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -76,7 +77,7 @@ namespace QuoteSwift // Repair Quote Swift
             //Still Needs Implementation.
         }
 
-        private void FrmViewPump_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnClose()
         {
             viewModel.SaveChanges();
         }

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -3,7 +3,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmViewQuotes : Form
+    public partial class FrmViewQuotes : BaseForm
     {
 
         readonly QuotesViewModel viewModel;
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly BindingSource quotesBindingSource = new BindingSource();
 
         public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -70,7 +71,7 @@ namespace QuoteSwift
         }
 
         readonly int count = 0;
-        private void FrmViewQuotes_FormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnClose()
         {
             viewModel.SaveChanges();
         }


### PR DESCRIPTION
## Summary
- add `BaseForm` abstract class with shared close behavior
- inherit from `BaseForm` in several forms and override `OnClose` where needed
- register new source file in the project

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fcdbf4ee4832595971911899a05ce