### PR TITLE
Add SaveQuoteCommand and hook Complete button

### DIFF
--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -52,8 +52,23 @@ namespace QuoteSwift
         DateTime paymentTerm = DateTime.Today;
 
         public ICommand AddQuoteCommand { get; }
+        public ICommand SaveQuoteCommand { get; }
         public ICommand LoadDataCommand { get; }
         public ICommand ExportQuoteCommand { get; }
+
+        Quote lastCreatedQuote;
+        public Quote LastCreatedQuote
+        {
+            get => lastCreatedQuote;
+            private set
+            {
+                if (lastCreatedQuote != value)
+                {
+                    lastCreatedQuote = value;
+                    OnPropertyChanged(nameof(LastCreatedQuote));
+                }
+            }
+        }
 
 
         public CreateQuoteViewModel(IDataService service, INotificationService notifier, IExcelExportService excelExporter)
@@ -62,6 +77,7 @@ namespace QuoteSwift
             notificationService = notifier;
             excelExportService = excelExporter;
             AddQuoteCommand = new RelayCommand(q => AddQuote(q as Quote));
+            SaveQuoteCommand = new RelayCommand(_ => LastCreatedQuote = CreateAndSaveQuote());
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             ExportQuoteCommand = new RelayCommand(q => ExportQuoteToTemplate(q as Quote));
         }

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -48,7 +48,8 @@ namespace QuoteSwift
             else
             {
                 viewModel.Pricing.Rebate = ParsingService.ParseDecimal(mtxtRebate.Text);
-                NewQuote = viewModel.CreateAndSaveQuote();
+                viewModel.SaveQuoteCommand.Execute(null);
+                NewQuote = viewModel.LastCreatedQuote;
 
                 if (NewQuote != null)
                 {
@@ -276,6 +277,7 @@ namespace QuoteSwift
             cbxCustomerDeliveryAddress.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedCustomerDeliveryAddress), false, DataSourceUpdateMode.OnPropertyChanged);
 
             UpdatePricingDisplay();
+            CommandBindings.Bind(btnComplete, viewModel.SaveQuoteCommand);
         }
 
         void UpdatePricingDisplay()


### PR DESCRIPTION
## Summary
- expose `SaveQuoteCommand` and `LastCreatedQuote` on `CreateQuoteViewModel`
- invoke the command from `BtnComplete_Click`
- bind the Complete button to the new command in `SetupBindings`

## Testing
- `dotnet build QuoteSwift.sln` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd48001d883259b11a79496a7de5e