### PR TITLE
Track pump edits via view model

### DIFF
--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -110,6 +110,48 @@ namespace QuoteSwift
 
         public bool CanEdit => changeSpecificObject;
 
+        public string PumpName
+        {
+            get => CurrentPump?.PumpName;
+            set
+            {
+                if (CurrentPump != null && CurrentPump.PumpName != value)
+                {
+                    CurrentPump.PumpName = value;
+                    if (!ChangeSpecificObject)
+                        ChangeSpecificObject = true;
+                }
+            }
+        }
+
+        public string PumpDescription
+        {
+            get => CurrentPump?.PumpDescription;
+            set
+            {
+                if (CurrentPump != null && CurrentPump.PumpDescription != value)
+                {
+                    CurrentPump.PumpDescription = value;
+                    if (!ChangeSpecificObject)
+                        ChangeSpecificObject = true;
+                }
+            }
+        }
+
+        public decimal NewPumpPrice
+        {
+            get => CurrentPump?.NewPumpPrice ?? 0m;
+            set
+            {
+                if (CurrentPump != null && CurrentPump.NewPumpPrice != value)
+                {
+                    CurrentPump.NewPumpPrice = value;
+                    if (!ChangeSpecificObject)
+                        ChangeSpecificObject = true;
+                }
+            }
+        }
+
 
         public AddPumpViewModel(IDataService service,
                                 INotificationService notifier,
@@ -126,6 +168,16 @@ namespace QuoteSwift
             this.applicationService = applicationService;
             SelectedMandatoryParts = new BindingList<Pump_Part>();
             SelectedNonMandatoryParts = new BindingList<Pump_Part>();
+            SelectedMandatoryParts.ListChanged += (_, __) =>
+            {
+                if (!ChangeSpecificObject)
+                    ChangeSpecificObject = true;
+            };
+            SelectedNonMandatoryParts.ListChanged += (_, __) =>
+            {
+                if (!ChangeSpecificObject)
+                    ChangeSpecificObject = true;
+            };
             RepairableItemNames = new HashSet<string>();
             AddPumpCommand = new RelayCommand(_ => LastOperationSuccessful = AddPump());
             UpdatePumpCommand = new RelayCommand(_ => LastOperationSuccessful = UpdatePump());

--- a/Views/FrmAddPump.Designer.cs
+++ b/Views/FrmAddPump.Designer.cs
@@ -133,7 +133,6 @@ namespace QuoteSwift.Views
             this.dgvMandatoryPartView.Name = "dgvMandatoryPartView";
             this.dgvMandatoryPartView.Size = new System.Drawing.Size(1266, 307);
             this.dgvMandatoryPartView.TabIndex = 9;
-            this.dgvMandatoryPartView.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvMandatoryPartView_CellContentClick);
             // 
             // ClmPartName
             // 
@@ -205,7 +204,6 @@ namespace QuoteSwift.Views
             this.dgvNonMandatoryPartView.Name = "dgvNonMandatoryPartView";
             this.dgvNonMandatoryPartView.Size = new System.Drawing.Size(1266, 286);
             this.dgvNonMandatoryPartView.TabIndex = 11;
-            this.dgvNonMandatoryPartView.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvNonMandatoryPartView_CellContentClick);
             // 
             // ClmNMPartName
             // 

--- a/Views/FrmAddPump.cs
+++ b/Views/FrmAddPump.cs
@@ -26,9 +26,9 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             viewModel.CloseAction = Close;
             viewModel.CurrentPump = viewModel.PumpToChange ?? new Pump();
-            mtxtPumpName.DataBindings.Add("Text", viewModel.CurrentPump, nameof(Pump.PumpName), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPumpDescription.DataBindings.Add("Text", viewModel.CurrentPump, nameof(Pump.PumpDescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtNewPumpPrice.DataBindings.Add("Text", viewModel.CurrentPump, nameof(Pump.NewPumpPrice), true, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(mtxtPumpName, viewModel, nameof(AddPumpViewModel.PumpName));
+            BindingHelpers.BindText(mtxtPumpDescription, viewModel, nameof(AddPumpViewModel.PumpDescription));
+            BindingHelpers.BindText(mtxtNewPumpPrice, viewModel, nameof(AddPumpViewModel.NewPumpPrice));
             mandatorySource.DataSource = viewModel.SelectedMandatoryParts;
             nonMandatorySource.DataSource = viewModel.SelectedNonMandatoryParts;
             CommandBindings.Bind(btnAddPump, viewModel.SavePumpCommand);
@@ -38,35 +38,7 @@ namespace QuoteSwift.Views
             BindIsBusy(viewModel);
         }
 
-        private void MtxtPumpName_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
-        {
-            if (!viewModel.ChangeSpecificObject)
-                viewModel.ChangeSpecificObject = true;
-        }
-
-        private void MtxtPumpDescription_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
-        {
-            if (!viewModel.ChangeSpecificObject)
-                viewModel.ChangeSpecificObject = true;
-        }
-
-        private void MtxtNewPumpPrice_MaskInputRejected(object sender, MaskInputRejectedEventArgs e)
-        {
-            if (!viewModel.ChangeSpecificObject)
-                viewModel.ChangeSpecificObject = true;
-        }
-
-        private void DgvMandatoryPartView_CellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
-            if (!viewModel.ChangeSpecificObject)
-                viewModel.ChangeSpecificObject = true;
-        }
-
-        private void DgvNonMandatoryPartView_CellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
-            if (!viewModel.ChangeSpecificObject)
-                viewModel.ChangeSpecificObject = true;
-        }
+        // Input changes are tracked by the view model
 
         private async void FrmAddPump_Load(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- trigger change tracking from `AddPumpViewModel` when pump properties change
- bind pump fields in the add pump form to the new view model properties
- remove obsolete flagging events and related designer hooks

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: default XML namespace must be MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6881475fadb88325a1703b64f10b1bbc