### PR TITLE
Bind cancel and exit commands

### DIFF
--- a/Views/FrmEditEmailAddress.Designer.cs
+++ b/Views/FrmEditEmailAddress.Designer.cs
@@ -47,7 +47,6 @@ namespace QuoteSwift.Views
             this.btnCancel.TabIndex = 2;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // mtxtEmail
             // 
@@ -95,7 +94,6 @@ namespace QuoteSwift.Views
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click_1);
             // 
             // FrmEditEmailAddress
             // 

--- a/Views/FrmEditEmailAddress.cs
+++ b/Views/FrmEditEmailAddress.cs
@@ -20,6 +20,8 @@ namespace QuoteSwift.Views
             this.navigation = navigation;
             viewModel.CloseAction = Close;
             SetupBindings();
+            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         void SetupBindings()
@@ -36,23 +38,7 @@ namespace QuoteSwift.Views
         {
         }
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
-        }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
-
-        private void CloseToolStripMenuItem_Click_1(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
+        // CommandBindings handle Cancel and Exit actions
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Views/FrmEditPhoneNumber.Designer.cs
+++ b/Views/FrmEditPhoneNumber.Designer.cs
@@ -47,7 +47,6 @@ namespace QuoteSwift.Views
             this.BtnCancel.TabIndex = 2;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // btnUpdateNumber
             // 
@@ -88,7 +87,6 @@ namespace QuoteSwift.Views
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // txtPhoneNumber
             // 

--- a/Views/FrmEditPhoneNumber.cs
+++ b/Views/FrmEditPhoneNumber.cs
@@ -20,6 +20,8 @@ namespace QuoteSwift.Views
             this.navigation = navigation;
             viewModel.CloseAction = Close;
             SetupBindings();
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         void SetupBindings()
@@ -44,17 +46,7 @@ namespace QuoteSwift.Views
                 messageService.ShowError(result.Message, result.Caption);
         }
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
-        }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
+        // CommandBindings handle Cancel and Exit actions
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Views/frmAddCustomer.Designer.cs
+++ b/Views/frmAddCustomer.Designer.cs
@@ -327,7 +327,6 @@ namespace QuoteSwift.Views
             this.btnCancel.TabIndex = 27;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // txtWorkPlace
             // 
@@ -371,7 +370,6 @@ namespace QuoteSwift.Views
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // gbxCustomerInformation
             // 

--- a/Views/frmAddCustomer.cs
+++ b/Views/frmAddCustomer.cs
@@ -63,12 +63,8 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnViewAllPOBoxAddresses, viewModel.ViewPOBoxAddressesCommand);
             CommandBindings.Bind(btnViewEmailAddresses, viewModel.ViewEmailAddressesCommand);
             CommandBindings.Bind(btnViewAddresses, viewModel.ViewAddressesCommand);
-        }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
 
@@ -110,12 +106,6 @@ namespace QuoteSwift.Views
 
 
 
-
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
-        }
 
         private void BtnViewAll_Click(object sender, EventArgs e)
         {

--- a/Views/frmAddPump.Designer.cs
+++ b/Views/frmAddPump.Designer.cs
@@ -276,7 +276,6 @@ namespace QuoteSwift.Views
             this.btnCancel.TabIndex = 4;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // btnAddPump
             // 

--- a/Views/frmAddPump.cs
+++ b/Views/frmAddPump.cs
@@ -35,19 +35,13 @@ namespace QuoteSwift.Views
             mandatorySource.DataSource = viewModel.SelectedMandatoryParts;
             nonMandatorySource.DataSource = viewModel.SelectedNonMandatoryParts;
             CommandBindings.Bind(btnAddPump, viewModel.SavePumpCommand);
+            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
             if (data != null)
                 viewModel.UpdateData(data.PumpList, data.PartList, viewModel.PumpToChange, viewModel.ChangeSpecificObject,
                                      data.PumpList != null ? new HashSet<string>(data.PumpList.Select(p => StringUtil.NormalizeKey(p.PumpName))) : null);
             BindIsBusy(viewModel);
         }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
-
 
         private void MtxtPumpName_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
         {
@@ -137,12 +131,6 @@ namespace QuoteSwift.Views
 
 
 
-
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
-        }
 
         private void UpdatePumpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Views/frmViewAllBusinesses.Designer.cs
+++ b/Views/frmViewAllBusinesses.Designer.cs
@@ -58,7 +58,6 @@ namespace QuoteSwift.Views
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // btnAddBusiness
             // 
