### PR TITLE
Make navigation methods asynchronous

### DIFF
--- a/Services/INavigationService.cs
+++ b/Services/INavigationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace QuoteSwift
 {
@@ -7,12 +8,12 @@ namespace QuoteSwift
         void CreateNewQuote(Quote quoteToChange = null, bool changeSpecificObject = false);
         void ViewAllQuotes();
         void ViewAllPumps();
-        void CreateNewPump();
+        Task CreateNewPump();
         void ViewAllParts();
         void AddNewPart(Part partToChange = null, bool changeSpecificObject = false);
-        void AddCustomer(Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false);
-        void ViewCustomers();
-        void AddBusiness(Business businessToChange = null, bool changeSpecificObject = false);
+        Task AddCustomer(Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false);
+        Task ViewCustomers();
+        Task AddBusiness(Business businessToChange = null, bool changeSpecificObject = false);
         void ViewBusinesses();
         void ViewBusinessesAddresses(Business business = null, Customer customer = null);
         void ViewBusinessesPOBoxAddresses(Business business = null, Customer customer = null);

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace QuoteSwift
@@ -59,12 +60,12 @@ namespace QuoteSwift
             }
         }
 
-        public void CreateNewPump()
+        public async Task CreateNewPump()
         {
             using (var form = serviceProvider.GetRequiredService<FrmAddPump>())
             {
                 form.ViewModel.UpdateData(appData.PumpList, appData.PartList);
-                form.ViewModel.LoadDataAsync().GetAwaiter().GetResult();
+                await form.ViewModel.LoadDataAsync();
                 form.ShowDialog();
                 appData.PumpList = form.ViewModel.PumpList;
                 appData.PartList = form.ViewModel.PartMap;
@@ -94,7 +95,7 @@ namespace QuoteSwift
         }
 
 
-        public void AddCustomer(Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false)
+        public async Task AddCustomer(Business businessToChange = null, Customer customerToChange = null, bool changeSpecificObject = false)
         {
             using (var form = serviceProvider.GetRequiredService<FrmAddCustomer>())
             {
@@ -103,23 +104,24 @@ namespace QuoteSwift
                 form.ShowDialog();
             }
             appData.SaveAll();
+            await Task.CompletedTask;
         }
 
-        public void ViewCustomers()
+        public async Task ViewCustomers()
         {
             using (var form = serviceProvider.GetRequiredService<FrmViewCustomers>())
             {
-                form.ViewModel.LoadDataAsync().GetAwaiter().GetResult();
+                await form.ViewModel.LoadDataAsync();
                 form.ShowDialog();
             }
         }
 
-        public void AddBusiness(Business businessToChange = null, bool changeSpecificObject = false)
+        public async Task AddBusiness(Business businessToChange = null, bool changeSpecificObject = false)
         {
             using (var form = serviceProvider.GetRequiredService<FrmAddBusiness>())
             {
                 form.ViewModel.UpdateData(appData.BusinessList, businessToChange, changeSpecificObject);
-                form.ViewModel.LoadDataAsync().GetAwaiter().GetResult();
+                await form.ViewModel.LoadDataAsync();
                 form.ShowDialog();
                 appData.BusinessList = form.ViewModel.BusinessList;
             }

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -53,11 +53,23 @@ namespace QuoteSwift
             CreateQuoteCommand = new AsyncRelayCommand(_ => CreateQuoteAsync());
             ViewQuoteCommand = new AsyncRelayCommand(_ => ViewQuoteAsync(), _ => Task.FromResult(SelectedQuote != null));
             CreateQuoteFromSelectionCommand = new AsyncRelayCommand(_ => CreateQuoteFromSelectionAsync(), _ => Task.FromResult(SelectedQuote != null));
-            AddBusinessCommand = new AsyncRelayCommand(async _ => { navigation?.AddBusiness(); await LoadDataAsync(); });
+            AddBusinessCommand = new AsyncRelayCommand(async _ => {
+                if (navigation != null) await navigation.AddBusiness();
+                await LoadDataAsync();
+            });
             ViewBusinessesCommand = new AsyncRelayCommand(async _ => { navigation?.ViewBusinesses(); await LoadDataAsync(); });
-            AddCustomerCommand = new AsyncRelayCommand(async _ => { navigation?.AddCustomer(); await LoadDataAsync(); });
-            ViewCustomersCommand = new AsyncRelayCommand(async _ => { navigation?.ViewCustomers(); await LoadDataAsync(); });
-            CreatePumpCommand = new AsyncRelayCommand(async _ => { navigation?.CreateNewPump(); await LoadDataAsync(); });
+            AddCustomerCommand = new AsyncRelayCommand(async _ => {
+                if (navigation != null) await navigation.AddCustomer();
+                await LoadDataAsync();
+            });
+            ViewCustomersCommand = new AsyncRelayCommand(async _ => {
+                if (navigation != null) await navigation.ViewCustomers();
+                await LoadDataAsync();
+            });
+            CreatePumpCommand = new AsyncRelayCommand(async _ => {
+                if (navigation != null) await navigation.CreateNewPump();
+                await LoadDataAsync();
+            });
             ViewPumpsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllPumps(); await LoadDataAsync(); });
             AddPartCommand = new AsyncRelayCommand(async _ => { navigation?.AddNewPart(); await LoadDataAsync(); });
             ViewPartsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllParts(); await LoadDataAsync(); });

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -22,14 +22,21 @@ namespace QuoteSwift
             this.navigation = navigation;
             this.messageService = messageService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
