### PR TITLE
Refactor form events to commands

### DIFF
--- a/FrmEditBusinessAddress.Designer.cs
+++ b/FrmEditBusinessAddress.Designer.cs
@@ -85,7 +85,6 @@ namespace QuoteSwift
             this.BtnUpdateAddress.TabIndex = 6;
             this.BtnUpdateAddress.Text = "Update Address";
             this.BtnUpdateAddress.UseVisualStyleBackColor = true;
-            this.BtnUpdateAddress.Click += new System.EventHandler(this.BtnUpdateAddress_Click);
             // 
             // mtxtAreaCode
             // 
@@ -189,7 +188,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // BtnCancel
             // 
@@ -200,7 +198,6 @@ namespace QuoteSwift
             this.BtnCancel.TabIndex = 7;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // FrmEditBusinessAddress
             // 

--- a/FrmEditBusinessAddress.cs
+++ b/FrmEditBusinessAddress.cs
@@ -17,6 +17,7 @@ namespace QuoteSwift
             this.viewModel = viewModel;
             this.messageService = messageService;
             this.navigation = navigation;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -28,11 +29,10 @@ namespace QuoteSwift
             txtSuburb.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.Suburb), false, DataSourceUpdateMode.OnPropertyChanged);
             txtCity.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.City), false, DataSourceUpdateMode.OnPropertyChanged);
             mtxtAreaCode.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.AreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
-        }
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            CommandBindings.Bind(BtnUpdateAddress, viewModel.SaveCommand);
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         private void FrmEditBusinessAddress_Load(object sender, EventArgs e)
@@ -43,24 +43,6 @@ namespace QuoteSwift
             }
         }
 
-        private void BtnUpdateAddress_Click(object sender, EventArgs e)
-        {
-            viewModel.UpdateAddressCommand.Execute(null);
-            var result = viewModel.LastResult;
-            if (result.Success)
-            {
-                messageService.ShowInformation("The address has been successfully updated", "INFORMATION - Address Successfully Updated");
-                Close();
-            }
-            else if (result.Message != null)
-                messageService.ShowError(result.Message, result.Caption);
-        }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                Application.Exit();
-        }
 
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/frmAddPart.Designer.cs
+++ b/frmAddPart.Designer.cs
@@ -90,7 +90,6 @@ namespace QuoteSwift
             this.updatePartToolStripMenuItem.Name = "updatePartToolStripMenuItem";
             this.updatePartToolStripMenuItem.Size = new System.Drawing.Size(164, 24);
             this.updatePartToolStripMenuItem.Text = "Update Part";
-            this.updatePartToolStripMenuItem.Click += new System.EventHandler(this.UpdatePartToolStripMenuItem_Click);
             // 
             // closeToolStripMenuItem
             // 
@@ -231,7 +230,6 @@ namespace QuoteSwift
             this.btnCancel.TabIndex = 9;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // lblnewPartQuantity
             // 

--- a/frmAddPart.cs
+++ b/frmAddPart.cs
@@ -24,6 +24,7 @@ namespace QuoteSwift
             appData = data;
             this.serializationService = serializationService;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             viewModel.Initialize();
             SetupBindings();
             BindIsBusy(viewModel);
@@ -56,36 +57,14 @@ namespace QuoteSwift
             CommandBindings.Bind(btnAddPart, viewModel.SavePartCommand);
             CommandBindings.Bind(loadPartBatchToolStripMenuItem, viewModel.ImportPartsCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(resetInputToolStripMenuItem, viewModel.ResetInputCommand);
+            CommandBindings.Bind(updatePartToolStripMenuItem, viewModel.StartEditCommand);
         }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
-
-        private void FrmAddPart_Activated(object sender, EventArgs e)
-        {
-
-        }
-
 
         private void CbAddToPumpSelection_ContextMenuStripChanged(object sender, EventArgs e)
         {
             if (!cbxMandatoryPart.Enabled) cbxMandatoryPart.Enabled = true;
-        }
-
-        private void ResetInputToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to reset the current screen to it's default values?", "REQUEST - Screen Defaults Reset"))
-            {
-                viewModel.ResetInput();
-            }
-        }
-
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
         }
 
         private void FrmAddPart_Load(object sender, EventArgs e)
@@ -94,8 +73,6 @@ namespace QuoteSwift
             {
                 viewModel.ChangeSpecificObject = true;
             }