@@ -121,7 +120,6 @@ namespace QuoteSwift.Views
             this.BtnCancel.TabIndex = 5;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // FrmViewAllBusinesses
             // 

--- a/Views/frmViewAllBusinesses.cs
+++ b/Views/frmViewAllBusinesses.cs
@@ -23,6 +23,8 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             viewModel.CloseAction = Close;
             SetupBindings();
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         void SetupBindings()
@@ -35,11 +37,7 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnAddBusiness, viewModel.AddBusinessCommand);
         }
 
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
+        // CommandBindings handle Exit action
 
         // Legacy button handlers kept for reference; functionality now provided via commands
         private void BtnUpdateBusiness_Click(object sender, EventArgs e) { }
@@ -83,11 +81,7 @@ namespace QuoteSwift.Views
         }
 
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
-        }
+        // CommandBindings handle Cancel action
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Views/frmViewCustomers.Designer.cs
+++ b/Views/frmViewCustomers.Designer.cs
@@ -61,7 +61,6 @@ namespace QuoteSwift.Views
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // DgvCustomerList
             // 
@@ -143,7 +142,6 @@ namespace QuoteSwift.Views
             this.BtnCancel.TabIndex = 6;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // clmCustomerCompanyName
             // 

--- a/Views/frmViewCustomers.cs
+++ b/Views/frmViewCustomers.cs
@@ -24,6 +24,8 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             viewModel.CloseAction = Close;
             SetupBindings();
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
             BindIsBusy(viewModel);
         }
 
@@ -37,12 +39,7 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnAddCustomer, viewModel.AddCustomerCommand);
         }
 
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-
-        }
+        // CommandBindings handle Exit action
 
 
         // Legacy button handlers kept for reference; functionality now provided via commands
@@ -128,11 +125,7 @@ namespace QuoteSwift.Views
             viewModel.SelectBusiness(GetSelectedBusiness());
         }
 
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
-        }
+        // CommandBindings handle Cancel action
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Views/frmViewParts.Designer.cs
+++ b/Views/frmViewParts.Designer.cs
@@ -63,7 +63,6 @@ namespace QuoteSwift.Views
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(57, 24);
             this.closeToolStripMenuItem.Text = "Close";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItem_Click);
             // 
             // dgvAllParts
             // 
@@ -171,7 +170,6 @@ namespace QuoteSwift.Views
             this.BtnCancel.TabIndex = 5;
             this.BtnCancel.Text = "Cancel";
             this.BtnCancel.UseVisualStyleBackColor = true;
-            this.BtnCancel.Click += new System.EventHandler(this.BtnCancel_Click);
             // 
             // FrmViewParts
             // 

--- a/Views/frmViewParts.cs
+++ b/Views/frmViewParts.cs
@@ -28,6 +28,8 @@ namespace QuoteSwift.Views
             if (appData != null)
                 viewModel.UpdateData(appData.PartList);
             SetupBindings();
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         void SetupBindings()
@@ -41,12 +43,6 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnAddPart, viewModel.AddPartCommand);
             CommandBindings.Bind(btnViewSelectedPart, viewModel.UpdatePartCommand);
             CommandBindings.Bind(btnRemovePart, viewModel.RemovePartCommand);
-        }
-
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
         }
 
         private void FrmViewParts_Activated(object sender, EventArgs e)
@@ -69,12 +65,6 @@ namespace QuoteSwift.Views
         Part GetSelectedPart()
         {
             return dgvAllParts.CurrentRow?.DataBoundItem as Part;
-        }
-
-        private void BtnCancel_Click(object sender, EventArgs e)
-        {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
         }
 
         private void FrmViewParts_Load(object sender, EventArgs e)

--- a/Views/frmViewPump.cs
+++ b/Views/frmViewPump.cs
@@ -45,11 +45,7 @@ namespace QuoteSwift.Views // Repair Quote Swift
             SetupBindings();
         }
 
-        private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
-        }
+        // CommandBindings handle Exit action
 
 
         private void MainScreenViewQuotesToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- wire up CancelCommand for several forms using `CommandBindings.Bind`
- remove event handlers that duplicate command behavior
- ensure ExitCommand is bound on close menu items

## Testing
- `xbuild QuoteSwift.sln` *(fails: default namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_6880a2a5e83483258bcca0340916bddb