### PR TITLE
Remove leftover WinForms usings

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Windows.Input;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace QuoteSwift
 {

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Windows.Forms;
 using System.Windows.Input;
 
 namespace QuoteSwift

--- a/ViewModels/ManageEmailsViewModel.cs
+++ b/ViewModels/ManageEmailsViewModel.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Linq;
-using System.Windows.Forms;
 using System.Windows.Input;
 
 namespace QuoteSwift

--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Linq;
-using System.Windows.Forms;
 using System.Windows.Input;
 
 namespace QuoteSwift

--- a/ViewModels/QuotesViewModel.cs
+++ b/ViewModels/QuotesViewModel.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using System.Windows.Forms;
 
 
 namespace QuoteSwift


### PR DESCRIPTION
## Summary
- remove unused `System.Windows.Forms` directives from several view models

## Testing
- `msbuild QuoteSwift.sln` *(fails: `msbuild` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e07f5e008325a67aae70b3e2b613