### PR TITLE
Add confirmation command helpers

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -319,24 +319,13 @@ namespace QuoteSwift
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation"))
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination"))
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -301,24 +301,13 @@ namespace QuoteSwift
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation"))
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination"))
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -125,16 +125,11 @@ namespace QuoteSwift
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             ImportPartsCommand = new AsyncRelayCommand(_ => ImportPartsAsync());
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination"))
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
 
             ResetInputCommand = new RelayCommand(_ =>
             {
@@ -144,13 +139,11 @@ namespace QuoteSwift
                     ResetInput();
             });
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService.RequestConfirmation(
-                        "By canceling the current event, any parts not added will not be available in the part's list.",
-                        "REQUEAST - Action Cancellation"))
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "By canceling the current event, any parts not added will not be available in the part's list.",
+                "REQUEAST - Action Cancellation");
 
             StartEditCommand = new RelayCommand(_ =>
             {

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -133,24 +133,17 @@ namespace QuoteSwift
                     LastOperationSuccessful = AddPump();
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "By canceling the current event, any parts not added will not be available in the part's list.",
-                        "REQUEAST - Action Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "By canceling the current event, any parts not added will not be available in the part's list.",
+                "REQUEAST - Action Cancellation");
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -114,24 +114,13 @@ namespace QuoteSwift
                     messageService?.ShowError(result.Message, result.Caption);
             });
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public void Initialize(Business business = null, Customer customer = null, Address address = null)

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -48,23 +48,12 @@ namespace QuoteSwift
                     messageService?.ShowError(result.Message, result.Caption);
             });
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    applicationService?.Exit();
-                }
-            });
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public void Initialize(Business business = null, Customer customer = null, string email = null)

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -30,20 +30,16 @@ namespace QuoteSwift
                 var r = UpdateNumber();
                 LastResult = r;
             });
-            CancelCommand = new RelayCommand(_ =>
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "By canceling the current event, any parts not added will not be available in the part's list.",
+                "REQUEAST - Action Cancellation");
+
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "By canceling the current event, any parts not added will not be available in the part's list.",
-                        "REQUEAST - Action Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
-            ExitCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                    applicationService?.Exit();
-            });
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public void Initialize(Business business = null, Customer customer = null, string number = "")

--- a/ViewModels/ManageEmailsViewModel.cs
+++ b/ViewModels/ManageEmailsViewModel.cs
@@ -47,24 +47,13 @@ namespace QuoteSwift
                 if (p is object[] arr && arr.Length == 2 && arr[0] is string oldE && arr[1] is string newE)
                     UpdateEmail(oldE, newE);
             });
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination"))
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation"))
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
 
             EditSelectedEmailCommand = new RelayCommand(_ =>
             {

--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -68,24 +68,17 @@ namespace QuoteSwift
                 if (p is object[] arr && arr.Length == 2 && arr[0] is string oldN && arr[1] is string newN)
                     UpdateCellphone(oldN, newN);
             });
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination"))
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.",
-                        "REQUEST - Cancelation"))
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "Are you sure you want to cancel the current action?\nCancelation can cause any changes to be lost.",
+                "REQUEST - Cancelation");
 
             EditCellphoneCommand = new RelayCommand(_ =>
             {

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -74,19 +74,14 @@ namespace QuoteSwift
             AddPartCommand = new AsyncRelayCommand(async _ => { navigation?.AddNewPart(); await LoadDataAsync(); });
             ViewPartsCommand = new AsyncRelayCommand(async _ => { navigation?.ViewAllParts(); await LoadDataAsync(); });
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination"))
-                {
-                    serializationService?.CloseApplication(true,
-                        BusinessList,
-                        PumpList,
-                        PartMap,
-                        QuoteMap);
-                }
-            });
+                serializationService?.CloseApplication(true,
+                    BusinessList,
+                    PumpList,
+                    PartMap,
+                    QuoteMap);
+            }, messageService);
         }
 
 

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -44,24 +44,13 @@ namespace QuoteSwift
                 }
             }, _ => Task.FromResult(SelectedBusiness != null));
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -49,24 +49,16 @@ namespace QuoteSwift
                 }
             }, _ => Task.FromResult(SelectedCustomer != null));
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.",
-                        "REQUEST - Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.");
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public BindingList<Business> Businesses

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -41,5 +41,67 @@ namespace QuoteSwift
                 }
             });
         }
