### PR TITLE
Add ExitCommand to view models and update forms

### DIFF
--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly INotificationService notificationService;
         readonly IMessageService messageService;
         readonly IFileDialogService fileDialogService;
+        readonly INavigationService navigation;
         Dictionary<string, Part> partMap;
         BindingList<Pump> pumpList;
         Part partToChange;
@@ -28,6 +29,7 @@ namespace QuoteSwift
         public ICommand SavePartCommand { get; }
         public ICommand LoadDataCommand { get; }
         public ICommand ImportPartsCommand { get; }
+        public ICommand ExitCommand { get; }
 
         public bool LastOperationSuccessful
         {
@@ -58,12 +60,14 @@ namespace QuoteSwift
 
 
         public AddPartViewModel(IDataService service, INotificationService notifier,
-                                IMessageService messenger = null, IFileDialogService dialogService = null)
+                                IMessageService messenger = null, IFileDialogService dialogService = null,
+                                INavigationService navigation = null)
         {
             dataService = service;
             notificationService = notifier;
             messageService = messenger;
             fileDialogService = dialogService;
+            this.navigation = navigation;
             CurrentPart = new Part();
             SavePartCommand = new RelayCommand(_ =>
             {
@@ -106,6 +110,11 @@ namespace QuoteSwift
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             ImportPartsCommand = new AsyncRelayCommand(_ => ImportPartsAsync());
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -9,6 +9,7 @@ namespace QuoteSwift
     {
         readonly IDataService dataService;
         readonly INotificationService notificationService;
+        readonly INavigationService navigation;
         Pump currentPump;
         bool lastOperationSuccessful;
         string formTitle;
@@ -17,6 +18,7 @@ namespace QuoteSwift
         public ICommand UpdatePumpCommand { get; }
         public ICommand SavePumpCommand { get; }
         public ICommand LoadDataCommand { get; }
+        public ICommand ExitCommand { get; }
 
         public bool LastOperationSuccessful
         {
@@ -86,10 +88,13 @@ namespace QuoteSwift
         public bool CanEdit => changeSpecificObject;
 
 
-        public AddPumpViewModel(IDataService service, INotificationService notifier)
+        public AddPumpViewModel(IDataService service,
+                                INotificationService notifier,
+                                INavigationService navigation = null)
         {
             dataService = service;
             notificationService = notifier;
+            this.navigation = navigation;
             SelectedMandatoryParts = new BindingList<Pump_Part>();
             SelectedNonMandatoryParts = new BindingList<Pump_Part>();
             RepairableItemNames = new HashSet<string>();
@@ -103,6 +108,11 @@ namespace QuoteSwift
                     LastOperationSuccessful = AddPump();
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INotificationService notificationService;
         readonly IExcelExportService excelExportService;
+        readonly INavigationService navigation;
         Dictionary<string, Part> partList;
         BindingList<Pump> pumps;
         BindingList<Business> businesses;
@@ -55,6 +56,7 @@ namespace QuoteSwift
         public ICommand SaveQuoteCommand { get; }
         public ICommand LoadDataCommand { get; }
         public ICommand ExportQuoteCommand { get; }
+        public ICommand ExitCommand { get; }
 
         Quote lastCreatedQuote;
         public Quote LastCreatedQuote
@@ -71,15 +73,24 @@ namespace QuoteSwift
         }
 
 
-        public CreateQuoteViewModel(IDataService service, INotificationService notifier, IExcelExportService excelExporter)
+        public CreateQuoteViewModel(IDataService service,
+                                    INotificationService notifier,
+                                    IExcelExportService excelExporter,
+                                    INavigationService navigation = null)
         {
             dataService = service;
             notificationService = notifier;
             excelExportService = excelExporter;
+            this.navigation = navigation;
             AddQuoteCommand = new RelayCommand(q => AddQuote(q as Quote));
             SaveQuoteCommand = new RelayCommand(_ => LastCreatedQuote = CreateAndSaveQuote());
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             ExportQuoteCommand = new AsyncRelayCommand(q => ExportQuoteToTemplateAsync(q as Quote));
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/ManageEmailsViewModel.cs
+++ b/ViewModels/ManageEmailsViewModel.cs
@@ -10,6 +10,7 @@ namespace QuoteSwift
         Business business;
         Customer customer;
         readonly BindingList<EmailEntry> emails;
+        readonly INavigationService navigation;
         EmailEntry selectedEmail;
         string newEmail;
 
@@ -17,11 +18,13 @@ namespace QuoteSwift
         public ICommand RemoveEmailCommand { get; }
         public ICommand RemoveSelectedEmailCommand { get; }
         public ICommand UpdateEmailCommand { get; }
+        public ICommand ExitCommand { get; }
 
 
-        public ManageEmailsViewModel(IDataService service)
+        public ManageEmailsViewModel(IDataService service, INavigationService navigation = null)
         {
             dataService = service;
+            this.navigation = navigation;
             emails = new BindingList<EmailEntry>();
             AddEmailCommand = new RelayCommand(
                 _ => { AddEmail(NewEmail); NewEmail = string.Empty; },
@@ -34,6 +37,11 @@ namespace QuoteSwift
             {
                 if (p is object[] arr && arr.Length == 2 && arr[0] is string oldE && arr[1] is string newE)
                     UpdateEmail(oldE, newE);
+            });
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
             });
         }
 

--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -15,6 +15,7 @@ namespace QuoteSwift
         NumberEntry selectedCellphoneNumber;
         string newTelephoneNumber;
         string newCellphoneNumber;
+        readonly INavigationService navigation;
 
         public ICommand RemoveTelephoneCommand { get; }
         public ICommand RemoveCellphoneCommand { get; }
@@ -24,11 +25,13 @@ namespace QuoteSwift
         public ICommand UpdateCellphoneCommand { get; }
         public ICommand AddTelephoneCommand { get; }
         public ICommand AddCellphoneCommand { get; }
+        public ICommand ExitCommand { get; }
 
 
-        public ManagePhoneNumbersViewModel(IDataService service)
+        public ManagePhoneNumbersViewModel(IDataService service, INavigationService navigation = null)
         {
             dataService = service;
+            this.navigation = navigation;
             telephoneNumbers = new BindingList<NumberEntry>();
             cellphoneNumbers = new BindingList<NumberEntry>();
             RemoveTelephoneCommand = new RelayCommand(n => RemoveTelephone(n as string));
@@ -54,6 +57,11 @@ namespace QuoteSwift
             {
                 if (p is object[] arr && arr.Length == 2 && arr[0] is string oldN && arr[1] is string newN)
                     UpdateCellphone(oldN, newN);
+            });
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
             });
         }
 

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -14,6 +14,8 @@ namespace QuoteSwift
         bool changeSpecificObject;
         Address selectedAddress;
 
+        public ICommand ExitCommand { get; }
+
         public ICommand RemoveSelectedAddressCommand { get; }
         public ICommand EditAddressCommand { get; }
 
@@ -31,6 +33,11 @@ namespace QuoteSwift
             EditAddressCommand = new RelayCommand(
                 _ => EditSelectedAddress(),
                 _ => SelectedAddress != null);
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -24,6 +24,7 @@ namespace QuoteSwift
         public ICommand UpdatePumpCommand { get; }
         public ICommand RemovePumpCommand { get; }
         public ICommand ExportInventoryCommand { get; }
+        public ICommand ExitCommand { get; }
 
 
         public ViewPumpViewModel(IDataService service, ISerializationService serializer,
@@ -40,6 +41,11 @@ namespace QuoteSwift
             UpdatePumpCommand = new RelayCommand(_ => UpdatePump(), _ => SelectedPump != null);
             RemovePumpCommand = new RelayCommand(_ => RemoveSelectedPump(), _ => SelectedPump != null);
             ExportInventoryCommand = new AsyncRelayCommand(_ => ExportInventoryActionAsync());
+            ExitCommand = new RelayCommand(_ =>
+            {
+                navigation?.SaveAllData();
+                System.Windows.Forms.Application.Exit();
+            });
         }
 
         public IDataService DataService => dataService;

--- a/frmAddPart.Designer.cs
+++ b/frmAddPart.Designer.cs
@@ -97,7 +97,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // lblAddPartDescription
             // 

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -52,16 +52,13 @@ namespace QuoteSwift
 
             CommandBindings.Bind(btnAddPart, viewModel.SavePartCommand);
             CommandBindings.Bind(loadPartBatchToolStripMenuItem, viewModel.ImportPartsCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         private void FrmAddPart_Activated(object sender, EventArgs e)

--- a/frmAddPump.Designer.cs
+++ b/frmAddPump.Designer.cs
@@ -100,7 +100,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // lblMandatoryParts
             // 

--- a/frmAddPump.cs
+++ b/frmAddPump.cs
@@ -34,6 +34,7 @@ namespace QuoteSwift
             mandatorySource.DataSource = viewModel.SelectedMandatoryParts;
             nonMandatorySource.DataSource = viewModel.SelectedNonMandatoryParts;
             CommandBindings.Bind(btnAddPump, viewModel.SavePumpCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
             if (data != null)
                 viewModel.UpdateData(data.PumpList, data.PartList, viewModel.PumpToChange, viewModel.ChangeSpecificObject,
                                      data.PumpList != null ? new HashSet<string>(data.PumpList.Select(p => StringUtil.NormalizeKey(p.PumpName))) : null);
@@ -41,13 +42,9 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
-
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
+        }
 
 
         private void MtxtPumpName_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
@@ -224,11 +221,8 @@ namespace QuoteSwift
 
         protected override void OnClose()
         {
-            serializationService.CloseApplication(true,
-                appData?.BusinessList,
-                appData?.PumpList,
-                appData?.PartList,
-                appData?.QuoteMap);
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
     }
 }

--- a/frmCreateQuote.Designer.cs
+++ b/frmCreateQuote.Designer.cs
@@ -196,7 +196,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // pnlBusinessDetails
             // 

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -86,12 +86,9 @@ namespace QuoteSwift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
+        }
 
         private void CbxPumpSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -265,6 +262,7 @@ namespace QuoteSwift
 
             UpdatePricingDisplay();
             CommandBindings.Bind(btnComplete, viewModel.SaveQuoteCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         void UpdatePricingDisplay()
@@ -380,11 +378,8 @@ namespace QuoteSwift
 
         protected override void OnClose()
         {
-            serializationService.CloseApplication(true,
-                appData?.BusinessList,
-                appData?.PumpList,
-                appData?.PartList,
-                appData?.QuoteMap);
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
 }

--- a/frmManageAllEmails.Designer.cs
+++ b/frmManageAllEmails.Designer.cs
@@ -59,7 +59,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // DgvEmails
             // 

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -31,14 +31,13 @@ namespace QuoteSwift
             CommandBindings.Bind(btnAddEmail, viewModel.AddEmailCommand);
 
             CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedEmailCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                Application.Exit();
-            }
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         private void FrmManageAllEmails_Load(object sender, EventArgs e)

--- a/frmViewPump.Designer.cs
+++ b/frmViewPump.Designer.cs
@@ -61,7 +61,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // exportInventoryToolStripMenuItem
             //

--- a/frmViewPump.cs
+++ b/frmViewPump.cs
@@ -25,6 +25,8 @@ namespace QuoteSwift // Repair Quote Swift
             CommandBindings.Bind(btnAddPump, viewModel.AddPumpCommand);
             CommandBindings.Bind(btnRemovePumpSelection, viewModel.RemovePumpCommand);
 
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+
             exportInventoryToolStripMenuItem.Click += async (s, e) =>
             {
                 if (viewModel.ExportInventoryCommand.CanExecute(null))
@@ -44,11 +46,8 @@ namespace QuoteSwift // Repair Quote Swift
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                viewModel.SaveChanges();
-                Application.Exit();
-            }
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
 


### PR DESCRIPTION
## Summary
- implement `ExitCommand` in several view models
- bind Close menu items to use the new command
- hook ExitCommand in add/edit forms for pumps, parts, quotes and emails

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_687ffad746bc83259fef0f878a28f1eb