### PR TITLE
Bind UI states to view models

### DIFF
--- a/FrmViewBusinessAddresses.cs
+++ b/FrmViewBusinessAddresses.cs
@@ -24,6 +24,10 @@ namespace QuoteSwift
                     viewModel.SelectedAddress = null;
             };
 
+            BindingHelpers.BindReadOnly(DgvViewAllBusinessAddresses, viewModel, nameof(ViewBusinessAddressesViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(BtnRemoveSelected, viewModel, nameof(ViewBusinessAddressesViewModel.CanEdit));
+            BindingHelpers.BindEnabled(BtnChangeAddressInfo, viewModel, nameof(ViewBusinessAddressesViewModel.CanEdit));
+
             CommandBindings.Bind(BtnRemoveSelected, viewModel.RemoveSelectedAddressCommand);
             CommandBindings.Bind(BtnChangeAddressInfo, viewModel.EditAddressCommand);
         }
@@ -57,7 +61,6 @@ namespace QuoteSwift
 
                 if (viewModel.IsReadOnly)
                 {
-                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 
@@ -68,7 +71,6 @@ namespace QuoteSwift
 
                 if (viewModel.IsReadOnly)
                 {
-                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 
@@ -90,11 +92,6 @@ namespace QuoteSwift
             if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
         }
 
-
-        void ApplyControlState()
-        {
-            ControlStateHelper.ApplyReadOnly(Controls, true);
-        }
 
         /** Form Specific Functions And Procedures: 
         *

--- a/Infrastructure/BindingHelpers.cs
+++ b/Infrastructure/BindingHelpers.cs
@@ -35,6 +35,33 @@ namespace QuoteSwift
             grid.DataBindings.Add("DataSource", source, listProperty, false, mode);
         }
 
+        public static void BindEnabled(Control control, object source, string propertyName,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (control == null || source == null || string.IsNullOrWhiteSpace(propertyName))
+                return;
+            ClearExisting(control, "Enabled");
+            control.DataBindings.Add("Enabled", source, propertyName, false, mode);
+        }
+
+        public static void BindVisible(Control control, object source, string propertyName,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (control == null || source == null || string.IsNullOrWhiteSpace(propertyName))
+                return;
+            ClearExisting(control, "Visible");
+            control.DataBindings.Add("Visible", source, propertyName, false, mode);
+        }
+
+        public static void BindReadOnly(Control control, object source, string propertyName,
+            DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)
+        {
+            if (control == null || source == null || string.IsNullOrWhiteSpace(propertyName))
+                return;
+            ClearExisting(control, "ReadOnly");
+            control.DataBindings.Add("ReadOnly", source, propertyName, false, mode);
+        }
+
         public static void BindComboBox(ComboBox combo, object source, string itemsProperty,
             string selectedItemProperty, string displayMember = null, string valueMember = null,
             DataSourceUpdateMode mode = DataSourceUpdateMode.OnPropertyChanged)

--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -402,12 +402,15 @@ namespace QuoteSwift
                     OnPropertyChanged(nameof(IsAdding));
                     OnPropertyChanged(nameof(ShowSaveButton));
                     OnPropertyChanged(nameof(SaveButtonText));
+                    OnPropertyChanged(nameof(CanEdit));
                     OnPropertyChanged(nameof(FormTitle));
                 }
             }
         }
 
         public bool IsReadOnly => !changeSpecificObject;
+
+        public bool CanEdit => changeSpecificObject;
 
         public Business CurrentBusiness
         {

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -372,12 +372,15 @@ namespace QuoteSwift
                     OnPropertyChanged(nameof(ChangeSpecificObject));
                     OnPropertyChanged(nameof(IsReadOnly));
                     OnPropertyChanged(nameof(IsEditing));
+                    OnPropertyChanged(nameof(CanEdit));
                     OnPropertyChanged(nameof(FormTitle));
                 }
             }
         }
 
         public bool IsReadOnly => !changeSpecificObject;
+
+        public bool CanEdit => changeSpecificObject;
 
         public Customer CurrentCustomer
         {

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -147,12 +147,15 @@ namespace QuoteSwift
                     OnPropertyChanged(nameof(ChangeSpecificObject));
                     OnPropertyChanged(nameof(IsReadOnly));
                     OnPropertyChanged(nameof(IsEditing));
+                    OnPropertyChanged(nameof(CanEdit));
                     OnPropertyChanged(nameof(FormTitle));
                 }
             }
         }
 
         public bool IsReadOnly => !changeSpecificObject;
+
+        public bool CanEdit => changeSpecificObject;
 
         public BindingList<Part> Parts
         {

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -75,12 +75,15 @@ namespace QuoteSwift
                     OnPropertyChanged(nameof(ChangeSpecificObject));
                     OnPropertyChanged(nameof(IsReadOnly));
                     OnPropertyChanged(nameof(IsEditing));
+                    OnPropertyChanged(nameof(CanEdit));
                     OnPropertyChanged(nameof(FormTitle));
                 }
             }
         }
 
         public bool IsReadOnly => !changeSpecificObject;
+
+        public bool CanEdit => changeSpecificObject;
 
 
         public AddPumpViewModel(IDataService service, INotificationService notifier)

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -67,11 +67,14 @@ namespace QuoteSwift
                     changeSpecificObject = value;
                     OnPropertyChanged(nameof(ChangeSpecificObject));
                     OnPropertyChanged(nameof(IsReadOnly));
+                    OnPropertyChanged(nameof(CanEdit));
                 }
             }
         }
 
         public bool IsReadOnly => !changeSpecificObject;
+
+        public bool CanEdit => changeSpecificObject;
 
         public void UpdateData(Business business = null, Customer customer = null)
         {

--- a/ViewModels/ViewPOBoxAddressesViewModel.cs
+++ b/ViewModels/ViewPOBoxAddressesViewModel.cs
@@ -61,11 +61,14 @@ namespace QuoteSwift
                     changeSpecificObject = value;
                     OnPropertyChanged(nameof(ChangeSpecificObject));
                     OnPropertyChanged(nameof(IsReadOnly));
+                    OnPropertyChanged(nameof(CanEdit));
                 }
             }
         }
 
         public bool IsReadOnly => !changeSpecificObject;
+
+        public bool CanEdit => changeSpecificObject;
 
         public void UpdateData(Business business = null, Customer customer = null)
         {

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -35,6 +35,14 @@ namespace QuoteSwift
             mtxtPartPrice.DataBindings.Add("Value", viewModel.CurrentPart, nameof(Part.PartPrice), false, DataSourceUpdateMode.OnPropertyChanged);
             cbxMandatoryPart.DataBindings.Add("Checked", viewModel.CurrentPart, nameof(Part.MandatoryPart), false, DataSourceUpdateMode.OnPropertyChanged);
 
+            BindingHelpers.BindReadOnly(mtxtPartName, viewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtPartDescription, viewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtOriginalPartNumber, viewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtNewPartNumber, viewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtPartPrice, viewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(cbxMandatoryPart, viewModel, nameof(AddPartViewModel.CanEdit));
+            BindingHelpers.BindVisible(btnAddPart, viewModel, nameof(AddPartViewModel.CanEdit));
+
             cbAddToPumpSelection.DataSource = viewModel.Pumps;
             cbAddToPumpSelection.DisplayMember = nameof(Pump.PumpName);
             cbAddToPumpSelection.ValueMember = nameof(Pump.PumpName);
@@ -84,7 +92,6 @@ namespace QuoteSwift
             if (viewModel.ChangeSpecificObject && viewModel.PartToChange != null)
             {
                 viewModel.ChangeSpecificObject = true;
-                ApplyControlState();
                 btnAddPart.Text = "Update";
                 updatePartToolStripMenuItem.Enabled = false;
             }
@@ -92,7 +99,6 @@ namespace QuoteSwift
             {
                 viewModel.ChangeSpecificObject = false;
                 btnAddPart.Visible = false;
-                ApplyControlState();
                 updatePartToolStripMenuItem.Enabled = true;
             }
         }
@@ -106,21 +112,6 @@ namespace QuoteSwift
 
 
 
-        void ApplyControlState()
-        {
-            bool ro = viewModel.IsReadOnly;
-            mtxtNewPartNumber.ReadOnly = ro;
-            mtxtOriginalPartNumber.ReadOnly = ro;
-            mtxtPartDescription.ReadOnly = ro;
-            mtxtPartName.ReadOnly = ro;
-            mtxtPartPrice.ReadOnly = ro;
-            cbAddToPumpSelection.Enabled = false;
-            NudQuantity.Enabled = false;
-            cbxMandatoryPart.Enabled = !ro;
-            btnAddPart.Visible = !ro;
-            if (!ro)
-                btnAddPart.Text = "Update Part";
-        }
 
         private void UpdatePartToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -128,7 +119,6 @@ namespace QuoteSwift
                 if (messageService.RequestConfirmation("You are currently only viewing " + viewModel.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
                 {
                     viewModel.ChangeSpecificObject = true;
-                    ApplyControlState();
                     updatePartToolStripMenuItem.Enabled = false;
                 }
         }

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -329,7 +329,8 @@ namespace QuoteSwift
 
         private void ConvertToReadOnly()
         {
-            ApplyControlState(true);
+            ControlStateHelper.ApplyReadOnly(Controls, true);
+            cbxPumpSelection.Enabled = false;
 
             dgvMandatoryPartReplacement.ReadOnly = true;
             DgvNonMandatoryPartReplacement.ReadOnly = true;
@@ -350,18 +351,14 @@ namespace QuoteSwift
 
         private void ConvertToReadWrite()
         {
-            ApplyControlState(false);
+            ControlStateHelper.ApplyReadOnly(Controls, false);
+            cbxPumpSelection.Enabled = true;
 
             Text = Text.Replace(quoteToChange.QuoteCompany.BusinessName, quoteToChange.QuoteCompany.BusinessName);
             Text = Text.Replace("Viewing", "Creating New");
 
         }
 
-        void ApplyControlState(bool readOnly)
-        {
-            ControlStateHelper.ApplyReadOnly(Controls, readOnly);
-            cbxPumpSelection.Enabled = !readOnly;
-        }
 
         private void CreateNewQuoteUsingThisQuoteToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/frmViewPOBoxAddresses.cs
+++ b/frmViewPOBoxAddresses.cs
@@ -24,6 +24,9 @@ namespace QuoteSwift
                     viewModel.SelectedAddress = null;
             };
 
+            BindingHelpers.BindReadOnly(dgvPOBoxAddresses, viewModel, nameof(ViewPOBoxAddressesViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(btnRemoveAddress, viewModel, nameof(ViewPOBoxAddressesViewModel.CanEdit));
+
             CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedAddressCommand);
         }
 
@@ -69,11 +72,6 @@ namespace QuoteSwift
             viewModel.UpdateData(business, customer);
         }
 
-        void ApplyControlState()
-        {
-            ControlStateHelper.ApplyReadOnly(Controls, true);
-        }
-
         private void FrmViewPOBoxAddresses_Load(object sender, EventArgs e)
         {
             if (business != null && business.BusinessPOBoxAddressList != null)
@@ -82,7 +80,6 @@ namespace QuoteSwift
 
                 if (viewModel.IsReadOnly)
                 {
-                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 
@@ -93,7 +90,6 @@ namespace QuoteSwift
 
                 if (viewModel.IsReadOnly)
                 {
-                    ApplyControlState();
                     BtnCancel.Enabled = true;
                 }
 


### PR DESCRIPTION
## Summary
- add helpers to bind Enabled, Visible and ReadOnly
- expose `CanEdit` on view models when editing is allowed
- connect form controls directly to view model properties
- drop old `ApplyControlState` methods and inline logic

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe54ae9cc8325836355152dd1b8be