### PR TITLE
Clean views by moving logic to view models

### DIFF
--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -88,10 +88,12 @@ namespace QuoteSwift
         public Business SelectedBusiness
         {
             get => selectedBusiness;
-            private set
+            set
             {
-                selectedBusiness = value;
-                OnPropertyChanged(nameof(SelectedBusiness));
+                if (SetProperty(ref selectedBusiness, value))
+                {
+                    RefreshCustomers();
+                }
             }
         }
 
@@ -130,7 +132,6 @@ namespace QuoteSwift
         public void SelectBusiness(Business business)
         {
             SelectedBusiness = business;
-            RefreshCustomers();
         }
 
         public void RefreshCustomers()

--- a/Views/FrmViewAllBusinesses.cs
+++ b/Views/FrmViewAllBusinesses.cs
@@ -59,17 +59,6 @@ namespace QuoteSwift.Views
         *       and clutter free.                                                          
         */
 
-        private Business GetBusinessSelection()
-        {
-            return DgvBusinessList.CurrentRow?.DataBoundItem as Business;
-        }
-
-        private void LoadInformation()
-        {
-            // Binding handled automatically via businessBindingSource
-        }
-
-
         // CommandBindings handle Cancel action
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Views/FrmViewCustomers.Designer.cs
+++ b/Views/FrmViewCustomers.Designer.cs
@@ -119,7 +119,6 @@ namespace QuoteSwift.Views
             this.cbBusinessSelection.Name = "cbBusinessSelection";
             this.cbBusinessSelection.Size = new System.Drawing.Size(258, 26);
             this.cbBusinessSelection.TabIndex = 4;
-            this.cbBusinessSelection.SelectedIndexChanged += new System.EventHandler(this.CbBusinessSelection_SelectedIndexChanged);
             // 
             // lblBusinessSelection
             // 

--- a/Views/FrmViewCustomers.cs
+++ b/Views/FrmViewCustomers.cs
@@ -33,6 +33,9 @@ namespace QuoteSwift.Views
             SelectionBindings.BindSelectedItem(DgvCustomerList, viewModel, nameof(ViewCustomersViewModel.SelectedCustomer));
             CommandBindings.Bind(btnUpdateSelectedCustomer, viewModel.UpdateCustomerCommand);
             CommandBindings.Bind(btnAddCustomer, viewModel.AddCustomerCommand);
+            BindingHelpers.BindComboBox(cbBusinessSelection, viewModel,
+                nameof(ViewCustomersViewModel.Businesses), nameof(ViewCustomersViewModel.SelectedBusiness),
+                "BusinessName", "BusinessName");
         }
 
         // CommandBindings handle Exit action
@@ -40,7 +43,6 @@ namespace QuoteSwift.Views
         private async void FrmViewCustomers_Load(object sender, EventArgs e)
         {
             await viewModel.LoadDataAsync();
-            LinkBusinessToSource(ref cbBusinessSelection);
             clmCustomerCompanyName.DataPropertyName = nameof(Customer.CustomerCompanyName);
             clmPreviousQuoteDate.DataPropertyName = nameof(Customer.PreviousQuoteDate);
             DgvCustomerList.AutoGenerateColumns = false;
@@ -62,52 +64,6 @@ namespace QuoteSwift.Views
         */
 
         // Binding handled automatically via customersBindingSource
-
-
-        private bool ReplaceCustomer(Customer Original, Customer New, Business Container)
-        {
-            if (New != null && Original != null && Container != null && Container.BusinessCustomerList != null)
-            {
-                if (Container.CustomerMap.TryGetValue(New.CustomerCompanyName, out Customer existing) && existing != Original)
-                {
-                    messageService.ShowError("This customer name is already in use.", "ERROR - Duplicate Customer Name");
-                    return false;
-                }
-
-                Container.UpdateCustomer(Original, New);
-                return true;
-            }
-
-            return false;
-        }
-
-        private Customer GetCustomerSelection()
-        {
-            return DgvCustomerList.CurrentRow?.DataBoundItem as Customer;
-        }
-
-        private Business GetSelectedBusiness()
-        {
-            return cbBusinessSelection.SelectedItem as Business;
-        }
-
-        public void LinkBusinessToSource(ref ComboBox cb)
-        {
-            if (viewModel.Businesses != null)
-            {
-                BindingSource source = new BindingSource { DataSource = viewModel.Businesses };
-
-                cb.DataSource = source.DataSource;
-
-                cb.DisplayMember = "BusinessName";
-                cb.ValueMember = "BusinessName";
-            }
-        }
-
-        private void CbBusinessSelection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            viewModel.SelectBusiness(GetSelectedBusiness());
-        }
 
         // CommandBindings handle Cancel action
 

--- a/Views/FrmViewParts.cs
+++ b/Views/FrmViewParts.cs
@@ -54,13 +54,6 @@ namespace QuoteSwift.Views
         *       and clutter free.                                                          
         */
 
-        // Binding handled automatically via BindingSource
-
-        Part GetSelectedPart()
-        {
-            return dgvAllParts.CurrentRow?.DataBoundItem as Part;
-        }
-
         private void FrmViewParts_Load(object sender, EventArgs e)
         {
             dgvAllParts.RowsDefaultCellStyle.BackColor = Color.Bisque;


### PR DESCRIPTION
## Summary
- delete unused helper methods in views
- bind business selection combo directly to the view model
- refresh customers when selected business changes
- remove unused selection helpers in parts and businesses views

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: default XML namespace in csproj)*

------
https://chatgpt.com/codex/tasks/task_e_68815ba63e68832596d1b666a2cce408