### PR TITLE
Refactor pricing display binding

### DIFF
--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -157,6 +157,9 @@ namespace QuoteSwift
                 if (p is DateTime date)
                     UpdateDates(date);
             });
+
+            pricing.PropertyChanged += Pricing_PropertyChanged;
+            OnPricingChanged();
         }
 
         public IDataService DataService => dataService;
@@ -450,15 +453,45 @@ namespace QuoteSwift
             get => pricing;
             private set
             {
+                if (pricing != null)
+                    pricing.PropertyChanged -= Pricing_PropertyChanged;
                 pricing = value;
+                if (pricing != null)
+                    pricing.PropertyChanged += Pricing_PropertyChanged;
                 OnPropertyChanged(nameof(Pricing));
+                OnPricingChanged();
             }
         }
 
         public float RepairPercentage
         {
             get => repairPercentage;
-            private set => SetProperty(ref repairPercentage, value);
+            private set
+            {
+                if (SetProperty(ref repairPercentage, value))
+                    OnPropertyChanged(nameof(RepairPercentageDisplay));
+            }
+        }
+
+        public string PumpPriceDisplay => $"New Pump Price: R {Pricing.PumpPrice}";
+        public string RebateDisplay => $"R{Pricing.Rebate}";
+        public string SubTotalDisplay => $"R{Pricing.SubTotal}";
+        public string VATDisplay => $"R{Pricing.VAT}";
+        public string TotalDueDisplay => $"R{Pricing.TotalDue}";
+        public string RepairPercentageDisplay => $"Repair Percentage: {RepairPercentage}%";
+
+        void Pricing_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            OnPricingChanged();
+        }
+
+        void OnPricingChanged()
+        {
+            OnPropertyChanged(nameof(PumpPriceDisplay));
+            OnPropertyChanged(nameof(RebateDisplay));
+            OnPropertyChanged(nameof(SubTotalDisplay));
+            OnPropertyChanged(nameof(VATDisplay));
+            OnPropertyChanged(nameof(TotalDueDisplay));
         }
 
         public Address SelectedBusinessPOBox

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -95,7 +94,6 @@ namespace QuoteSwift.Views
         {
             mandatorySource.DataSource = viewModel.MandatoryParts;
             nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
-            UpdatePricingDisplay();
         }
 
         private async void FrmCreateQuote_Load(object sender, EventArgs e)
@@ -128,7 +126,6 @@ namespace QuoteSwift.Views
                 viewModel.LoadPartlists();
                 mandatorySource.DataSource = viewModel.MandatoryParts;
                 nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
-                UpdatePricingDisplay();
                 if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
                     viewModel.QuoteNumber = viewModel.NextQuoteNumber;
 
@@ -155,13 +152,11 @@ namespace QuoteSwift.Views
         private void DgvMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
         {
             viewModel.Calculate();
-            UpdatePricingDisplay();
         }
 
         private void DgvNonMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
         {
             viewModel.Calculate();
-            UpdatePricingDisplay();
         }
 
 
@@ -246,6 +241,13 @@ namespace QuoteSwift.Views
             BindingHelpers.BindText(lblCustomerPOBoxAreaCode, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxAreaCodeDisplay));
             BindingHelpers.BindText(lblCustomerVendorNumber, viewModel, nameof(CreateQuoteViewModel.CustomerVendorNumberDisplay));
 
+            BindingHelpers.BindText(lblNewPumpUnitPrice, viewModel, nameof(CreateQuoteViewModel.PumpPriceDisplay));
+            BindingHelpers.BindText(lblRebateValue, viewModel, nameof(CreateQuoteViewModel.RebateDisplay));
+            BindingHelpers.BindText(lblSubTotalValue, viewModel, nameof(CreateQuoteViewModel.SubTotalDisplay));
+            BindingHelpers.BindText(lblVATValue, viewModel, nameof(CreateQuoteViewModel.VATDisplay));
+            BindingHelpers.BindText(lblTotalDueValue, viewModel, nameof(CreateQuoteViewModel.TotalDueDisplay));
+            BindingHelpers.BindText(lblRepairPercentage, viewModel, nameof(CreateQuoteViewModel.RepairPercentageDisplay));
+
             gbxBusinessInformation.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
             gbxBusinessPOBoxDetails.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
             gbxQuoteNumberManagement.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
@@ -256,28 +258,12 @@ namespace QuoteSwift.Views
             BindingHelpers.BindEnabled(cbxPumpSelection, viewModel, nameof(CreateQuoteViewModel.IsEditing));
             BindingHelpers.BindVisible(btnComplete, viewModel, nameof(CreateQuoteViewModel.ShowSaveButton));
             btnComplete.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.SaveButtonText));
-
-            UpdatePricingDisplay();
             CommandBindings.Bind(btnComplete, viewModel.SaveQuoteCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
             CommandBindings.Bind(BtnCalculateRebate, viewModel.CalculateRebateCommand);
             CommandBindings.Bind(dtpQuoteCreationDate, viewModel.UpdateDatesCommand);
             CommandBindings.Bind(dtpQuoteExpiryDate, viewModel.UpdateDatesCommand);
-            viewModel.PropertyChanged += ViewModel_PropertyChanged;
-            viewModel.Pricing.PropertyChanged += Pricing_PropertyChanged;
         }
-
-        void UpdatePricingDisplay()
-        {
-            lblNewPumpUnitPrice.Text = "New Pump Price: R " + viewModel.Pricing.PumpPrice.ToString();
-            lblRebateValue.Text = "R" + viewModel.Pricing.Rebate.ToString();
-            lblSubTotalValue.Text = "R" + viewModel.Pricing.SubTotal.ToString();
-            lblVATValue.Text = "R" + viewModel.Pricing.VAT.ToString();
-            lblTotalDueValue.Text = "R" + viewModel.Pricing.TotalDue.ToString();
-            lblRepairPercentage.Text = "Repair Percentage: " + viewModel.RepairPercentage + "%";
-        }
-
-
 
         private void CbxUseAutomaticNumberingScheme_CheckedChanged(object sender, EventArgs e)
         {
@@ -299,27 +285,11 @@ namespace QuoteSwift.Views
             await ((AsyncRelayCommand)viewModel.ExportQuoteCommand).ExecuteAsync(q);
         }
 
-        void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(CreateQuoteViewModel.Pricing))
-            {
-                viewModel.Pricing.PropertyChanged += Pricing_PropertyChanged;
-                UpdatePricingDisplay();
-            }
-        }
-
-        void Pricing_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            UpdatePricingDisplay();
-        }
-
-
         private void LoadFromPassedObject()
         {
             viewModel.LoadFromQuote(quoteToChange);
             mandatorySource.DataSource = viewModel.MandatoryParts;
             nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
-            UpdatePricingDisplay();
         }
 
         // View-model bindings manage read-only state


### PR DESCRIPTION
## Summary
- compute pricing label text in `CreateQuoteViewModel`
- bind price labels to these read‑only properties
- drop manual display updates in `FrmCreateQuote`

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace of project must be MSBuild namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6880e20224848325b47f1c7699df78fe