### PR TITLE
Inject ApplicationData into view models

### DIFF
--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -56,7 +56,7 @@ namespace QuoteSwift
         {
             using (var form = serviceProvider.GetRequiredService<FrmViewPump>())
             {
-                form.ViewModel.UpdateData(appData.PumpList);
+                form.ViewModel.LoadDataCommand.Execute(null);
                 form.ShowDialog();
             }
         }
@@ -65,11 +65,8 @@ namespace QuoteSwift
         {
             using (var form = serviceProvider.GetRequiredService<FrmAddPump>())
             {
-                form.ViewModel.UpdateData(appData.PumpList, appData.PartList);
                 await form.ViewModel.LoadDataAsync();
                 form.ShowDialog();
-                appData.PumpList = form.ViewModel.PumpList;
-                appData.PartList = form.ViewModel.PartMap;
             }
             appData.SaveAll();
         }
@@ -78,7 +75,7 @@ namespace QuoteSwift
         {
             using (var form = serviceProvider.GetRequiredService<FrmViewParts>())
             {
-                form.ViewModel.UpdateData(appData.PartList);
+                form.ViewModel.LoadDataCommand.Execute(null);
                 form.ShowDialog();
             }
         }
@@ -87,10 +84,10 @@ namespace QuoteSwift
         {
             using (var form = serviceProvider.GetRequiredService<FrmAddPart>())
             {
-                form.ViewModel.UpdateData(appData.PartList, appData.PumpList, partToChange, changeSpecificObject);
+                form.ViewModel.PartToChange = partToChange;
+                form.ViewModel.ChangeSpecificObject = changeSpecificObject;
+                form.ViewModel.LoadDataCommand.Execute(null);
                 form.ShowDialog();
-                appData.PartList = form.ViewModel.PartMap;
-                appData.PumpList = form.ViewModel.PumpList;
             }
             appData.SaveAll();
         }

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -15,6 +15,7 @@ namespace QuoteSwift
         readonly IFileDialogService fileDialogService;
         readonly INavigationService navigation;
         readonly IApplicationService applicationService;
+        readonly ApplicationData appData;
         Dictionary<string, Part> partMap;
         BindingList<Pump> pumpList;
         Part partToChange;
