### PR TITLE
Handle invalid parameters on AddBusiness form

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -487,6 +487,19 @@ namespace QuoteSwift
             return false;
         }
 
+        public OperationResult InitializeCurrentBusinessResult()
+        {
+            if (InitializeCurrentBusiness())
+            {
+                return OperationResult.Successful();
+            }
+
+            return OperationResult.Failure(
+                "The form was activated without the correct parameters to have an achievable goal.\n" +
+                "The Form's input parameters will be disabled to avoid possible data corruption.",
+                "ERROR - Undefined Form Use Called");
+        }
+
         public void EnsureLegalDetails()
         {
             if (CurrentBusiness != null && CurrentBusiness.BusinessLegalDetails == null)

--- a/frmAddBusiness.cs
+++ b/frmAddBusiness.cs
@@ -44,9 +44,9 @@ namespace QuoteSwift
         private async void FrmAddBusiness_Load(object sender, EventArgs e)
         {
             await viewModel.LoadDataAsync();
-            if (!viewModel.InitializeCurrentBusiness())
+            var initResult = viewModel.InitializeCurrentBusinessResult();
+            if (!initResult.Success)
             {
-                messageService.ShowError("The form was activated without the correct parameters to have an achievable goal.\nThe Form's input parameters will be disabled to avoid possible data corruption.", "ERROR - Undefined Form Use Called");
                 DisableMainComponents();
             }
 
@@ -110,6 +110,17 @@ namespace QuoteSwift
             CommandBindings.Bind(btnViewAll, viewModel.ViewPhoneNumbersCommand);
             CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+        }
+
+        private void DisableMainComponents()
+        {
+            gbxBusinessAddress.Enabled = false;
+            gbxBusinessInformation.Enabled = false;
+            gbxPhoneRelated.Enabled = false;
+            gbxEmailRelated.Enabled = false;
+            gbxLegalInformation.Enabled = false;
+            gbxPOBoxAddress.Enabled = false;
+            btnAddBusiness.Enabled = false;
         }
 
         /**********************************************************************************/


### PR DESCRIPTION
## Summary
- expose an `InitializeCurrentBusinessResult` helper in `AddBusinessViewModel`
- use it during form load for `FrmAddBusiness`
- disable the form when initialization fails

## Testing
- `dotnet msbuild QuoteSwift.sln /nologo /verbosity:minimal` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688081bb75a08325bf5967fa6c5c0074