### PR TITLE
Bind IsBusy across forms

### DIFF
--- a/Views/FrmEditBusinessAddress.cs
+++ b/Views/FrmEditBusinessAddress.cs
@@ -18,6 +18,7 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             this.navigation = navigation;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
         }
 

--- a/Views/FrmEditEmailAddress.cs
+++ b/Views/FrmEditEmailAddress.cs
@@ -19,6 +19,7 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             this.navigation = navigation;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
             CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);

--- a/Views/FrmEditPhoneNumber.cs
+++ b/Views/FrmEditPhoneNumber.cs
@@ -19,6 +19,7 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             this.navigation = navigation;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
             CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);

--- a/Views/FrmManageAllEmails.cs
+++ b/Views/FrmManageAllEmails.cs
@@ -20,6 +20,7 @@ namespace QuoteSwift.Views
             this.navigation = navigation;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
         }
 

--- a/Views/FrmManagingPhoneNumbers.cs
+++ b/Views/FrmManagingPhoneNumbers.cs
@@ -20,6 +20,7 @@ namespace QuoteSwift.Views
             this.navigation = navigation;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
         }
 

--- a/Views/FrmViewAllBusinesses.cs
+++ b/Views/FrmViewAllBusinesses.cs
@@ -22,6 +22,7 @@ namespace QuoteSwift.Views
             this.navigation = navigation;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
             CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);

--- a/Views/FrmViewBusinessAddresses.cs
+++ b/Views/FrmViewBusinessAddresses.cs
@@ -36,6 +36,7 @@ namespace QuoteSwift.Views
             this.viewModel = viewModel;
             this.navigation = navigation;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
         }
 

--- a/Views/FrmViewPOBoxAddresses.cs
+++ b/Views/FrmViewPOBoxAddresses.cs
@@ -35,6 +35,7 @@ namespace QuoteSwift.Views
             this.viewModel = viewModel;
             this.navigation = navigation;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
         }
 

--- a/Views/FrmViewParts.cs
+++ b/Views/FrmViewParts.cs
@@ -25,6 +25,7 @@ namespace QuoteSwift.Views
             appData = data;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             if (appData != null)
                 viewModel.UpdateData(appData.PartList);
             SetupBindings();

--- a/Views/FrmViewPump.cs
+++ b/Views/FrmViewPump.cs
@@ -42,6 +42,7 @@ namespace QuoteSwift.Views // Repair Quote Swift
             this.navigation = navigation;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
+            BindIsBusy(viewModel);
             SetupBindings();
         }
 


### PR DESCRIPTION
## Summary
- hook up `BindIsBusy` on remaining WinForms
- keep cursor busy when view models perform long operations

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6880f379b57c83259806812e26547e71