### PR TITLE
Add cancel and exit commands

### DIFF
--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Windows.Input;
 
@@ -15,7 +16,10 @@ namespace QuoteSwift
         bool changeSpecificObject;
         Address selectedAddress;
 
+        public Action CloseAction { get; set; }
+
         public ICommand ExitCommand { get; }
+        public ICommand CancelCommand { get; }
 
         public ICommand RemoveSelectedAddressCommand { get; }
         public ICommand EditAddressCommand { get; }
@@ -36,11 +40,17 @@ namespace QuoteSwift
             EditAddressCommand = new RelayCommand(
                 _ => EditSelectedAddress(),
                 _ => SelectedAddress != null);
-            ExitCommand = new RelayCommand(_ =>
+
+            CancelCommand = CreateCancelCommand(
+                () => CloseAction?.Invoke(),
+                messageService,
+                "Are you sure you want to cancel the current action?\nCancellation can cause any changes to this current window to be lost.");
+
+            ExitCommand = CreateExitCommand(() =>
             {
                 navigation?.SaveAllData();
                 applicationService?.Exit();
-            });
+            }, messageService);
         }
 
         public IDataService DataService => dataService;

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -29,6 +29,7 @@ namespace QuoteSwift.Views
         {
             InitializeComponent();
             this.viewModel = viewModel;
+            viewModel.CloseAction = Close;
             appData = data;
             this.messageService = messageService;
             this.serializationService = serializationService;
@@ -81,7 +82,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("By canceling the current event, any parts not added will not be available in the part's list.", "REQUEAST - Action Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/FrmViewBusinessAddresses.cs
+++ b/Views/FrmViewBusinessAddresses.cs
@@ -9,7 +9,6 @@ namespace QuoteSwift.Views
 
         readonly ViewBusinessAddressesViewModel viewModel;
         readonly INavigationService navigation;
-        readonly IMessageService messageService;
         Business business;
         Customer customer;
         public ViewBusinessAddressesViewModel ViewModel => viewModel;
@@ -31,6 +30,8 @@ namespace QuoteSwift.Views
 
             CommandBindings.Bind(BtnRemoveSelected, viewModel.RemoveSelectedAddressCommand);
             CommandBindings.Bind(BtnChangeAddressInfo, viewModel.EditAddressCommand);
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
@@ -39,7 +40,7 @@ namespace QuoteSwift.Views
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -51,11 +52,8 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                navigation?.SaveAllData();
-                Application.Exit();
-            }
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
         private void FrmViewBusinessAddresses_Load(object sender, EventArgs e)
@@ -94,7 +92,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
 
@@ -104,12 +103,6 @@ namespace QuoteSwift.Views
         *       Some of them are only to keep the above events readable 
         *       and clutter free.                                                          
         */
-
-        Address GetAddressSelection()
-        {
-            return DgvViewAllBusinessAddresses.CurrentRow?.DataBoundItem as Address;
-        }
-
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/Views/FrmViewPOBoxAddresses.cs
+++ b/Views/FrmViewPOBoxAddresses.cs
@@ -9,7 +9,6 @@ namespace QuoteSwift.Views
 
         readonly ViewPOBoxAddressesViewModel viewModel;
         readonly INavigationService navigation;
-        readonly IMessageService messageService;
         Business business;
         Customer customer;
         public ViewPOBoxAddressesViewModel ViewModel => viewModel;
@@ -29,6 +28,9 @@ namespace QuoteSwift.Views
             BindingHelpers.BindEnabled(btnRemoveAddress, viewModel, nameof(ViewPOBoxAddressesViewModel.CanEdit));
 
             CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedAddressCommand);
+            CommandBindings.Bind(btnChangeAddressInfo, viewModel.EditAddressCommand);
+            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
         }
 
         public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
@@ -37,7 +39,7 @@ namespace QuoteSwift.Views
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            this.messageService = messageService;
+            viewModel.CloseAction = Close;
             SetupBindings();
         }
 
@@ -49,32 +51,21 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to close the application?", "REQUEST - Application Termination"))
-            {
-                navigation?.SaveAllData();
-                Application.Exit();
-            }
+            if (viewModel.ExitCommand.CanExecute(null))
+                viewModel.ExitCommand.Execute(null);
         }
 
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (messageService.RequestConfirmation("Are you sure you want to cancel the current action?\nCancellation can cause any changes to be lost.", "REQUEST - Cancellation")) Close();
+            if (viewModel.CancelCommand.CanExecute(null))
+                viewModel.CancelCommand.Execute(null);
         }
 
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
         {
-            Address address = GetAddressSelection();
-
-            if (address == null)
-            {
-                messageService.ShowError("Please select a valid P.O.Box Address, the current selection is invalid", "ERROR - Invalid P.O.Box Address Selection");
-                return;
-            }
-
-            navigation?.EditBusinessAddress(business, customer, address);
-
-            viewModel.UpdateData(business, customer);
+            if (viewModel.EditAddressCommand.CanExecute(null))
+                viewModel.EditAddressCommand.Execute(null);
         }
 
         private void FrmViewPOBoxAddresses_Load(object sender, EventArgs e)
@@ -112,12 +103,6 @@ namespace QuoteSwift.Views
         *       Some of them are only to keep the above events readable 
         *       and clutter free.                                                          
         */
-
-        Address GetAddressSelection()
-        {
-            return dgvPOBoxAddresses.CurrentRow?.DataBoundItem as Address;
-        }
-
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- add CancelCommand and ExitCommand support in more viewmodels
- wire up CancelCommand and ExitCommand from forms
- use injected IMessageService in constructors

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace issue)*

------
https://chatgpt.com/codex/tasks/task_e_6880ee69f6f883259560924437aad770