### PR TITLE
Implement cancellation and exit commands

### DIFF
--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -46,6 +46,10 @@ namespace QuoteSwift
         public ICommand UpdateCustomerCommand { get; }
         public ICommand SaveCustomerCommand { get; }
         public ICommand LoadDataCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ExitCommand { get; }
+
+        public Action CloseAction { get; set; }
 
         public OperationResult LastResult
         {
@@ -293,6 +297,25 @@ namespace QuoteSwift
                 }
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
+
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService.RequestConfirmation(
+                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
+                        "REQUEST - Cancellation"))
+                    CloseAction?.Invoke();
+            });
+
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination"))
+                {
+                    navigation?.SaveAllData();
+                    System.Windows.Forms.Application.Exit();
+                }
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -15,6 +15,8 @@ namespace QuoteSwift
 
         public ICommand UpdateEmailCommand { get; }
         public ICommand SaveCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ExitCommand { get; }
 
         public Action CloseAction { get; set; }
 
@@ -41,6 +43,24 @@ namespace QuoteSwift
                 }
                 else if (result.Message != null)
                     messageService?.ShowError(result.Message, result.Caption);
+            });
+
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
+                        "REQUEST - Cancellation") == true)
+                    CloseAction?.Invoke();
+            });
+
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination") == true)
+                {
+                    System.Windows.Forms.Application.Exit();
+                }
             });
         }
 

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -7,20 +7,40 @@ namespace QuoteSwift
     {
         Business business;
         Customer customer;
+        readonly IMessageService messageService;
         OperationResult lastResult = OperationResult.Successful();
         string originalNumber;
         string currentNumber;
 
         public ICommand UpdateNumberCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ExitCommand { get; }
+
+        public Action CloseAction { get; set; }
 
 
-        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "")
+        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "", IMessageService messageService = null)
         {
+            this.messageService = messageService;
             Initialize(business, customer, number);
             UpdateNumberCommand = new RelayCommand(_ =>
             {
                 var r = UpdateNumber();
                 LastResult = r;
+            });
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "By canceling the current event, any parts not added will not be available in the part's list.",
+                        "REQUEAST - Action Cancellation") == true)
+                    CloseAction?.Invoke();
+            });
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination") == true)
+                    System.Windows.Forms.Application.Exit();
             });
         }
 

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -14,6 +14,10 @@ namespace QuoteSwift
         public ICommand LoadDataCommand { get; }
         public ICommand AddBusinessCommand { get; }
         public ICommand UpdateBusinessCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ExitCommand { get; }
+
+        public Action CloseAction { get; set; }
 
 
         public ViewBusinessesViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
@@ -37,6 +41,25 @@ namespace QuoteSwift
                     messageService?.ShowError("Please select a valid Business, the current selection is invalid", "ERROR - Invalid Business Selection");
                 }
             }, _ => Task.FromResult(SelectedBusiness != null));
+
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
+                        "REQUEST - Cancellation") == true)
+                    CloseAction?.Invoke();
+            });
+
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination") == true)
+                {
+                    navigation?.SaveAllData();
+                    System.Windows.Forms.Application.Exit();
+                }
+            });
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -19,6 +19,10 @@ namespace QuoteSwift
         public ICommand LoadDataCommand { get; }
         public ICommand AddCustomerCommand { get; }
         public ICommand UpdateCustomerCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ExitCommand { get; }
+
+        public Action CloseAction { get; set; }
 
 
         public ViewCustomersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
@@ -42,6 +46,25 @@ namespace QuoteSwift
                     messageService?.ShowError("Please select a valid customer, the current selection is invalid", "ERROR - Invalid Customer Selection");
                 }
             }, _ => Task.FromResult(SelectedCustomer != null));
+
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.",
+                        "REQUEST - Cancellation") == true)
+                    CloseAction?.Invoke();
+            });
+
+            ExitCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination") == true)
+                {
+                    navigation?.SaveAllData();
+                    System.Windows.Forms.Application.Exit();
+                }
+            });
         }
 
         public BindingList<Business> Businesses

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -25,6 +25,9 @@ namespace QuoteSwift
         public ICommand RemovePumpCommand { get; }
         public ICommand ExportInventoryCommand { get; }
         public ICommand ExitCommand { get; }
