### PR TITLE
Remove unused combo box handlers

### DIFF
--- a/frmCreateQuote.Designer.cs
+++ b/frmCreateQuote.Designer.cs
@@ -301,7 +301,6 @@ namespace QuoteSwift
             this.CbxPOBoxSelection.Size = new System.Drawing.Size(315, 26);
             this.CbxPOBoxSelection.TabIndex = 2;
             this.CbxPOBoxSelection.Text = "Business Selection";
-            this.CbxPOBoxSelection.SelectedIndexChanged += new System.EventHandler(this.CbxPOBoxSelection_SelectedIndexChanged);
             // 
             // lblBusinessPOBoxAreaCode
             // 
@@ -352,7 +351,6 @@ namespace QuoteSwift
             this.cbxBusinessSelection.Size = new System.Drawing.Size(389, 26);
             this.cbxBusinessSelection.TabIndex = 1;
             this.cbxBusinessSelection.Text = "Business Selection";
-            this.cbxBusinessSelection.SelectedIndexChanged += new System.EventHandler(this.CbxBusinessSelection_SelectedIndexChanged);
             // 
             // panel1
             // 
@@ -532,7 +530,6 @@ namespace QuoteSwift
             this.CbxCustomerPOBoxSelection.Size = new System.Drawing.Size(312, 26);
             this.CbxCustomerPOBoxSelection.TabIndex = 7;
             this.CbxCustomerPOBoxSelection.Text = "Customer P.O.Box Selection";
-            this.CbxCustomerPOBoxSelection.SelectedIndexChanged += new System.EventHandler(this.CbxCustomerPOBoxSelection_SelectedIndexChanged);
             // 
             // lblCustomerPOBoxStreetName
             // 
@@ -583,7 +580,6 @@ namespace QuoteSwift
             this.cbxCustomerSelection.Size = new System.Drawing.Size(400, 26);
             this.cbxCustomerSelection.TabIndex = 6;
             this.cbxCustomerSelection.Text = "Customer Selection";
-            this.cbxCustomerSelection.SelectedIndexChanged += new System.EventHandler(this.CbxCustomerSelection_SelectedIndexChanged);
             // 
             // panel3
             // 
@@ -637,7 +633,6 @@ namespace QuoteSwift
             this.cbxCustomerDeliveryAddress.Size = new System.Drawing.Size(400, 26);
             this.cbxCustomerDeliveryAddress.TabIndex = 12;
             this.cbxCustomerDeliveryAddress.Text = "Customer Delivery Address Selection";
-            this.cbxCustomerDeliveryAddress.SelectedIndexChanged += new System.EventHandler(this.CbxCustomerDeliveryAddress_SelectedIndexChanged);
             // 
             // panel4
             // 

--- a/frmCreateQuote.cs
+++ b/frmCreateQuote.cs
@@ -152,23 +152,6 @@ namespace QuoteSwift
             DgvNonMandatoryPartReplacement.RowsDefaultCellStyle.BackColor = Color.Bisque;
             DgvNonMandatoryPartReplacement.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
         }
-
-        private void CbxCustomerSelection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void CbxBusinessSelection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void CbxPOBoxSelection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
-        private void CbxCustomerDeliveryAddress_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
-
         private void DgvMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
         {
             viewModel.Calculate();
@@ -294,11 +277,6 @@ namespace QuoteSwift
             lblRepairPercentage.Text = "Repair Percentage: " + viewModel.RepairPercentage + "%";
         }
 
-
-
-        private void CbxCustomerPOBoxSelection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-        }
 
 
         private void CbxUseAutomaticNumberingScheme_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- delete unused `SelectedIndexChanged` methods from `FrmCreateQuote`
- drop the related designer event subscriptions

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: missing .NET Framework 4.8 reference assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_688085ac9dc4832588f08f5f2190fa05