### PR TITLE
Refactor form bindings with helpers

### DIFF
--- a/Infrastructure/BindingHelpers.cs
+++ b/Infrastructure/BindingHelpers.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    /// <summary>
+    /// Utility methods simplifying common WinForms data bindings.
+    /// </summary>
+    static class BindingHelpers
+    {
+        public static void BindText(Control control, object source, string propertyName,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (control == null || source == null || string.IsNullOrWhiteSpace(propertyName))
+                return;
+            ClearExisting(control, "Text");
+            control.DataBindings.Add("Text", source, propertyName, false, mode);
+        }
+
+        public static void BindValue(Control control, object source, string propertyName,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (control == null || source == null || string.IsNullOrWhiteSpace(propertyName))
+                return;
+            ClearExisting(control, "Value");
+            control.DataBindings.Add("Value", source, propertyName, false, mode);
+        }
+
+        public static void BindDataGridView(DataGridView grid, object source, string listProperty,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (grid == null || source == null || string.IsNullOrWhiteSpace(listProperty))
+                return;
+            ClearExisting(grid, "DataSource");
+            grid.DataBindings.Add("DataSource", source, listProperty, false, mode);
+        }
+
+        public static void BindComboBox(ComboBox combo, object source, string itemsProperty,
+            string selectedItemProperty, string displayMember = null, string valueMember = null,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (combo == null || source == null)
+                return;
+            if (!string.IsNullOrWhiteSpace(itemsProperty))
+            {
+                ClearExisting(combo, "DataSource");
+                combo.DataBindings.Add("DataSource", source, itemsProperty, false, mode);
+            }
+            if (!string.IsNullOrWhiteSpace(displayMember))
+                combo.DisplayMember = displayMember;
+            if (!string.IsNullOrWhiteSpace(valueMember))
+                combo.ValueMember = valueMember;
+            if (!string.IsNullOrWhiteSpace(selectedItemProperty))
+            {
+                ClearExisting(combo, "SelectedItem");
+                combo.DataBindings.Add("SelectedItem", source, selectedItemProperty, false, mode);
+            }
+        }
+
+        static void ClearExisting(Control control, string propertyName)
+        {
+            var toRemove = control.DataBindings.Cast<Binding>()
+                .Where(b => b.PropertyName == propertyName)
+                .ToList();
+            foreach (var b in toRemove)
+                control.DataBindings.Remove(b);
+        }
+    }
+}

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -93,35 +93,28 @@ namespace QuoteSwift
 
         private void SetupBindings()
         {
-            txtBusinessName.DataBindings.Clear();
-            txtBusinessName.DataBindings.Add("Text", viewModel.CurrentBusiness, nameof(Business.BusinessName), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtBusinessName, viewModel.CurrentBusiness, nameof(Business.BusinessName));
+            BindingHelpers.BindText(rtxtExtraInformation, viewModel.CurrentBusiness, nameof(Business.BusinessExtraInformation));
+            BindingHelpers.BindText(mtxtVATNumber, viewModel.CurrentBusiness, "BusinessLegalDetails.VatNumber");
+            BindingHelpers.BindText(mtxtRegistrationNumber, viewModel.CurrentBusiness, "BusinessLegalDetails.RegistrationNumber");
 
-            rtxtExtraInformation.DataBindings.Clear();
-            rtxtExtraInformation.DataBindings.Add("Text", viewModel.CurrentBusiness, nameof(Business.BusinessExtraInformation), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtBusinessAddresssDescription, viewModel, nameof(AddBusinessViewModel.AddressDescription));
+            BindingHelpers.BindText(mtxtStreetnumber, viewModel, nameof(AddBusinessViewModel.StreetNumber));
+            BindingHelpers.BindText(txtStreetName, viewModel, nameof(AddBusinessViewModel.StreetName));
+            BindingHelpers.BindText(txtSuburb, viewModel, nameof(AddBusinessViewModel.Suburb));
+            BindingHelpers.BindText(txtCity, viewModel, nameof(AddBusinessViewModel.City));
+            BindingHelpers.BindText(mtxtAreaCode, viewModel, nameof(AddBusinessViewModel.AreaCode));
 
-            mtxtVATNumber.DataBindings.Clear();
-            mtxtVATNumber.DataBindings.Add("Text", viewModel.CurrentBusiness, "BusinessLegalDetails.VatNumber", false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtBusinessPODescription, viewModel, nameof(AddBusinessViewModel.PODescription));
+            BindingHelpers.BindText(mtxtPOBoxStreetNumber, viewModel, nameof(AddBusinessViewModel.POStreetNumber));
+            BindingHelpers.BindText(txtPOBoxSuburb, viewModel, nameof(AddBusinessViewModel.POSuburb));
+            BindingHelpers.BindText(txtPOBoxCity, viewModel, nameof(AddBusinessViewModel.POCity));
+            BindingHelpers.BindText(mtxtPOBoxAreaCode, viewModel, nameof(AddBusinessViewModel.POAreaCode));
 
-            mtxtRegistrationNumber.DataBindings.Clear();
-            mtxtRegistrationNumber.DataBindings.Add("Text", viewModel.CurrentBusiness, "BusinessLegalDetails.RegistrationNumber", false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(mtxtTelephoneNumber, viewModel, nameof(AddBusinessViewModel.TelephoneInput));
+            BindingHelpers.BindText(mtxtCellphoneNumber, viewModel, nameof(AddBusinessViewModel.CellphoneInput));
 
-            txtBusinessAddresssDescription.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.AddressDescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtStreetnumber.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.StreetNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtStreetName.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.StreetName), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtSuburb.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.Suburb), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtCity.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.City), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtAreaCode.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.AreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
-
-            txtBusinessPODescription.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.PODescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPOBoxStreetNumber.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.POStreetNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtPOBoxSuburb.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.POSuburb), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtPOBoxCity.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.POCity), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPOBoxAreaCode.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.POAreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
-
-            mtxtTelephoneNumber.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.TelephoneInput), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtCellphoneNumber.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.CellphoneInput), false, DataSourceUpdateMode.OnPropertyChanged);
-
-            mtxtEmail.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.EmailInput), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(mtxtEmail, viewModel, nameof(AddBusinessViewModel.EmailInput));
 
             gbxBusinessAddress.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
             gbxBusinessInformation.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -25,24 +25,24 @@ namespace QuoteSwift
             this.Container = container;
             viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
 