-            AddBusinessCommand = new RelayCommand(_ => navigation?.AddBusiness());
-            UpdateBusinessCommand = new RelayCommand(_ =>
+            AddBusinessCommand = new AsyncRelayCommand(async _ =>
+            {
+                if (navigation != null) await navigation.AddBusiness();
+            });
+            UpdateBusinessCommand = new AsyncRelayCommand(async _ =>
             {
                 if (SelectedBusiness != null)
-                    navigation?.AddBusiness(SelectedBusiness, false);
+                {
+                    if (navigation != null) await navigation.AddBusiness(SelectedBusiness, false);
+                }
                 else
+                {
                     messageService?.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
-            }, _ => SelectedBusiness != null);
+                }
+            }, _ => Task.FromResult(SelectedBusiness != null));
         }
 
         public IDataService DataService => dataService;
@@ -51,7 +58,7 @@ namespace QuoteSwift
             {
                 if (SetProperty(ref selectedBusiness, value))
                 {
-                    ((RelayCommand)UpdateBusinessCommand).RaiseCanExecuteChanged();
+                    ((AsyncRelayCommand)UpdateBusinessCommand).RaiseCanExecuteChanged();
                 }
             }
         }

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -27,14 +27,21 @@ namespace QuoteSwift
             this.navigation = navigation;
             this.messageService = messageService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
-            AddCustomerCommand = new RelayCommand(_ => navigation?.AddCustomer());
-            UpdateCustomerCommand = new RelayCommand(_ =>
+            AddCustomerCommand = new AsyncRelayCommand(async _ =>
+            {
+                if (navigation != null) await navigation.AddCustomer();
+            });
+            UpdateCustomerCommand = new AsyncRelayCommand(async _ =>
             {
                 if (SelectedCustomer != null)
-                    navigation?.AddCustomer(SelectedBusiness, SelectedCustomer, false);
+                {
+                    if (navigation != null) await navigation.AddCustomer(SelectedBusiness, SelectedCustomer, false);
+                }
                 else
+                {
                     messageService?.ShowError("Please select a valid customer, the current selection is invalid", "ERROR - Invalid Customer Selection");
-            }, _ => SelectedCustomer != null);
+                }
+            }, _ => Task.FromResult(SelectedCustomer != null));
         }
 
         public BindingList<Business> Businesses
@@ -84,7 +91,7 @@ namespace QuoteSwift
             {
                 if (SetProperty(ref selectedCustomer, value))
                 {
-                    ((RelayCommand)UpdateCustomerCommand).RaiseCanExecuteChanged();
+                    ((AsyncRelayCommand)UpdateCustomerCommand).RaiseCanExecuteChanged();
                 }
             }
         }

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -37,8 +37,8 @@ namespace QuoteSwift
             this.messageService = messageService;
             fileDialogService = dialogService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
-            AddPumpCommand = new RelayCommand(_ => AddPump());
-            UpdatePumpCommand = new RelayCommand(_ => UpdatePump(), _ => SelectedPump != null);
+            AddPumpCommand = new AsyncRelayCommand(_ => AddPumpAsync());
+            UpdatePumpCommand = new AsyncRelayCommand(_ => UpdatePumpAsync(), _ => Task.FromResult(SelectedPump != null));
             RemovePumpCommand = new RelayCommand(_ => RemoveSelectedPump(), _ => SelectedPump != null);
             ExportInventoryCommand = new AsyncRelayCommand(_ => ExportInventoryActionAsync());
             ExitCommand = new RelayCommand(_ =>
@@ -77,7 +77,7 @@ namespace QuoteSwift
             {
                 if (SetProperty(ref selectedPump, value))
                 {
-                    ((RelayCommand)UpdatePumpCommand).RaiseCanExecuteChanged();
+                    ((AsyncRelayCommand)UpdatePumpCommand).RaiseCanExecuteChanged();
                     ((RelayCommand)RemovePumpCommand).RaiseCanExecuteChanged();
                 }
             }
@@ -116,17 +116,19 @@ namespace QuoteSwift
                 RepairableItemNames = new HashSet<string>();
         }
 
-        void AddPump()
+        async Task AddPumpAsync()
         {
-            navigation?.CreateNewPump();
+            if (navigation != null)
+                await navigation.CreateNewPump();
             RefreshRepairableNames();
         }
 
-        void UpdatePump()
+        async Task UpdatePumpAsync()
         {
             if (SelectedPump != null)
             {
-                navigation?.CreateNewPump();
+                if (navigation != null)
+                    await navigation.CreateNewPump();
                 RefreshRepairableNames();
             }
             else


### PR DESCRIPTION
## Summary
- update `INavigationService` to return `Task` for methods that open dialogs
- await view-model load calls in `NavigationService`
- make callers await navigation methods using `AsyncRelayCommand`

## Testing
- `msbuild QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880037666888325b008db9caaa21246