-
-            updatePartToolStripMenuItem.Enabled = viewModel.IsViewing;
         }
 
         /** Form Specific Functions And Procedures: 
@@ -108,15 +85,6 @@ namespace QuoteSwift
 
 
 
-        private void UpdatePartToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (!viewModel.ChangeSpecificObject)
-                if (messageService.RequestConfirmation("You are currently only viewing " + viewModel.PartToChange.PartName + " part, would you like to update it's details instead?", "REQUEST - Update Specific Part Details"))
-                {
-                    viewModel.ChangeSpecificObject = true;
-                    updatePartToolStripMenuItem.Enabled = false;
-                }
-        }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/frmManageAllEmails.Designer.cs
+++ b/frmManageAllEmails.Designer.cs
@@ -93,7 +93,6 @@ namespace QuoteSwift
             this.BtnCancel.TabIndex = 4;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // btnRemoveAddress
             // 
@@ -116,7 +115,6 @@ namespace QuoteSwift
             this.BtnChangeAddressInfo.TabIndex = 8;
             this.BtnChangeAddressInfo.Text = "Update Selected Email";
             this.BtnChangeAddressInfo.UseVisualStyleBackColor = true;
-            this.BtnChangeAddressInfo.Click += new System.EventHandler(this.BtnChangeAddressInfo_Click);
             //
             // txtNewEmail
             //

--- a/frmManageAllEmails.cs
+++ b/frmManageAllEmails.cs
@@ -19,6 +19,7 @@ namespace QuoteSwift
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -30,15 +31,10 @@ namespace QuoteSwift
             txtNewEmail.DataBindings.Add("Text", viewModel, nameof(ManageEmailsViewModel.NewEmail), false, DataSourceUpdateMode.OnPropertyChanged);
 
             CommandBindings.Bind(btnAddEmail, viewModel.AddEmailCommand);
-
             CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedEmailCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-        }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(BtnChangeAddressInfo, viewModel.EditSelectedEmailCommand);
         }
 
         private void FrmManageAllEmails_Load(object sender, EventArgs e)
@@ -60,17 +56,7 @@ namespace QuoteSwift
             DgvEmails.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
         }
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
-        }
 
-
-        private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
-        {
-            string email = viewModel.SelectedEmail?.Address ?? string.Empty;
-            navigation?.EditBusinessEmailAddress(viewModel.Business, viewModel.Customer, email);
-        }
 
 
 

--- a/frmManagingPhoneNumbers.Designer.cs
+++ b/frmManagingPhoneNumbers.Designer.cs
@@ -68,7 +68,6 @@ namespace QuoteSwift
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // dgvTelephoneNumbers
             // 
@@ -167,7 +166,6 @@ namespace QuoteSwift
             this.BtnCancel.TabIndex = 7;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // BtnUpdateCellphoneNumber
             // 
@@ -179,7 +177,6 @@ namespace QuoteSwift
             this.BtnUpdateCellphoneNumber.TabIndex = 6;
             this.BtnUpdateCellphoneNumber.Text = "Update Selected Phone Number";
             this.BtnUpdateCellphoneNumber.UseVisualStyleBackColor = true;
-            this.BtnUpdateCellphoneNumber.Click += new System.EventHandler(this.BtnChangePhoneNumberInfo_Click);
             // 
             // BtnUpdateTelephoneNumber
             // 
@@ -191,7 +188,6 @@ namespace QuoteSwift
             this.BtnUpdateTelephoneNumber.TabIndex = 8;
             this.BtnUpdateTelephoneNumber.Text = "Update Selected Phone Number";
             this.BtnUpdateTelephoneNumber.UseVisualStyleBackColor = true;
-            this.BtnUpdateTelephoneNumber.Click += new System.EventHandler(this.BtnUpdateTelephoneNumber_Click);
             //
             // txtNewTelephone
             //

--- a/frmManagingPhoneNumbers.cs
+++ b/frmManagingPhoneNumbers.cs
@@ -19,6 +19,7 @@ namespace QuoteSwift
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -38,43 +39,13 @@ namespace QuoteSwift
 
             CommandBindings.Bind(btnRemoveTelNumber, viewModel.RemoveSelectedTelephoneCommand);
             CommandBindings.Bind(btnRemoveCellNumber, viewModel.RemoveSelectedCellphoneCommand);
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(BtnUpdateTelephoneNumber, viewModel.EditTelephoneCommand);
+            CommandBindings.Bind(BtnUpdateCellphoneNumber, viewModel.EditCellphoneCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                Application.Exit();
-            }
-        }
 
-        private void BtnChangePhoneNumberInfo_Click(object sender, EventArgs e)
-        {
-            if (viewModel.Business != null && viewModel.Business.BusinessCellphoneNumberList != null)
-            {
-                string oldNumber = viewModel.SelectedCellphoneNumber?.Number ?? string.Empty;
-                navigation?.EditPhoneNumber(viewModel.Business, null, oldNumber);
-            }
-            else if (viewModel.Customer != null && viewModel.Customer.CustomerCellphoneNumberList != null)
-            {
-                string oldNumber = viewModel.SelectedCellphoneNumber?.Number ?? string.Empty;
-                navigation?.EditPhoneNumber(null, viewModel.Customer, oldNumber);
-            }
-        }
-
-        private void BtnUpdateTelephoneNumber_Click(object sender, EventArgs e)
-        {
-            if (viewModel.Business != null && viewModel.Business.BusinessTelephoneNumberList != null)
-            {
-                string oldNumber = viewModel.SelectedTelephoneNumber?.Number ?? string.Empty;
-                navigation?.EditPhoneNumber(viewModel.Business, null, oldNumber);
-            }
-            else if (viewModel.Customer != null && viewModel.Customer.CustomerTelephoneNumberList != null)
-            {
-                string oldNumber = viewModel.SelectedTelephoneNumber?.Number ?? string.Empty;
-                navigation?.EditPhoneNumber(null, viewModel.Customer, oldNumber);
-            }
-        }
 
         private void FrmManagingPhoneNumbers_Load(object sender, EventArgs e)
         {
@@ -99,10 +70,7 @@ namespace QuoteSwift
         }
 
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();
-        }
+
 
 
 


### PR DESCRIPTION
## Summary
- move FrmAddPart actions into AddPartViewModel
- move email management events into ManageEmailsViewModel
- move phone management events into ManagePhoneNumbersViewModel
- move business address events into EditBusinessAddressViewModel
- bind new commands from each form
- remove obsolete event handler wiring

## Testing
- `apt-get update`
- `apt-get install -y mono-complete`
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace issue)*

------
https://chatgpt.com/codex/tasks/task_e_6880747af09c8325bcfb4d7e56bde923