-            txtCustomerCompanyName.DataBindings.Add("Text", viewModel.CurrentCustomer, nameof(Customer.CustomerCompanyName), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtVendorNumber.DataBindings.Add("Text", viewModel.CurrentCustomer, nameof(Customer.VendorNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtCustomerCompanyName, viewModel.CurrentCustomer, nameof(Customer.CustomerCompanyName));
+            BindingHelpers.BindText(mtxtVendorNumber, viewModel.CurrentCustomer, nameof(Customer.VendorNumber));
 
-            txtCustomerAddresssDescription.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.AddressDescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtAtt.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.Att), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtWorkArea.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.WorkArea), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtWorkPlace.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.WorkPlace), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtCustomerAddresssDescription, viewModel, nameof(AddCustomerViewModel.AddressDescription));
+            BindingHelpers.BindText(txtAtt, viewModel, nameof(AddCustomerViewModel.Att));
+            BindingHelpers.BindText(txtWorkArea, viewModel, nameof(AddCustomerViewModel.WorkArea));
+            BindingHelpers.BindText(txtWorkPlace, viewModel, nameof(AddCustomerViewModel.WorkPlace));
 
-            txtCustomerPODescription.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.PODescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPOBoxStreetNumber.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.POStreetNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtPOBoxSuburb.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.POSuburb), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtPOBoxCity.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.POCity), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPOBoxAreaCode.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.POAreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtCustomerPODescription, viewModel, nameof(AddCustomerViewModel.PODescription));
+            BindingHelpers.BindText(mtxtPOBoxStreetNumber, viewModel, nameof(AddCustomerViewModel.POStreetNumber));
+            BindingHelpers.BindText(txtPOBoxSuburb, viewModel, nameof(AddCustomerViewModel.POSuburb));
+            BindingHelpers.BindText(txtPOBoxCity, viewModel, nameof(AddCustomerViewModel.POCity));
+            BindingHelpers.BindText(mtxtPOBoxAreaCode, viewModel, nameof(AddCustomerViewModel.POAreaCode));
 
-            mtxtTelephoneNumber.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.TelephoneInput), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtCellphoneNumber.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.CellphoneInput), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(mtxtTelephoneNumber, viewModel, nameof(AddCustomerViewModel.TelephoneInput));
+            BindingHelpers.BindText(mtxtCellphoneNumber, viewModel, nameof(AddCustomerViewModel.CellphoneInput));
 
-            mtxtEmailAddress.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.EmailInput), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(mtxtEmailAddress, viewModel, nameof(AddCustomerViewModel.EmailInput));
 
             gbxCustomerInformation.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
             gbxCustomerAddress.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -196,7 +196,7 @@ namespace QuoteSwift
             clmTotal.DataPropertyName = nameof(Quote_Part.Price);
             ClmRepairDevider.DataPropertyName = nameof(Quote_Part.RepairDevider);
             mandatorySource.DataSource = viewModel.MandatoryParts;