+
+        /// <summary>
+        /// Creates a <see cref="RelayCommand"/> that first displays a confirmation
+        /// dialog via the provided <see cref="IMessageService"/> and executes the
+        /// supplied action when confirmed.
+        /// </summary>
+        /// <param name="executeAction">Action to execute if the user confirms.</param>
+        /// <param name="messageService">Service used to show the confirmation.</param>
+        /// <param name="message">Confirmation message text.</param>
+        /// <param name="caption">Confirmation dialog caption.</param>
+        /// <returns>An initialized <see cref="RelayCommand"/>.</returns>
+        protected RelayCommand CreateConfirmationCommand(
+            Action executeAction,
+            IMessageService messageService,
+            string message,
+            string caption)
+        {
+            if (executeAction == null)
+                throw new ArgumentNullException(nameof(executeAction));
+
+            return new RelayCommand(_ =>
+            {
+                if (messageService?.RequestConfirmation(message, caption) == true)
+                    executeAction();
+            });
+        }
+
+        /// <summary>
+        /// Creates a <see cref="RelayCommand"/> prompting for cancellation
+        /// confirmation.
+        /// </summary>
+        /// <param name="cancelAction">Action to execute when confirmed.</param>
+        /// <param name="messageService">Service used to show the confirmation.</param>
+        /// <param name="message">Optional confirmation message.</param>
+        /// <param name="caption">Optional confirmation caption.</param>
+        /// <returns>An initialized <see cref="RelayCommand"/>.</returns>
+        protected RelayCommand CreateCancelCommand(
+            Action cancelAction,
+            IMessageService messageService,
+            string message = "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
+            string caption = "REQUEST - Cancellation")
+        {
+            return CreateConfirmationCommand(cancelAction, messageService, message, caption);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="RelayCommand"/> prompting for application exit
+        /// confirmation.
+        /// </summary>
+        /// <param name="exitAction">Action to execute when confirmed.</param>
+        /// <param name="messageService">Service used to show the confirmation.</param>
+        /// <param name="message">Optional confirmation message.</param>
+        /// <param name="caption">Optional confirmation caption.</param>
+        /// <returns>An initialized <see cref="RelayCommand"/>.</returns>
+        protected RelayCommand CreateExitCommand(
+            Action exitAction,
+            IMessageService messageService,
+            string message = "Are you sure you want to close the application?",
+            string caption = "REQUEST - Application Termination")
+        {
+            return CreateConfirmationCommand(exitAction, messageService, message, caption);
+        }
     }
 }

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -43,24 +43,16 @@ namespace QuoteSwift
             RemovePartCommand = new RelayCommand(_ => RemoveSelectedPart(), _ => SelectedPart != null);
             SaveChangesCommand = new RelayCommand(_ => SaveChanges());
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.",
-                        "REQUEST - Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.");
 
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
         }
 
         public IDataService DataService => dataService;

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -46,24 +46,13 @@ namespace QuoteSwift
             UpdatePumpCommand = new AsyncRelayCommand(_ => UpdatePumpAsync(), _ => Task.FromResult(SelectedPump != null));
             RemovePumpCommand = new RelayCommand(_ => RemoveSelectedPump(), _ => SelectedPump != null);
             ExportInventoryCommand = new AsyncRelayCommand(_ => ExportInventoryActionAsync());
-            ExitCommand = new RelayCommand(_ =>
+            ExitCommand = CreateExitCommand(() =>
             {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to close the application?",
-                        "REQUEST - Application Termination") == true)
-                {
-                    navigation?.SaveAllData();
-                    applicationService?.Exit();
-                }
-            });
+                navigation?.SaveAllData();
+                applicationService?.Exit();
+            }, messageService);
 
-            CancelCommand = new RelayCommand(_ =>
-            {
-                if (messageService?.RequestConfirmation(
-                        "Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.",
-                        "REQUEST - Cancellation") == true)
-                    CloseAction?.Invoke();
-            });
+            CancelCommand = CreateCancelCommand(() => CloseAction?.Invoke(), messageService);
         }
 
         public IDataService DataService => dataService;


### PR DESCRIPTION
## Summary
- add helper methods in `ViewModelBase` for confirmation, cancel and exit commands
- refactor view models to use these helpers for Exit and Cancel logic

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_6880e206a694832580d0f43768dfd158