+        public ICommand CancelCommand { get; }
+
+        public Action CloseAction { get; set; }
 
 
         public ViewPumpViewModel(IDataService service, ISerializationService serializer,
@@ -43,8 +46,21 @@ namespace QuoteSwift
             ExportInventoryCommand = new AsyncRelayCommand(_ => ExportInventoryActionAsync());
             ExitCommand = new RelayCommand(_ =>
             {
-                navigation?.SaveAllData();
-                System.Windows.Forms.Application.Exit();
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to close the application?",
+                        "REQUEST - Application Termination") == true)
+                {
+                    navigation?.SaveAllData();
+                    System.Windows.Forms.Application.Exit();
+                }
+            });
+
+            CancelCommand = new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(
+                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
+                        "REQUEST - Cancellation") == true)
+                    CloseAction?.Invoke();
             });
         }
 

--- a/Views/FrmEditEmailAddress.cs
+++ b/Views/FrmEditEmailAddress.cs
@@ -38,19 +38,20 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.", "REQUEST - Cancelation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?\nAny unsaved work will be lost.", "REQUEST - Application Termination"))
-                Application.Exit();
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                Application.Exit();
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/FrmEditPhoneNumber.cs
+++ b/Views/FrmEditPhoneNumber.cs
@@ -18,6 +18,7 @@ namespace QuoteSwift.Views
             this.viewModel = viewModel;
             this.messageService = messageService;
             this.navigation = navigation;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -45,13 +46,14 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                Application.Exit();
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/frmAddCustomer.cs
+++ b/Views/frmAddCustomer.cs
@@ -24,6 +24,7 @@ namespace QuoteSwift.Views
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
             BindIsBusy(viewModel);
 
@@ -66,11 +67,9 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                navigation?.SaveAllData();
-                Application.Exit();
-            }
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
+        }
 
 
         private async void FrmAddCustomer_Load(object sender, EventArgs e)
@@ -114,7 +113,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void BtnViewAll_Click(object sender, EventArgs e)

--- a/Views/frmAddPump.cs
+++ b/Views/frmAddPump.cs
@@ -27,6 +27,7 @@ namespace QuoteSwift.Views
             appData = data;
             this.serializationService = serializationService;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             viewModel.CurrentPump = viewModel.PumpToChange ?? new Pump();
             mtxtPumpName.DataBindings.Add("Text", viewModel.CurrentPump, nameof(Pump.PumpName), false, DataSourceUpdateMode.OnPropertyChanged);
             mtxtPumpDescription.DataBindings.Add("Text", viewModel.CurrentPump, nameof(Pump.PumpDescription), false, DataSourceUpdateMode.OnPropertyChanged);
@@ -139,7 +140,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void UpdatePumpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/frmViewAllBusinesses.cs
+++ b/Views/frmViewAllBusinesses.cs
@@ -21,6 +21,7 @@ namespace QuoteSwift.Views
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -36,8 +37,8 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                Application.Exit();
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         // Legacy button handlers kept for reference; functionality now provided via commands
@@ -84,7 +85,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/frmViewCustomers.cs
+++ b/Views/frmViewCustomers.cs
@@ -22,6 +22,7 @@ namespace QuoteSwift.Views
             this.serializationService = serializationService;
             this.appData = appData;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
             BindIsBusy(viewModel);
         }
@@ -38,12 +39,8 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
 
         }
 
@@ -133,7 +130,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.", "REQUEST - Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/frmViewParts.cs
+++ b/Views/frmViewParts.cs
@@ -24,6 +24,7 @@ namespace QuoteSwift.Views
             this.serializationService = serializationService;
             appData = data;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             if (appData != null)
                 viewModel.UpdateData(appData.PartList);
             SetupBindings();
@@ -44,12 +45,9 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-                serializationService.CloseApplication(true,
-                    appData?.BusinessList,
-                    appData?.PumpList,
-                    appData?.PartList,
-                    appData?.QuoteMap);
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
+        }
 
         private void FrmViewParts_Activated(object sender, EventArgs e)
         {
@@ -75,7 +73,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.", "REQUEST - Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void FrmViewParts_Load(object sender, EventArgs e)

--- a/Views/frmViewPump.cs
+++ b/Views/frmViewPump.cs
@@ -41,6 +41,7 @@ namespace QuoteSwift.Views // Repair Quote Swift
             this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 


### PR DESCRIPTION
## Summary
- add CancelCommand and ExitCommand implementations across view models
- wire CloseAction callbacks for window closing
- update forms to execute new commands

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace not set)*

------
https://chatgpt.com/codex/tasks/task_e_68809a7ba2548325bd829a72687f5251