-            dgvMandatoryPartReplacement.DataSource = mandatorySource;
+            BindingHelpers.BindDataGridView(dgvMandatoryPartReplacement, mandatorySource, nameof(BindingSource.DataSource));
 
             DgvNonMandatoryPartReplacement.AutoGenerateColumns = false;
             dataGridViewTextBoxColumn1.DataPropertyName = "PumpPart.PumpPart.NewPartNumber";
@@ -210,71 +210,52 @@ namespace QuoteSwift
             dataGridViewTextBoxColumn9.DataPropertyName = nameof(Quote_Part.Price);
             ClmNMRepairDevider.DataPropertyName = nameof(Quote_Part.RepairDevider);
             nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
-            DgvNonMandatoryPartReplacement.DataSource = nonMandatorySource;
+            BindingHelpers.BindDataGridView(DgvNonMandatoryPartReplacement, nonMandatorySource, nameof(BindingSource.DataSource));
 
-            cbxBusinessSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.Businesses), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxBusinessSelection.DisplayMember = "BusinessName";
-            cbxBusinessSelection.ValueMember = "BusinessName";
-            cbxBusinessSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedBusiness), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindComboBox(cbxBusinessSelection, viewModel, nameof(CreateQuoteViewModel.Businesses), nameof(CreateQuoteViewModel.SelectedBusiness), "BusinessName", "BusinessName");
 
-            cbxPumpSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.Pumps), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxPumpSelection.DisplayMember = "PumpName";
-            cbxPumpSelection.ValueMember = "PumpName";
-            cbxPumpSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedPump), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindComboBox(cbxPumpSelection, viewModel, nameof(CreateQuoteViewModel.Pumps), nameof(CreateQuoteViewModel.SelectedPump), "PumpName", "PumpName");
 
-            cbxBusinessTelephoneNumberSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.BusinessTelephoneNumbers), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxBusinessCellphoneNumberSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.BusinessCellphoneNumbers), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxBusinessEmailAddressSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.BusinessEmailAddresses), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindComboBox(cbxBusinessTelephoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessTelephoneNumbers), null);
+            BindingHelpers.BindComboBox(cbxBusinessCellphoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessCellphoneNumbers), null);
+            BindingHelpers.BindComboBox(cbxBusinessEmailAddressSelection, viewModel, nameof(CreateQuoteViewModel.BusinessEmailAddresses), null);
 
-            cbxCustomerSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.Customers), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxCustomerSelection.DisplayMember = "CustomerCompanyName";
-            cbxCustomerSelection.ValueMember = "CustomerCompanyName";
-            cbxCustomerSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedCustomer), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindComboBox(cbxCustomerSelection, viewModel, nameof(CreateQuoteViewModel.Customers), nameof(CreateQuoteViewModel.SelectedCustomer), "CustomerCompanyName", "CustomerCompanyName");
 
-            cbxCustomerDeliveryAddress.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.CustomerDeliveryAddresses), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxCustomerDeliveryAddress.DisplayMember = "AddressDescription";
-            cbxCustomerDeliveryAddress.ValueMember = "AddressDescription";
+            BindingHelpers.BindComboBox(cbxCustomerDeliveryAddress, viewModel, nameof(CreateQuoteViewModel.CustomerDeliveryAddresses), nameof(CreateQuoteViewModel.SelectedCustomerDeliveryAddress), "AddressDescription", "AddressDescription");
 
-            CbxPOBoxSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxes), false, DataSourceUpdateMode.OnPropertyChanged);
-            CbxPOBoxSelection.DisplayMember = "AddressDescription";
-            CbxPOBoxSelection.ValueMember = "AddressDescription";
+            BindingHelpers.BindComboBox(CbxPOBoxSelection, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxes), nameof(CreateQuoteViewModel.SelectedBusinessPOBox), "AddressDescription", "AddressDescription");
 
-            CbxCustomerPOBoxSelection.DataBindings.Add("DataSource", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxes), false, DataSourceUpdateMode.OnPropertyChanged);
-            CbxCustomerPOBoxSelection.DisplayMember = "AddressDescription";
-            CbxCustomerPOBoxSelection.ValueMember = "AddressDescription";
+            BindingHelpers.BindComboBox(CbxCustomerPOBoxSelection, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxes), nameof(CreateQuoteViewModel.SelectedCustomerPOBox), "AddressDescription", "AddressDescription");
 