@@ -74,11 +75,13 @@ namespace QuoteSwift
 
 
         public AddPartViewModel(IDataService service, INotificationService notifier,
+                                ApplicationData appData,
                                 IMessageService messenger = null, IFileDialogService dialogService = null,
                                 INavigationService navigation = null, IApplicationService applicationService = null)
         {
             dataService = service;
             notificationService = notifier;
+            this.appData = appData;
             messageService = messenger;
             fileDialogService = dialogService;
             this.navigation = navigation;
@@ -267,11 +270,12 @@ namespace QuoteSwift
 
         public async Task LoadDataAsync()
         {
-            PartMap = await dataService.LoadPartListAsync();
-            PumpList = await dataService.LoadPumpListAsync();
+            PartMap = appData.PartList;
+            PumpList = appData.PumpList;
             Parts = new BindingList<Part>(PartMap?.Values.ToList() ?? new List<Part>());
             Pumps = PumpList;
             CurrentPart = PartToChange ?? new Part();
+            await Task.CompletedTask;
         }
 
         public void UpdateData(Dictionary<string, Part> partMap,

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Windows.Input;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace QuoteSwift
 {
@@ -12,6 +13,7 @@ namespace QuoteSwift
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly IApplicationService applicationService;
+        readonly ApplicationData appData;
         Pump currentPump;
         bool lastOperationSuccessful;
         string formTitle;
@@ -111,12 +113,14 @@ namespace QuoteSwift
 
         public AddPumpViewModel(IDataService service,
                                 INotificationService notifier,
+                                ApplicationData appData,
                                 INavigationService navigation = null,
                                 IMessageService messageService = null,
                                 IApplicationService applicationService = null)
         {
             dataService = service;
             notificationService = notifier;
+            this.appData = appData;
             this.navigation = navigation;
             this.messageService = messageService;
             this.applicationService = applicationService;
@@ -165,18 +169,17 @@ namespace QuoteSwift
 
         public async Task LoadDataAsync()
         {
-            PumpList = await dataService.LoadPumpListAsync();
-            PartMap = await dataService.LoadPartListAsync();
+            PumpList = appData.PumpList;
+            PartMap = appData.PartList;
             if (PumpList != null)
             {
-                RepairableItemNames = new HashSet<string>();
-                foreach (var p in PumpList)
-                    RepairableItemNames.Add(StringUtil.NormalizeKey(p.PumpName));
+                RepairableItemNames = new HashSet<string>(PumpList.Select(p => StringUtil.NormalizeKey(p.PumpName)));
             }
             else
             {
                 RepairableItemNames = new HashSet<string>();
             }
+            await Task.CompletedTask;
         }
 
         public void UpdateData(BindingList<Pump> pumpList,

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -14,6 +14,7 @@ namespace QuoteSwift
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly IApplicationService applicationService;
+        readonly ApplicationData appData;
         Dictionary<string, Part> partList;
         BindingList<Pump> pumps;
         BindingList<Business> businesses;
@@ -135,6 +136,7 @@ namespace QuoteSwift
         public CreateQuoteViewModel(IDataService service,
                                     INotificationService notifier,
                                     IExcelExportService excelExporter,
+                                    ApplicationData appData,
                                     INavigationService navigation = null,
                                     IMessageService messageService = null,
                                     IApplicationService applicationService = null)
@@ -142,6 +144,7 @@ namespace QuoteSwift
             dataService = service;
             notificationService = notifier;
             excelExportService = excelExporter;
+            this.appData = appData;
             this.navigation = navigation;
             this.messageService = messageService;
             this.applicationService = applicationService;
@@ -653,12 +656,13 @@ namespace QuoteSwift
 
         public async Task LoadDataAsync()
         {
-            PartList = await dataService.LoadPartListAsync();
-            Pumps = await dataService.LoadPumpListAsync();
-            Businesses = await dataService.LoadBusinessListAsync();
-            QuoteMap = await dataService.LoadQuoteMapAsync();
+            PartList = appData.PartList;
+            Pumps = appData.PumpList;
+            Businesses = appData.BusinessList;
+            QuoteMap = appData.QuoteMap;
             Pricing = new Pricing();
             PrepareComboBoxLists();
+            await Task.CompletedTask;
         }
 
         public void LoadQuote(Quote quote)

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -12,6 +12,7 @@ namespace QuoteSwift
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly IApplicationService applicationService;
+        readonly ApplicationData appData;
         Dictionary<string, Part> partList;
         readonly BindingList<Part> mandatoryParts;
         readonly BindingList<Part> nonMandatoryParts;
@@ -28,9 +29,10 @@ namespace QuoteSwift
         public Action CloseAction { get; set; }
 
 
-        public ViewPartsViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
+        public ViewPartsViewModel(IDataService service, ApplicationData appData, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)
         {
             dataService = service;
+            this.appData = appData;
             this.navigation = navigation;
             this.messageService = messageService;
             this.applicationService = applicationService;
@@ -88,8 +90,9 @@ namespace QuoteSwift
 
         public async Task LoadDataAsync()
         {
-            PartList = await dataService.LoadPartListAsync();
+            PartList = appData.PartList;
             RefreshLists();
+            await Task.CompletedTask;
         }
 
         public void UpdateData(Dictionary<string, Part> parts)

--- a/Views/FrmAddPart.cs
+++ b/Views/FrmAddPart.cs
@@ -10,18 +10,15 @@ namespace QuoteSwift.Views
         readonly AddPartViewModel viewModel;
         public AddPartViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
-
-        readonly ApplicationData appData;
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
 
-        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
             : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            appData = data;
             this.serializationService = serializationService;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
@@ -69,7 +66,7 @@ namespace QuoteSwift.Views
 
         private async void FrmAddPart_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)viewModel.LoadDataCommand).ExecuteAsync(null);
             if (viewModel.PartToChange == null)
             {
                 viewModel.ChangeSpecificObject = true;

--- a/Views/FrmAddPump.cs
+++ b/Views/FrmAddPump.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace QuoteSwift.Views
@@ -12,19 +11,17 @@ namespace QuoteSwift.Views
         readonly AddPumpViewModel viewModel;
         public AddPumpViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
-        readonly ApplicationData appData;
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
         readonly BindingSource mandatorySource = new BindingSource();
         readonly BindingSource nonMandatorySource = new BindingSource();
 
-        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
             : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.navigation = navigation;
-            appData = data;
             this.serializationService = serializationService;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
@@ -37,9 +34,7 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnAddPump, viewModel.SavePumpCommand);
             CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            if (data != null)
-                viewModel.UpdateData(data.PumpList, data.PartList, viewModel.PumpToChange, viewModel.ChangeSpecificObject,
-                                     data.PumpList != null ? new HashSet<string>(data.PumpList.Select(p => StringUtil.NormalizeKey(p.PumpName))) : null);
+            viewModel.LoadDataCommand.Execute(null);
             BindIsBusy(viewModel);
         }
 
@@ -75,7 +70,7 @@ namespace QuoteSwift.Views
 
         private async void FrmAddPump_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)viewModel.LoadDataCommand).ExecuteAsync(null);
             SetupBindings();
 
             if (viewModel.PumpToChange == null)

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -13,7 +13,6 @@ namespace QuoteSwift.Views
     {
         readonly CreateQuoteViewModel viewModel;
         public CreateQuoteViewModel ViewModel => viewModel;
-        readonly ApplicationData appData;
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
         Quote quoteToChange;
@@ -24,13 +23,12 @@ namespace QuoteSwift.Views
         readonly BindingSource nonMandatorySource = new BindingSource();
 
 
-        public FrmCreateQuote(CreateQuoteViewModel viewModel, ApplicationData data, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmCreateQuote(CreateQuoteViewModel viewModel, IMessageService messageService = null, ISerializationService serializationService = null)
             : base(messageService)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             viewModel.CloseAction = Close;
-            appData = data;
             this.messageService = messageService;
             this.serializationService = serializationService;
             SetupBindings();
@@ -65,7 +63,7 @@ namespace QuoteSwift.Views
 
         private async void FrmCreateQuote_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)viewModel.LoadDataCommand).ExecuteAsync(null);
             viewModel.QuoteToChange = quoteToChange;
             viewModel.ChangeSpecificObject = changeSpecificObject;
             if (viewModel.IsViewing)

--- a/Views/FrmViewParts.cs
+++ b/Views/FrmViewParts.cs
@@ -12,22 +12,18 @@ namespace QuoteSwift.Views
         public ViewPartsViewModel ViewModel => viewModel;
 
         readonly BindingSource partsBindingSource = new BindingSource();
-
-        readonly ApplicationData appData;
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
-        public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, ApplicationData data = null, IMessageService messageService = null, ISerializationService serializationService = null)
+        public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
             : base(messageService, navigation)
         {
             InitializeComponent();
             this.viewModel = viewModel;
             this.serializationService = serializationService;
-            appData = data;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
             BindIsBusy(viewModel);
-            if (appData != null)
-                viewModel.UpdateData(appData.PartList);
+            viewModel.LoadDataCommand.Execute(null);
             SetupBindings();
             CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
@@ -48,10 +44,7 @@ namespace QuoteSwift.Views
 
         private void FrmViewParts_Activated(object sender, EventArgs e)
         {
-            if (appData != null)
-            {
-                viewModel.UpdateData(appData.PartList);
-            }
+            viewModel.LoadDataCommand.Execute(null);
         }
 
         /** Form Specific Functions And Procedures: 


### PR DESCRIPTION
## Summary
- pass `ApplicationData` into AddPump/AddPart/CreateQuote/ViewParts view models
- update forms to rely on the view models for loading data
- remove redundant `ApplicationData` references from forms
- adjust navigation service to trigger view model loading commands

## Testing
- `msbuild QuoteSwift.sln /t:build /p:Configuration=Release` *(fails: `msbuild` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881026a67848325b5b9bb3a8f661e92