### PR TITLE
Centralize close logic

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -206,6 +206,11 @@ namespace QuoteSwift
         public void SaveAllData()
         {
             appData.SaveAll();
+            serializationService.CloseApplication(true,
+                appData.BusinessList,
+                appData.PumpList,
+                appData.PartList,
+                appData.QuoteMap);
         }
     }
 }

--- a/Views/frmViewCustomers.cs
+++ b/Views/frmViewCustomers.cs
@@ -9,18 +9,14 @@ namespace QuoteSwift.Views
         readonly ViewCustomersViewModel viewModel;
         public ViewCustomersViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
-        readonly ISerializationService serializationService;
         readonly IMessageService messageService;
         readonly BindingSource customersBindingSource = new BindingSource();
-        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, ApplicationData appData = null, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
             : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            this.serializationService = serializationService;
-            this.appData = appData;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
             SetupBindings();
@@ -127,14 +123,7 @@ namespace QuoteSwift.Views
             //Still Needs Implementation.
         }
 
-        protected override void OnClose()
-        {
-            serializationService.CloseApplication(true,
-                appData?.BusinessList,
-                appData?.PumpList,
-                appData?.PartList,
-                appData?.QuoteMap);
-        }
+        // rely on base.OnClose for data persistence
 
         /**********************************************************************************/
     }


### PR DESCRIPTION
## Summary
- remove form-level calls to `CloseApplication`
- call `CloseApplication` from `NavigationService.SaveAllData`
- rely on base `OnClose` in `frmViewCustomers`

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880cc5a42ac8325ab1e551edc6433f2