-            txtCustomerVATNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerVATNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtJobNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.JobNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtReferenceNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.ReferenceNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtPRNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.PRNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtLineNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.LineNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtQuoteNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.QuoteNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(txtCustomerVATNumber, viewModel, nameof(CreateQuoteViewModel.CustomerVATNumber));
+            BindingHelpers.BindText(txtJobNumber, viewModel, nameof(CreateQuoteViewModel.JobNumber));
+            BindingHelpers.BindText(txtReferenceNumber, viewModel, nameof(CreateQuoteViewModel.ReferenceNumber));
+            BindingHelpers.BindText(txtPRNumber, viewModel, nameof(CreateQuoteViewModel.PRNumber));
+            BindingHelpers.BindText(txtLineNumber, viewModel, nameof(CreateQuoteViewModel.LineNumber));
+            BindingHelpers.BindText(txtQuoteNumber, viewModel, nameof(CreateQuoteViewModel.QuoteNumber));
 
-            rtxCustomerDeliveryDescripton.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerDeliveryDescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            dtpQuoteCreationDate.DataBindings.Add("Value", viewModel, nameof(CreateQuoteViewModel.QuoteCreationDate), false, DataSourceUpdateMode.OnPropertyChanged);
-            dtpQuoteExpiryDate.DataBindings.Add("Value", viewModel, nameof(CreateQuoteViewModel.QuoteExpiryDate), false, DataSourceUpdateMode.OnPropertyChanged);
-            dtpPaymentTerm.DataBindings.Add("Value", viewModel, nameof(CreateQuoteViewModel.PaymentTerm), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(rtxCustomerDeliveryDescripton, viewModel, nameof(CreateQuoteViewModel.CustomerDeliveryDescription));
+            BindingHelpers.BindValue(dtpQuoteCreationDate, viewModel, nameof(CreateQuoteViewModel.QuoteCreationDate));
+            BindingHelpers.BindValue(dtpQuoteExpiryDate, viewModel, nameof(CreateQuoteViewModel.QuoteExpiryDate));
+            BindingHelpers.BindValue(dtpPaymentTerm, viewModel, nameof(CreateQuoteViewModel.PaymentTerm));
 
-            cbxBusinessTelephoneNumberSelection.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessTelephone), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxBusinessCellphoneNumberSelection.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessCellphone), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxBusinessEmailAddressSelection.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessEmail), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(cbxBusinessTelephoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessTelephone));
+            BindingHelpers.BindText(cbxBusinessCellphoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessCellphone));
+            BindingHelpers.BindText(cbxBusinessEmailAddressSelection, viewModel, nameof(CreateQuoteViewModel.BusinessEmail));
 
-            lblBusinessPOBoxNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblBusinessPOBoxSuburb.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxSuburbDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblBusinessPOBoxCity.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxCityDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblBusinessPOBoxAreaCode.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxAreaCodeDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblBusinessRegistrationNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessRegistrationNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblBusinessVATNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.BusinessVATNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(lblBusinessPOBoxNumber, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxNumberDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxSuburb, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxSuburbDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxCity, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxCityDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxAreaCode, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxAreaCodeDisplay));
+            BindingHelpers.BindText(lblBusinessRegistrationNumber, viewModel, nameof(CreateQuoteViewModel.BusinessRegistrationNumberDisplay));
+            BindingHelpers.BindText(lblBusinessVATNumber, viewModel, nameof(CreateQuoteViewModel.BusinessVATNumberDisplay));
 
-            lblCustomerPOBoxStreetName.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxStreetNameDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblCustomerPOBoxSuburb.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxSuburbDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblCustomerPOBoxCity.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxCityDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblCustomerPOBoxAreaCode.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxAreaCodeDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-            lblCustomerVendorNumber.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.CustomerVendorNumberDisplay), false, DataSourceUpdateMode.OnPropertyChanged);
-
-            CbxPOBoxSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedBusinessPOBox), false, DataSourceUpdateMode.OnPropertyChanged);
-            CbxCustomerPOBoxSelection.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedCustomerPOBox), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxCustomerDeliveryAddress.DataBindings.Add("SelectedItem", viewModel, nameof(CreateQuoteViewModel.SelectedCustomerDeliveryAddress), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(lblCustomerPOBoxStreetName, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxStreetNameDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxSuburb, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxSuburbDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxCity, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxCityDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxAreaCode, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxAreaCodeDisplay));
+            BindingHelpers.BindText(lblCustomerVendorNumber, viewModel, nameof(CreateQuoteViewModel.CustomerVendorNumberDisplay));
 
             UpdatePricingDisplay();
             CommandBindings.Bind(btnComplete, viewModel.SaveQuoteCommand);


### PR DESCRIPTION
## Summary
- add `BindingHelpers` utility for common WinForms bindings
- use `BindingHelpers` in business, customer and quote forms to remove repetition

## Testing
- `msbuild QuoteSwift.sln -t:Build -p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fda999b2483258bb5bbcac897a9e3