### PR TITLE
Switch forms to BaseForm inheritance

### DIFF
--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -3,17 +3,20 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmEditBusinessAddress : Form
+    public partial class FrmEditBusinessAddress : BaseForm
     {
         readonly IMessageService messageService;
+        readonly INavigationService navigation;
         readonly EditBusinessAddressViewModel viewModel;
         public EditBusinessAddressViewModel ViewModel => viewModel;
 
-        public FrmEditBusinessAddress(EditBusinessAddressViewModel viewModel, IMessageService messageService = null)
+        public FrmEditBusinessAddress(EditBusinessAddressViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.messageService = messageService;
+            this.navigation = navigation;
             SetupBindings();
         }
 
@@ -65,8 +68,6 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmEditBusinessAddress_FormClosing(object sender, FormClosingEventArgs e)
-        {
-        }
+        
     }
 }

--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -3,18 +3,21 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmEditEmailAddress : Form
+    public partial class FrmEditEmailAddress : BaseForm
     {
 
         readonly IMessageService messageService;
+        readonly INavigationService navigation;
         readonly EditEmailAddressViewModel viewModel;
         public EditEmailAddressViewModel ViewModel => viewModel;
 
-        public FrmEditEmailAddress(EditEmailAddressViewModel viewModel, IMessageService messageService = null)
+        public FrmEditEmailAddress(EditEmailAddressViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.messageService = messageService;
+            this.navigation = navigation;
             SetupBindings();
         }
 
@@ -62,8 +65,5 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmEditEmailAddress_FormClosing(object sender, FormClosingEventArgs e)
-        {
-        }
     }
 }

--- a/FrmEditPhoneNumber.cs
+++ b/FrmEditPhoneNumber.cs
@@ -3,18 +3,21 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmEditPhoneNumber : Form
+    public partial class FrmEditPhoneNumber : BaseForm
     {
 
         readonly IMessageService messageService;
+        readonly INavigationService navigation;
         readonly EditPhoneNumberViewModel viewModel;
         public EditPhoneNumberViewModel ViewModel => viewModel;
 
-        public FrmEditPhoneNumber(EditPhoneNumberViewModel viewModel, IMessageService messageService = null)
+        public FrmEditPhoneNumber(EditPhoneNumberViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.messageService = messageService;
+            this.navigation = navigation;
             SetupBindings();
         }
 
@@ -56,8 +59,5 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmEditPhoneNumber_FormClosing(object sender, FormClosingEventArgs e)
-        {
-        }
     }
 }

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmAddPart : Form
+    public partial class FrmAddPart : BaseForm
     {
 
         readonly AddPartViewModel viewModel;
@@ -16,6 +16,7 @@ namespace QuoteSwift
         readonly IMessageService messageService;
 
         public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -25,6 +26,7 @@ namespace QuoteSwift
             this.messageService = messageService;
             viewModel.Initialize();
             SetupBindings();
+            BindIsBusy(viewModel);
         }
 
         void SetupBindings()

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmManageAllEmails : Form
+    public partial class FrmManageAllEmails : BaseForm
     {
 
         readonly ManageEmailsViewModel viewModel;
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly INavigationService navigation;
 
         public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -78,9 +79,6 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmManageAllEmails_FormClosing(object sender, FormClosingEventArgs e)
-        {
-        }
     }
 
 }

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmManagingPhoneNumbers : Form
+    public partial class FrmManagingPhoneNumbers : BaseForm
     {
 
         readonly ManagePhoneNumbersViewModel viewModel;
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly INavigationService navigation;
 
         public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -110,8 +111,5 @@ namespace QuoteSwift
             //Still Needs Implementation.
         }
 
-        private void FrmManagingPhoneNumbers_FormClosing(object sender, FormClosingEventArgs e)
-        {
-        }
     }
 }

--- a/frmViewAllBusinesses.cs
+++ b/frmViewAllBusinesses.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 
 namespace QuoteSwift
 {
-    public partial class FrmViewAllBusinesses : Form
+    public partial class FrmViewAllBusinesses : BaseForm
     {
 
         readonly ViewBusinessesViewModel viewModel;
@@ -15,6 +15,7 @@ namespace QuoteSwift
         readonly BindingSource businessBindingSource = new BindingSource();
 
         public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
+            : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
@@ -89,10 +90,6 @@ namespace QuoteSwift
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {
             //Still Needs Implementation.
-        }
-
-        private void FrmViewAllBusinesses_FormClosing(object sender, FormClosingEventArgs e)
-        {
         }
 
         /**********************************************************************************/


### PR DESCRIPTION
## Summary
- make FrmEditBusinessAddress, FrmEditEmailAddress, FrmEditPhoneNumber, FrmAddPart, FrmManageAllEmails, FrmManagingPhoneNumbers, and FrmViewAllBusinesses inherit from `BaseForm`
- pass services to the base class constructors
- bind `IsBusy` for `FrmAddPart`
- remove unused `FormClosing` handlers

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_6880071e9e408325aa905018d5db97f5