### PR TITLE
Add command-based rebate and date handling

### DIFF
--- a/Infrastructure/CommandBindings.cs
+++ b/Infrastructure/CommandBindings.cs
@@ -30,5 +30,18 @@ namespace QuoteSwift
                     command.Execute(null);
             };
         }
+
+        public static void Bind(DateTimePicker picker, ICommand command)
+        {
+            if (picker == null || command == null)
+                return;
+            picker.Enabled = command.CanExecute(picker);
+            command.CanExecuteChanged += (s, e) => picker.Enabled = command.CanExecute(picker);
+            picker.ValueChanged += (s, e) =>
+            {
+                if (command.CanExecute(picker))
+                    command.Execute(picker);
+            };
+        }
     }
 }

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -51,6 +51,7 @@ namespace QuoteSwift
         DateTime quoteCreationDate = DateTime.Today;
         DateTime quoteExpiryDate = DateTime.Today;
         DateTime paymentTerm = DateTime.Today;
+        decimal rebateInput;
 
         Quote quoteToChange;
         bool changeSpecificObject;
@@ -60,6 +61,8 @@ namespace QuoteSwift
         public ICommand LoadDataCommand { get; }
         public ICommand ExportQuoteCommand { get; }
         public ICommand ExitCommand { get; }
+        public ICommand CalculateRebateCommand { get; }
+        public ICommand UpdateDatesCommand { get; }
 
         Quote lastCreatedQuote;
         public Quote LastCreatedQuote
@@ -141,6 +144,12 @@ namespace QuoteSwift
                 navigation?.SaveAllData();
                 System.Windows.Forms.Application.Exit();
             });
+            CalculateRebateCommand = new RelayCommand(_ =>
+            {
+                Pricing.Rebate = RebateInput;
+                Calculate();
+            });
+            UpdateDatesCommand = new RelayCommand(p => UpdateDates(p as System.Windows.Forms.DateTimePicker));
         }
 
         public IDataService DataService => dataService;
@@ -532,6 +541,12 @@ namespace QuoteSwift
             set => SetProperty(ref paymentTerm, value);
         }
 
+        public decimal RebateInput
+        {
+            get => rebateInput;
+            set => SetProperty(ref rebateInput, value);
+        }
+
         public string BusinessPOBoxNumberDisplay =>
             SelectedBusinessPOBox != null ?
                 $"P.O.Box Number {SelectedBusinessPOBox.AddressStreetNumber}" : string.Empty;
@@ -771,6 +786,22 @@ namespace QuoteSwift
 
             var part = NonMandatoryParts?.FirstOrDefault(p => p.PumpPart.PumpPart.PartDescription == description);
             return part?.Price ?? 0m;
+        }
+
+        void UpdateDates(System.Windows.Forms.DateTimePicker picker)
+        {
+            if (picker == null)
+                return;
+            if (picker.Name == "dtpQuoteCreationDate")
+            {
+                QuoteExpiryDate = QuoteCreationDate.AddMonths(2);
+                PaymentTerm = QuoteCreationDate.AddMonths(1);
+            }
+            else if (picker.Name == "dtpQuoteExpiryDate")
+            {
+                QuoteCreationDate = QuoteExpiryDate.AddMonths(-2);
+                PaymentTerm = QuoteCreationDate.AddMonths(1);
+            }
         }
 
         public void UpdateNextQuoteNumber()

--- a/frmCreateQuote.Designer.cs
+++ b/frmCreateQuote.Designer.cs
@@ -376,7 +376,6 @@ namespace QuoteSwift
             this.dtpQuoteExpiryDate.Name = "dtpQuoteExpiryDate";
             this.dtpQuoteExpiryDate.Size = new System.Drawing.Size(326, 24);
             this.dtpQuoteExpiryDate.TabIndex = 11;
-            this.dtpQuoteExpiryDate.ValueChanged += new System.EventHandler(this.DtpQuoteExpiryDate_ValueChanged);
             // 
             // dtpQuoteCreationDate
             // 
@@ -385,7 +384,6 @@ namespace QuoteSwift
             this.dtpQuoteCreationDate.Name = "dtpQuoteCreationDate";
             this.dtpQuoteCreationDate.Size = new System.Drawing.Size(326, 24);
             this.dtpQuoteCreationDate.TabIndex = 10;
