### PR TITLE
Introduce application service for exiting app

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -19,6 +19,7 @@ namespace QuoteSwift
             services.AddSingleton<IDataService, FileDataService>();
             services.AddSingleton<INotificationService, MessageBoxNotificationService>();
             services.AddSingleton<IFileDialogService, FileDialogService>();
+            services.AddSingleton<IApplicationService, WinFormsApplicationService>();
             services.AddSingleton<ApplicationData>();
             services.AddSingleton<IExcelExportService, FileExcelExportService>();
             services.AddSingleton<INavigationService, NavigationService>();

--- a/QuoteSwift.csproj
+++ b/QuoteSwift.csproj
@@ -250,6 +250,8 @@
     <Compile Include="Services\ParsingService.cs" />
     <Compile Include="Services\IExcelExportService.cs" />
     <Compile Include="Services\FileExcelExportService.cs" />
+    <Compile Include="Services\IApplicationService.cs" />
+    <Compile Include="Services\WinFormsApplicationService.cs" />
     <Compile Include="ViewModels\QuotesViewModel.cs" />
     <Compile Include="ViewModels\AddCustomerViewModel.cs" />
     <Compile Include="ViewModels\ViewCustomersViewModel.cs" />

--- a/Services/IApplicationService.cs
+++ b/Services/IApplicationService.cs
@@ -1,0 +1,7 @@
+namespace QuoteSwift
+{
+    public interface IApplicationService
+    {
+        void Exit();
+    }
+}

--- a/Services/WinFormsApplicationService.cs
+++ b/Services/WinFormsApplicationService.cs
@@ -1,0 +1,12 @@
+using System.Windows.Forms;
+
+namespace QuoteSwift
+{
+    public class WinFormsApplicationService : IApplicationService
+    {
+        public void Exit()
+        {
+            Application.Exit();
+        }
+    }
+}

--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         BindingList<Business> businessList;
         readonly Dictionary<string, Business> businessLookup = new Dictionary<string, Business>();
         readonly HashSet<string> businessVatNumbers = new HashSet<string>();
