### PR TITLE
Add busy indicator to forms

### DIFF
--- a/BaseForm.cs
+++ b/BaseForm.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Forms;
 
 namespace QuoteSwift
@@ -22,6 +23,24 @@ namespace QuoteSwift
         {
             OnClose();
             base.OnFormClosing(e);
+        }
+
+        /// <summary>
+        /// Binds the form's wait cursor to the IsBusy property of the supplied
+        /// view model.
+        /// </summary>
+        protected void BindIsBusy(ViewModelBase viewModel)
+        {
+            if (viewModel == null)
+                return;
+
+            viewModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(ViewModelBase.IsBusy))
+                {
+                    BeginInvoke(new Action(() => UseWaitCursor = viewModel.IsBusy));
+                }
+            };
         }
     }
 }

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -9,6 +9,17 @@ namespace QuoteSwift
     /// </summary>
     public class ViewModelBase : ObservableObject
     {
+        bool isBusy;
+
+        /// <summary>
+        /// Indicates whether the view model is performing a background
+        /// operation.
+        /// </summary>
+        public bool IsBusy
+        {
+            get => isBusy;
+            protected set => SetProperty(ref isBusy, value);
+        }
         /// <summary>
         /// Creates an <see cref="AsyncRelayCommand"/> for the supplied asynchronous
         /// load action.
@@ -17,7 +28,18 @@ namespace QuoteSwift
         /// <returns>An initialized <see cref="AsyncRelayCommand"/>.</returns>
         protected AsyncRelayCommand CreateLoadCommand(Func<Task> loadAction)
         {
-            return new AsyncRelayCommand(loadAction);
+            return new AsyncRelayCommand(async () =>
+            {
+                IsBusy = true;
+                try
+                {
+                    await loadAction();
+                }
+                finally
+                {
+                    IsBusy = false;
+                }
+            });
         }
     }
 }

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -23,6 +23,7 @@ namespace QuoteSwift
 
             DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.FormTitle));
             viewModel.PropertyChanged += ViewModel_PropertyChanged;
+            BindIsBusy(viewModel);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmAddCustomer.cs
+++ b/frmAddCustomer.cs
@@ -24,6 +24,7 @@ namespace QuoteSwift
             this.messageService = messageService;
             this.Container = container;
             viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
+            BindIsBusy(viewModel);
 
             BindingHelpers.BindText(txtCustomerCompanyName, viewModel.CurrentCustomer, nameof(Customer.CustomerCompanyName));
             BindingHelpers.BindText(mtxtVendorNumber, viewModel.CurrentCustomer, nameof(Customer.VendorNumber));

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -35,6 +35,7 @@ namespace QuoteSwift
             this.quoteToChange = quoteToChange;
             this.changeSpecificObject = changeSpecificObject;
             SetupBindings();
+            BindIsBusy(viewModel);
         }
 
         private void BtnComplete_Click(object sender, EventArgs e)

--- a/frmViewCustomers.cs
+++ b/frmViewCustomers.cs
@@ -22,6 +22,7 @@ namespace QuoteSwift
             this.appData = appData;
             this.messageService = messageService;
             SetupBindings();
+            BindIsBusy(viewModel);
         }
 
         void SetupBindings()

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -23,6 +23,7 @@ namespace QuoteSwift
             quotesBindingSource.DataSource = viewModel.Quotes;
             dgvPreviousQuotes.DataSource = quotesBindingSource;
             SetupBindings();
+            BindIsBusy(viewModel);
         }
 
         void SetupBindings()


### PR DESCRIPTION
## Summary
- add `IsBusy` property to `ViewModelBase`
- track busy state in commands created via `CreateLoadCommand`
- expose `BindIsBusy` helper in `BaseForm`
- hook busy indicator in forms when loading data

## Testing
- `dotnet restore QuoteSwift.sln -nologo`
- `dotnet msbuild QuoteSwift.sln -nologo` *(fails: reference assemblies for .NETFramework,Version=v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdba6793c83258085d4ebc34d0feb