### PR TITLE
Add notification logic to email edit viewmodel

### DIFF
--- a/FrmEditEmailAddress.cs
+++ b/FrmEditEmailAddress.cs
@@ -18,6 +18,7 @@ namespace QuoteSwift
             this.viewModel = viewModel;
             this.messageService = messageService;
             this.navigation = navigation;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -28,15 +29,7 @@ namespace QuoteSwift
 
         private void BtnUpdateBusinessEmail_Click(object sender, EventArgs e)
         {
-            viewModel.UpdateEmailCommand.Execute(null);
-            var result = viewModel.LastResult;
-            if (result.Success)
-            {
-                messageService.ShowInformation("The email address has been successfully updated", "INFORMATION - Email Address Successfully Updated");
-                Close();
-            }
-            else if (result.Message != null)
-                messageService.ShowError(result.Message, result.Caption);
+            viewModel.SaveCommand.Execute(null);
         }
 
         private void FrmEditEmailAddress_Load(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- inject `IMessageService` into `EditEmailAddressViewModel`
- add `SaveCommand` with success/error notifications and form close callback
- wire the callback from `FrmEditEmailAddress`
- simplify button click to execute the new command

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688081960d308325b1f3af613b0341d4