### PR TITLE
Remove WinForms reference from library

### DIFF
--- a/MainProgramLibrary/MainProgramLibrary.csproj
+++ b/MainProgramLibrary/MainProgramLibrary.csproj
@@ -9,10 +9,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Windows.Forms">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Windows.Forms.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- remove `System.Windows.Forms` reference from `MainProgramLibrary`
- attempt to build library with `dotnet` to confirm success

## Testing
- `dotnet build MainProgramLibrary/MainProgramLibrary.csproj`
- `dotnet build QuoteSwift.sln` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e084a52883259bb9affca2277ec3