### PR TITLE
Refactor navigation into view model commands

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Windows.Input;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace QuoteSwift
 {
@@ -49,6 +50,10 @@ namespace QuoteSwift
         public ICommand UpdateBusinessCommand { get; }
         public ICommand SaveBusinessCommand { get; }
         public ICommand LoadDataCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ExitCommand { get; }
+
+        public Action CloseAction { get; set; }
 
         public OperationResult LastResult
         {
@@ -310,6 +315,25 @@ namespace QuoteSwift
                 }
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
+
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService.RequestConfirmation(
+                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
+                        "REQUEST - Cancellation"))
+                    CloseAction?.Invoke();
+            });
+
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination"))
+                {
+                    navigation?.SaveAllData();
+                    System.Windows.Forms.Application.Exit();
+                }
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.Windows.Forms;
+
 
 namespace QuoteSwift
 {
@@ -12,6 +14,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly ISerializationService serializationService;
         BindingList<Quote> quotes;
         Quote selectedQuote;
 
@@ -32,15 +35,18 @@ namespace QuoteSwift
         public ICommand ViewPumpsCommand { get; }
         public ICommand AddPartCommand { get; }
         public ICommand ViewPartsCommand { get; }
+        public ICommand ExitCommand { get; }
 
 
         public QuotesViewModel(IDataService service,
                                INavigationService navigation = null,
-                               IMessageService messageService = null)
+                               IMessageService messageService = null,
+                               ISerializationService serializationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.serializationService = serializationService;
 
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
 
@@ -55,6 +61,20 @@ namespace QuoteSwift
             ViewPumpsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllPumps(); await LoadDataAsync(); });
             AddPartCommand = new AsyncRelayCommand(async _ => { navigation?.AddNewPart(); await LoadDataAsync(); });
             ViewPartsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllParts(); await LoadDataAsync(); });
+
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination"))
+                {
+                    serializationService?.CloseApplication(true,
+                        BusinessList,
+                        PumpList,
+                        PartMap,
+                        QuoteMap);
+                }
+            });
         }
 
 

--- a/frmAddBusiness.Designer.cs
+++ b/frmAddBusiness.Designer.cs
@@ -128,7 +128,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // gbxBusinessInformation
             // 
@@ -261,7 +260,6 @@ namespace QuoteSwift
             this.btnViewAll.TabIndex = 14;
             this.btnViewAll.Text = "View All Numbers";
             this.btnViewAll.UseVisualStyleBackColor = true;
-            this.btnViewAll.Click += new System.EventHandler(this.BtnViewAll_Click);
             // 
             // mtxtCellphoneNumber
             // 
@@ -366,7 +364,6 @@ namespace QuoteSwift
             this.btnViewAddresses.TabIndex = 10;
             this.btnViewAddresses.Text = "View All Addresses";
             this.btnViewAddresses.UseVisualStyleBackColor = true;
-            this.btnViewAddresses.Click += new System.EventHandler(this.BtnViewAddresses_Click);
             // 
             // lblAreaCode
             // 
@@ -498,7 +495,6 @@ namespace QuoteSwift
             this.btnViewEmailAddresses.TabIndex = 17;
             this.btnViewEmailAddresses.Text = "View All Email Addresses";
             this.btnViewEmailAddresses.UseVisualStyleBackColor = true;
-            this.btnViewEmailAddresses.Click += new System.EventHandler(this.BtnViewEmailAddresses_Click);
             // 
             // mtxtEmail
             // 
@@ -571,7 +567,6 @@ namespace QuoteSwift
             this.btnViewAllPOBoxAddresses.TabIndex = 24;
             this.btnViewAllPOBoxAddresses.Text = "View All Addresses";
             this.btnViewAllPOBoxAddresses.UseVisualStyleBackColor = true;
-            this.btnViewAllPOBoxAddresses.Click += new System.EventHandler(this.BtnViewAllPOBoxAddresses_Click);
             // 
             // txtBusinessPODescription
             // 
@@ -687,7 +682,6 @@ namespace QuoteSwift
             this.btnCancel.TabIndex = 27;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // FrmAddBusiness
             // 

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -20,20 +20,14 @@ namespace QuoteSwift
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
 
             DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.FormTitle));
             viewModel.PropertyChanged += ViewModel_PropertyChanged;
             BindIsBusy(viewModel);
         }
 
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                navigation?.SaveAllData();
-                Application.Exit();
-            }
-        }
+
 
 
         void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -44,30 +38,7 @@ namespace QuoteSwift
             }
         }
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
-        }
 
-        private void BtnViewEmailAddresses_Click(object sender, EventArgs e)
-        {
-            viewModel.ViewEmailAddressesCommand.Execute(null);
-        }
-
-        private void BtnViewAddresses_Click(object sender, EventArgs e)
-        {
-            viewModel.ViewAddressesCommand.Execute(null);
-        }
-
-        private void BtnViewAllPOBoxAddresses_Click(object sender, EventArgs e)
-        {
-            viewModel.ViewPOBoxAddressesCommand.Execute(null);
-        }
-
-        private void BtnViewAll_Click(object sender, EventArgs e)
-        {
-            viewModel.ViewPhoneNumbersCommand.Execute(null);
-        }
 
         private async void FrmAddBusiness_Load(object sender, EventArgs e)
         {
@@ -136,6 +107,8 @@ namespace QuoteSwift
             CommandBindings.Bind(btnViewAddresses, viewModel.ViewAddressesCommand);
             CommandBindings.Bind(btnViewAllPOBoxAddresses, viewModel.ViewPOBoxAddressesCommand);
             CommandBindings.Bind(btnViewAll, viewModel.ViewPhoneNumbersCommand);
+            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         /**********************************************************************************/

--- a/frmViewQuotes.Designer.cs
+++ b/frmViewQuotes.Designer.cs
@@ -164,7 +164,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // btnCreateNewQuote
             // 

--- a/frmViewQuotes.cs
+++ b/frmViewQuotes.cs
@@ -49,19 +49,9 @@ namespace QuoteSwift
             CommandBindings.Bind(managePumpPartsToolStripMenuItem, viewModel.ViewPartsCommand);
             CommandBindings.Bind(addNewPartToolStripMenuItem, viewModel.AddPartCommand);
             CommandBindings.Bind(viewAllPartsToolStripMenuItem, viewModel.ViewPartsCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                serializationService.CloseApplication(true,
-                    viewModel.BusinessList,
-                    viewModel.PumpList,
-                    viewModel.PartMap,
-                    viewModel.QuoteMap);
-            }
-        }
 
         bool columnsConfigured = false;
         private async void FrmViewQuotes_Load(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- delegate cancel and exit actions to view models
- bind buttons and menus directly to new commands
- drop old event handlers

## Testing
- `xbuild QuoteSwift.sln` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_687fee07147c8325bfe3d7b749dd45ad