@@ -190,11 +191,13 @@ namespace QuoteSwift
 
         public AddBusinessViewModel(IDataService service,
                                     INavigationService navigation,
-                                    IMessageService messageService)
+                                    IMessageService messageService,
+                                    IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             AddBusinessCommand = new RelayCommand(_ =>
             {
                 var result = AddBusiness();
@@ -331,7 +334,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination"))
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly INotificationService notificationService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         BindingList<Business> businessList;
         Customer customerToChange;
         bool changeSpecificObject;
@@ -167,12 +168,14 @@ namespace QuoteSwift
         public AddCustomerViewModel(IDataService service,
                                     INotificationService notifier,
                                     INavigationService navigation,
-                                    IMessageService messageService)
+                                    IMessageService messageService,
+                                    IApplicationService applicationService = null)
         {
             dataService = service;
             notificationService = notifier;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             currentCustomer = new Customer();
             AddCustomerCommand = new RelayCommand(p =>
             {
@@ -313,7 +316,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination"))
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -14,6 +14,7 @@ namespace QuoteSwift
         readonly IMessageService messageService;
         readonly IFileDialogService fileDialogService;
         readonly INavigationService navigation;
+        readonly IApplicationService applicationService;
         Dictionary<string, Part> partMap;
         BindingList<Pump> pumpList;
         Part partToChange;
@@ -74,13 +75,14 @@ namespace QuoteSwift
 
         public AddPartViewModel(IDataService service, INotificationService notifier,
                                 IMessageService messenger = null, IFileDialogService dialogService = null,
-                                INavigationService navigation = null)
+                                INavigationService navigation = null, IApplicationService applicationService = null)
         {
             dataService = service;
             notificationService = notifier;
             messageService = messenger;
             fileDialogService = dialogService;
             this.navigation = navigation;
+            this.applicationService = applicationService;
             CurrentPart = new Part();
             SavePartCommand = new RelayCommand(_ =>
             {
@@ -130,7 +132,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination"))
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
 

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly INotificationService notificationService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         Pump currentPump;
         bool lastOperationSuccessful;
         string formTitle;
@@ -111,12 +112,14 @@ namespace QuoteSwift
         public AddPumpViewModel(IDataService service,
                                 INotificationService notifier,
                                 INavigationService navigation = null,
-                                IMessageService messageService = null)
+                                IMessageService messageService = null,
+                                IApplicationService applicationService = null)
         {
             dataService = service;
             notificationService = notifier;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             SelectedMandatoryParts = new BindingList<Pump_Part>();
             SelectedNonMandatoryParts = new BindingList<Pump_Part>();
             RepairableItemNames = new HashSet<string>();
@@ -137,7 +140,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination") == true)
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
 

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -12,6 +12,7 @@ namespace QuoteSwift
         readonly INotificationService notificationService;
         readonly IExcelExportService excelExportService;
         readonly INavigationService navigation;
+        readonly IApplicationService applicationService;
         Dictionary<string, Part> partList;
         BindingList<Pump> pumps;
         BindingList<Business> businesses;
@@ -129,12 +130,14 @@ namespace QuoteSwift
         public CreateQuoteViewModel(IDataService service,
                                     INotificationService notifier,
                                     IExcelExportService excelExporter,
-                                    INavigationService navigation = null)
+                                    INavigationService navigation = null,
+                                    IApplicationService applicationService = null)
         {
             dataService = service;
             notificationService = notifier;
             excelExportService = excelExporter;
             this.navigation = navigation;
+            this.applicationService = applicationService;
             AddQuoteCommand = new RelayCommand(q => AddQuote(q as Quote));
             SaveQuoteCommand = new RelayCommand(_ => LastCreatedQuote = CreateAndSaveQuote());
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
@@ -142,7 +145,7 @@ namespace QuoteSwift
             ExitCommand = new RelayCommand(_ =>
             {
                 navigation?.SaveAllData();
-                System.Windows.Forms.Application.Exit();
+                applicationService?.Exit();
             });
             CalculateRebateCommand = new RelayCommand(_ =>
             {

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         Address address;
         readonly IMessageService messageService;
         readonly INavigationService navigation;
+        readonly IApplicationService applicationService;
 
         string addressDescription = string.Empty;
         int streetNumber;
@@ -77,10 +78,11 @@ namespace QuoteSwift
         }
 
 
-        public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null, IMessageService messageService = null, INavigationService navigation = null)
+        public EditBusinessAddressViewModel(Business business = null, Customer customer = null, Address address = null, IMessageService messageService = null, INavigationService navigation = null, IApplicationService applicationService = null)
         {
             this.messageService = messageService;
             this.navigation = navigation;
+            this.applicationService = applicationService;
             Initialize(business, customer, address);
 
             UpdateAddressCommand = new RelayCommand(_ =>
@@ -127,7 +129,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination") == true)
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -9,6 +9,7 @@ namespace QuoteSwift
         Business business;
         Customer customer;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         OperationResult lastResult = OperationResult.Successful();
         string originalEmail;
         string currentEmail;
@@ -23,9 +24,11 @@ namespace QuoteSwift
         public EditEmailAddressViewModel(Business business = null,
                                           Customer customer = null,
                                           string email = null,
-                                          IMessageService messageService = null)
+                                          IMessageService messageService = null,
+                                          IApplicationService applicationService = null)
         {
             this.messageService = messageService;
+            this.applicationService = applicationService;
             Initialize(business, customer, email);
             UpdateEmailCommand = new RelayCommand(_ =>
             {
@@ -59,7 +62,7 @@ namespace QuoteSwift
                         "Are you sure you want to close the application?",
                         "REQUEST - Application Termination") == true)
                 {
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -8,6 +8,7 @@ namespace QuoteSwift
         Business business;
         Customer customer;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         OperationResult lastResult = OperationResult.Successful();
         string originalNumber;
         string currentNumber;
@@ -19,9 +20,10 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "", IMessageService messageService = null)
+        public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "", IMessageService messageService = null, IApplicationService applicationService = null)
         {
             this.messageService = messageService;
+            this.applicationService = applicationService;
             Initialize(business, customer, number);
             UpdateNumberCommand = new RelayCommand(_ =>
             {
@@ -40,7 +42,7 @@ namespace QuoteSwift
                 if (messageService?.RequestConfirmation(
                         "Are you sure you want to close the application?",
                         "REQUEST - Application Termination") == true)
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
             });
         }
 

--- a/ViewModels/ManageEmailsViewModel.cs
+++ b/ViewModels/ManageEmailsViewModel.cs
@@ -13,6 +13,7 @@ namespace QuoteSwift
         readonly BindingList<EmailEntry> emails;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         EmailEntry selectedEmail;
         string newEmail;
 
@@ -27,11 +28,12 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public ManageEmailsViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
+        public ManageEmailsViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             emails = new BindingList<EmailEntry>();
             AddEmailCommand = new RelayCommand(
                 _ => { AddEmail(NewEmail); NewEmail = string.Empty; },
@@ -52,7 +54,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination"))
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
 

--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -18,6 +18,7 @@ namespace QuoteSwift
         string newCellphoneNumber;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
 
         public ICommand RemoveTelephoneCommand { get; }
         public ICommand RemoveCellphoneCommand { get; }
@@ -35,11 +36,12 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public ManagePhoneNumbersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
+        public ManagePhoneNumbersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             telephoneNumbers = new BindingList<NumberEntry>();
             cellphoneNumbers = new BindingList<NumberEntry>();
             RemoveTelephoneCommand = new RelayCommand(n => RemoveTelephone(n as string));
@@ -73,7 +75,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination"))
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
 

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -8,6 +8,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         readonly BindingList<Address> addresses = new BindingList<Address>();
         Business business;
         Customer customer;
@@ -22,11 +23,13 @@ namespace QuoteSwift
 
         public ViewBusinessAddressesViewModel(IDataService service,
                                               INavigationService navigation,
-                                              IMessageService messageService)
+                                              IMessageService messageService,
+                                              IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             RemoveSelectedAddressCommand = new RelayCommand(
                 _ => RemoveAddress(SelectedAddress),
                 _ => SelectedAddress != null);
@@ -36,7 +39,7 @@ namespace QuoteSwift
             ExitCommand = new RelayCommand(_ =>
             {
                 navigation?.SaveAllData();
-                System.Windows.Forms.Application.Exit();
+                applicationService?.Exit();
             });
         }
 

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -8,6 +8,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         BindingList<Business> businesses;
         Business selectedBusiness;
 
@@ -20,11 +21,12 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public ViewBusinessesViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
+        public ViewBusinessesViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             AddBusinessCommand = new AsyncRelayCommand(async _ =>
             {
@@ -57,7 +59,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination") == true)
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         BindingList<Business> businesses;
         SortedDictionary<string, Quote> quoteMap;
         Business selectedBusiness;
@@ -25,11 +26,12 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public ViewCustomersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
+        public ViewCustomersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             AddCustomerCommand = new AsyncRelayCommand(async _ =>
             {
@@ -62,7 +64,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination") == true)
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -11,6 +11,7 @@ namespace QuoteSwift
         readonly IDataService dataService;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
+        readonly IApplicationService applicationService;
         Dictionary<string, Part> partList;
         readonly BindingList<Part> mandatoryParts;
         readonly BindingList<Part> nonMandatoryParts;
@@ -27,11 +28,12 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public ViewPartsViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null)
+        public ViewPartsViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
         {
             dataService = service;
             this.navigation = navigation;
             this.messageService = messageService;
+            this.applicationService = applicationService;
             mandatoryParts = new BindingList<Part>();
             nonMandatoryParts = new BindingList<Part>();
             allParts = new BindingList<Part>();
@@ -56,7 +58,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination") == true)
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
         }

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -15,6 +15,7 @@ namespace QuoteSwift
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly IFileDialogService fileDialogService;
+        readonly IApplicationService applicationService;
         HashSet<string> repairableItemNames;
 
         Pump selectedPump;
@@ -32,13 +33,14 @@ namespace QuoteSwift
 
         public ViewPumpViewModel(IDataService service, ISerializationService serializer,
                                  INavigationService navigation = null, IMessageService messageService = null,
-                                 IFileDialogService dialogService = null)
+                                 IFileDialogService dialogService = null, IApplicationService applicationService = null)
         {
             dataService = service;
             serializationService = serializer;
             this.navigation = navigation;
             this.messageService = messageService;
             fileDialogService = dialogService;
+            this.applicationService = applicationService;
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             AddPumpCommand = new AsyncRelayCommand(_ => AddPumpAsync());
             UpdatePumpCommand = new AsyncRelayCommand(_ => UpdatePumpAsync(), _ => Task.FromResult(SelectedPump != null));
@@ -51,7 +53,7 @@ namespace QuoteSwift
                         "REQUEST - Application Termination") == true)
                 {
                     navigation?.SaveAllData();
-                    System.Windows.Forms.Application.Exit();
+                    applicationService?.Exit();
                 }
             });
 


### PR DESCRIPTION
## Summary
- add `IApplicationService` interface and WinForms implementation
- register the new service in `Program.cs`
- inject `IApplicationService` into view models and replace direct calls to `Application.Exit`
- include new service files in the project

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_6880c97ec4f08325b321ea96cfb94379