-            this.dtpQuoteCreationDate.ValueChanged += new System.EventHandler(this.DtpQuoteCreationDate_ValueChanged);
             // 
             // lblQuoteExpiryDate
             // 
@@ -1097,7 +1095,6 @@ namespace QuoteSwift
             this.BtnCalculateRebate.TabIndex = 22;
             this.BtnCalculateRebate.Text = "Recalculate";
             this.BtnCalculateRebate.UseVisualStyleBackColor = true;
-            this.BtnCalculateRebate.Click += new System.EventHandler(this.BtnCalculateRebate_Click);
             // 
             // lblRebateTestInput
             // 

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -244,6 +244,7 @@ namespace QuoteSwift
             BindingHelpers.BindValue(dtpQuoteCreationDate, viewModel, nameof(CreateQuoteViewModel.QuoteCreationDate));
             BindingHelpers.BindValue(dtpQuoteExpiryDate, viewModel, nameof(CreateQuoteViewModel.QuoteExpiryDate));
             BindingHelpers.BindValue(dtpPaymentTerm, viewModel, nameof(CreateQuoteViewModel.PaymentTerm));
+            mtxtRebate.DataBindings.Add("Value", viewModel, nameof(CreateQuoteViewModel.RebateInput), false, DataSourceUpdateMode.OnPropertyChanged);
 
             BindingHelpers.BindText(cbxBusinessTelephoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessTelephone));
             BindingHelpers.BindText(cbxBusinessCellphoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessCellphone));
@@ -276,6 +277,11 @@ namespace QuoteSwift
             UpdatePricingDisplay();
             CommandBindings.Bind(btnComplete, viewModel.SaveQuoteCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(BtnCalculateRebate, viewModel.CalculateRebateCommand);
+            CommandBindings.Bind(dtpQuoteCreationDate, viewModel.UpdateDatesCommand);
+            CommandBindings.Bind(dtpQuoteExpiryDate, viewModel.UpdateDatesCommand);
+            viewModel.PropertyChanged += ViewModel_PropertyChanged;
+            viewModel.Pricing.PropertyChanged += Pricing_PropertyChanged;
         }
 
         void UpdatePricingDisplay()
@@ -288,24 +294,7 @@ namespace QuoteSwift
             lblRepairPercentage.Text = "Repair Percentage: " + viewModel.RepairPercentage + "%";
         }
 
-        private void BtnCalculateRebate_Click(object sender, EventArgs e)
-        {
-            viewModel.Pricing.Rebate = ParsingService.ParseDecimal(mtxtRebate.Text);
-            viewModel.Calculate();
-            UpdatePricingDisplay();
-        }
 
-        private void DtpQuoteCreationDate_ValueChanged(object sender, EventArgs e)
-        {
-            dtpQuoteExpiryDate.Value = dtpQuoteCreationDate.Value.AddMonths(2);
-            dtpPaymentTerm.Value = dtpQuoteCreationDate.Value.AddMonths(1);
-        }
-
-        private void DtpQuoteExpiryDate_ValueChanged(object sender, EventArgs e)
-        {
-            dtpQuoteCreationDate.Value = dtpQuoteExpiryDate.Value.AddMonths(-2);
-            dtpPaymentTerm.Value = dtpQuoteCreationDate.Value.AddMonths(1);
-        }
 
         private void CbxCustomerPOBoxSelection_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -330,6 +319,20 @@ namespace QuoteSwift
         private async System.Threading.Tasks.Task ExportQuoteToTemplateAsync(Quote q)
         {
             await ((AsyncRelayCommand)viewModel.ExportQuoteCommand).ExecuteAsync(q);
+        }
+
+        void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(CreateQuoteViewModel.Pricing))
+            {
+                viewModel.Pricing.PropertyChanged += Pricing_PropertyChanged;
+                UpdatePricingDisplay();
+            }
+        }
+
+        void Pricing_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            UpdatePricingDisplay();
         }
 
 


### PR DESCRIPTION
## Summary
- add `CalculateRebateCommand` and `UpdateDatesCommand` to `CreateQuoteViewModel`
- store rebate entry in new `RebateInput` property
- implement date update logic inside view model
- extend `CommandBindings` to bind `DateTimePicker` events
- bind rebate button and date pickers to the new commands
- remove obsolete event handlers

## Testing
- `xbuild QuoteSwift.sln /verbosity:minimal /target:Build` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_688081a979cc83259f2f068fc5dc6b13