### PR TITLE
Refactor form state into view-models

### DIFF
--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -49,6 +49,8 @@ namespace QuoteSwift
         public ICommand LoadDataCommand { get; }
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
+        public ICommand StartEditCommand { get; }
+        public ICommand StartViewCommand { get; }
 
         public Action CloseAction { get; set; }
 
@@ -151,6 +153,14 @@ namespace QuoteSwift
         }
 
         public bool IsEditing => changeSpecificObject;
+
+        public bool IsViewing => customerToChange != null && !changeSpecificObject;
+
+        public bool IsAdding => customerToChange == null && !changeSpecificObject;
+
+        public bool ShowSaveButton => !IsViewing;
+
+        public string SaveButtonText => changeSpecificObject ? "Update Customer" : "Add Customer";
 
         public string FormTitle
         {
@@ -308,6 +318,9 @@ namespace QuoteSwift
                 navigation?.SaveAllData();
                 applicationService?.Exit();
             }, messageService);
+
+            StartEditCommand = new RelayCommand(_ => ConvertToEdit(), _ => !ChangeSpecificObject);
+            StartViewCommand = new RelayCommand(_ => ConvertToViewOnly(), _ => ChangeSpecificObject);
         }
 
         public IDataService DataService => dataService;
@@ -372,6 +385,10 @@ namespace QuoteSwift
                     customerToChange = value;
                     OnPropertyChanged(nameof(CustomerToChange));
                     OnPropertyChanged(nameof(FormTitle));
+                    OnPropertyChanged(nameof(IsViewing));
+                    OnPropertyChanged(nameof(IsAdding));
+                    OnPropertyChanged(nameof(ShowSaveButton));
+                    OnPropertyChanged(nameof(SaveButtonText));
                 }
             }
         }
@@ -387,8 +404,12 @@ namespace QuoteSwift
                     OnPropertyChanged(nameof(ChangeSpecificObject));
                     OnPropertyChanged(nameof(IsReadOnly));
                     OnPropertyChanged(nameof(IsEditing));
+                    OnPropertyChanged(nameof(IsViewing));
+                    OnPropertyChanged(nameof(IsAdding));
                     OnPropertyChanged(nameof(CanEdit));
                     OnPropertyChanged(nameof(FormTitle));
+                    OnPropertyChanged(nameof(ShowSaveButton));
+                    OnPropertyChanged(nameof(SaveButtonText));
                 }
             }
         }
@@ -406,6 +427,48 @@ namespace QuoteSwift
                 OnPropertyChanged(nameof(CurrentCustomer));
                 OnPropertyChanged(nameof(FormTitle));
             }
+        }
+
+        public void ConvertToViewOnly()
+        {
+            ChangeSpecificObject = false;
+        }
+
+        public void ConvertToEdit()
+        {
+            ChangeSpecificObject = true;
+        }
+
+        public void ClearCustomerAddressInput()
+        {
+            AddressDescription = string.Empty;
+            Att = string.Empty;
+            WorkArea = string.Empty;
+            WorkPlace = string.Empty;
+        }
+
+        public void ClearPOBoxAddressInput()
+        {
+            PODescription = string.Empty;
+            POStreetNumber = string.Empty;
+            POSuburb = string.Empty;
+            POCity = string.Empty;
+            POAreaCode = string.Empty;
+        }
+
+        public void ResetScreenInput()
+        {
+            CurrentCustomer = new Customer();
+            ClearCustomerAddressInput();
+            ClearPOBoxAddressInput();
+            TelephoneInput = string.Empty;
+            CellphoneInput = string.Empty;
+            EmailInput = string.Empty;
+        }
+
+        public void LoadInformation()
+        {
+            OnPropertyChanged(nameof(CurrentCustomer));
         }
 
         public async Task LoadDataAsync()

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -71,6 +71,7 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand CalculateRebateCommand { get; }
         public ICommand UpdateDatesCommand { get; }
+        public ICommand LoadPassedQuoteCommand { get; }
 
         Quote lastCreatedQuote;
         public Quote LastCreatedQuote
@@ -176,6 +177,8 @@ namespace QuoteSwift
                 if (p is DateTime date)
                     UpdateDates(date);
             });
+
+            LoadPassedQuoteCommand = new RelayCommand(_ => LoadFromPassedObject());
 
             pricing.PropertyChanged += Pricing_PropertyChanged;
             OnPricingChanged();
@@ -722,6 +725,14 @@ namespace QuoteSwift
         {
             LoadQuote(quote);
             PrepareComboBoxLists();
+        }
+
+        public void LoadFromPassedObject()
+        {
+            if (QuoteToChange != null)
+            {
+                LoadFromQuote(QuoteToChange);
+            }
         }
 
         public void PrepareComboBoxLists()

--- a/Views/FrmAddCustomer.Designer.cs
+++ b/Views/FrmAddCustomer.Designer.cs
@@ -363,7 +363,6 @@ namespace QuoteSwift.Views
             this.updatedCustomerInformationToolStripMenuItem.Name = "updatedCustomerInformationToolStripMenuItem";
             this.updatedCustomerInformationToolStripMenuItem.Size = new System.Drawing.Size(285, 24);
             this.updatedCustomerInformationToolStripMenuItem.Text = "Update Customer\'s Information";
-            this.updatedCustomerInformationToolStripMenuItem.Click += new System.EventHandler(this.UpdatedCustomerInformationToolStripMenuItem_Click);
             // 
             // closeToolStripMenuItem
             // 

--- a/Views/FrmAddCustomer.cs
+++ b/Views/FrmAddCustomer.cs
@@ -25,6 +25,8 @@ namespace QuoteSwift.Views
             this.serializationService = serializationService;
             this.messageService = messageService;
             viewModel.CloseAction = Close;
+            viewModel.PropertyChanged += ViewModel_PropertyChanged;
+            DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.FormTitle));
             viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
             BindIsBusy(viewModel);
 
@@ -54,6 +56,9 @@ namespace QuoteSwift.Views
             gbxPhoneRelated.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
             gbxPOBoxAddress.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
 
+            btnAddCustomer.DataBindings.Add("Visible", viewModel, nameof(AddCustomerViewModel.ShowSaveButton));
+            btnAddCustomer.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.SaveButtonText));
+
             CommandBindings.Bind(btnAddCustomer, viewModel.SaveCustomerCommand);
             CommandBindings.Bind(btnAddAddress, viewModel.AddAddressCommand);
             CommandBindings.Bind(btnAddPOBoxAddress, viewModel.AddPOBoxAddressCommand);
@@ -65,6 +70,15 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnViewAddresses, viewModel.ViewAddressesCommand);
             CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(updatedCustomerInformationToolStripMenuItem, viewModel.StartEditCommand);
+        }
+
+        void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AddCustomerViewModel.IsViewing))
+            {
+                updatedCustomerInformationToolStripMenuItem.Enabled = viewModel.IsViewing;
+            }
         }
 
 
@@ -86,8 +100,8 @@ namespace QuoteSwift.Views
             else if (viewModel.CustomerToChange != null && !viewModel.ChangeSpecificObject) // View Existing Customer Info
             {
                 viewModel.CurrentCustomer = viewModel.CustomerToChange;
-                ConvertToViewOnly();
-                LoadInformation();
+                viewModel.ConvertToViewOnly();
+                viewModel.LoadInformation();
 
             }
             else if (viewModel.CustomerToChange == null && !viewModel.ChangeSpecificObject) // Add New Business Info
@@ -127,12 +141,7 @@ namespace QuoteSwift.Views
             viewModel.ViewAddressesCommand.Execute(null);
         }
 
-        private void UpdatedCustomerInformationToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            ConvertToEdit();
-            viewModel.ChangeSpecificObject = true;
-            updatedCustomerInformationToolStripMenuItem.Enabled = false;
-        }
+
 
 
 
@@ -153,76 +162,6 @@ namespace QuoteSwift.Views
             gbxEmailRelated.Enabled = false;
             gbxPOBoxAddress.Enabled = false;
             btnAddCustomer.Enabled = false;
-        }
-
-        private void ClearCustomerAddressInput()
-        {
-            txtCustomerAddresssDescription.ResetText();
-            txtAtt.ResetText();
-            txtWorkArea.ResetText();
-            txtWorkPlace.ResetText();
-        }
-
-        private void ClearPOBoxAddressInput()
-        {
-            txtCustomerPODescription.ResetText();
-            mtxtPOBoxStreetNumber.ResetText();
-            txtPOBoxSuburb.ResetText();
-            txtPOBoxCity.ResetText();
-            mtxtPOBoxAreaCode.ResetText();
-        }
-
-        private void ResetScreenInput()
-        {
-            txtCustomerCompanyName.ResetText();
-            cbBusinessSelection.ResetText();
-            mtxtVATNumber.ResetText();
-            mtxtRegistrationNumber.ResetText();
-            ClearCustomerAddressInput();
-            ClearPOBoxAddressInput();
-            mtxtEmailAddress.ResetText();
-            mtxtCellphoneNumber.ResetText();
-            mtxtTelephoneNumber.ResetText();
-            mtxtVendorNumber.ResetText();
-        }
-
-        private void LoadInformation()
-        {
-            if (viewModel.CurrentCustomer != null)
-            {
-                txtCustomerCompanyName.Text = viewModel.CurrentCustomer.CustomerCompanyName;
-                cbBusinessSelection.Text = Container?.BusinessName;
-                mtxtVATNumber.Text = viewModel.CurrentCustomer.CustomerLegalDetails.VatNumber;
-                mtxtRegistrationNumber.Text = viewModel.CurrentCustomer.CustomerLegalDetails.RegistrationNumber;
-                mtxtVendorNumber.Text = viewModel.CurrentCustomer.VendorNumber;
-            }
-        }
-
-        private void ConvertToViewOnly()
-        {
-            viewModel.ChangeSpecificObject = false;
-
-            btnViewAddresses.Enabled = true;
-            btnViewAll.Enabled = true;
-            btnViewAllPOBoxAddresses.Enabled = true;
-            btnViewEmailAddresses.Enabled = true;
-
-            btnAddCustomer.Visible = false;
-            Text = Text.Replace("Add Customer", "Viewing " + viewModel.CurrentCustomer.CustomerName);
-            updatedCustomerInformationToolStripMenuItem.Enabled = true;
-        }
-
-        private void ConvertToEdit()
-        {
-            viewModel.ChangeSpecificObject = true;
-
-            btnAddCustomer.Visible = true;
-            btnAddCustomer.Text = "Update Customer";
-            if (Container != null)
-                Text = Text.Replace("Viewing " + Container.BusinessName, "Updating " + Container.BusinessName);
-            if (viewModel.CustomerToChange != null)
-                Text = Text.Replace("Viewing " + viewModel.CustomerToChange.CustomerName, "Updating " + viewModel.CustomerToChange.CustomerName);
-            updatedCustomerInformationToolStripMenuItem.Enabled = false;
         }
 
 

--- a/Views/FrmCreateQuote.Designer.cs
+++ b/Views/FrmCreateQuote.Designer.cs
@@ -1047,7 +1047,6 @@ namespace QuoteSwift.Views
             this.cbxPumpSelection.Size = new System.Drawing.Size(343, 26);
             this.cbxPumpSelection.TabIndex = 20;
             this.cbxPumpSelection.Text = "Pump Selection";
-            this.cbxPumpSelection.SelectedIndexChanged += new System.EventHandler(this.CbxPumpSelection_SelectedIndexChanged);
             // 
             // panel6
             // 

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -20,8 +20,6 @@ namespace QuoteSwift.Views
         bool changeSpecificObject;
         public Quote NewQuote;
 
-        readonly BindingSource mandatorySource = new BindingSource();
-        readonly BindingSource nonMandatorySource = new BindingSource();
 
 
         public FrmCreateQuote(CreateQuoteViewModel viewModel, IMessageService messageService = null, ISerializationService serializationService = null)
@@ -70,11 +68,6 @@ namespace QuoteSwift.Views
                 viewModel.ExitCommand.Execute(null);
         }
 
-        private void CbxPumpSelection_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            mandatorySource.DataSource = viewModel.MandatoryParts;
-            nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
-        }
 
         private async void FrmCreateQuote_Load(object sender, EventArgs e)
         {
@@ -83,11 +76,11 @@ namespace QuoteSwift.Views
             viewModel.ChangeSpecificObject = changeSpecificObject;
             if (viewModel.IsViewing)
             {
-                LoadFromPassedObject();
+                viewModel.LoadPassedQuoteCommand.Execute(null);
             }
             else if (viewModel.IsEditing && viewModel.QuoteToChange != null)
             {
-                LoadFromPassedObject();
+                viewModel.LoadPassedQuoteCommand.Execute(null);
 
                 viewModel.QuoteCreationDate = DateTime.Today;
                 viewModel.QuoteExpiryDate = viewModel.QuoteCreationDate.AddMonths(2);
@@ -103,8 +96,6 @@ namespace QuoteSwift.Views
             {
                 viewModel.PrepareComboBoxLists();
                 viewModel.LoadPartlists();
-                mandatorySource.DataSource = viewModel.MandatoryParts;
-                nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
                 if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
                     viewModel.QuoteNumber = viewModel.NextQuoteNumber;
 
@@ -157,8 +148,7 @@ namespace QuoteSwift.Views
             clmUnitPrice.DataPropertyName = nameof(Quote_Part.UnitPrice);
             clmTotal.DataPropertyName = nameof(Quote_Part.Price);
             ClmRepairDevider.DataPropertyName = nameof(Quote_Part.RepairDevider);
-            mandatorySource.DataSource = viewModel.MandatoryParts;
-            BindingHelpers.BindDataGridView(dgvMandatoryPartReplacement, mandatorySource, nameof(BindingSource.DataSource));
+            BindingHelpers.BindDataGridView(dgvMandatoryPartReplacement, viewModel, nameof(CreateQuoteViewModel.MandatoryParts));
 
             DgvNonMandatoryPartReplacement.AutoGenerateColumns = false;
             dataGridViewTextBoxColumn1.DataPropertyName = "PumpPart.PumpPart.NewPartNumber";
@@ -171,8 +161,7 @@ namespace QuoteSwift.Views
             ClmNMUnitPrice.DataPropertyName = nameof(Quote_Part.UnitPrice);
             dataGridViewTextBoxColumn9.DataPropertyName = nameof(Quote_Part.Price);
             ClmNMRepairDevider.DataPropertyName = nameof(Quote_Part.RepairDevider);
-            nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
-            BindingHelpers.BindDataGridView(DgvNonMandatoryPartReplacement, nonMandatorySource, nameof(BindingSource.DataSource));
+            BindingHelpers.BindDataGridView(DgvNonMandatoryPartReplacement, viewModel, nameof(CreateQuoteViewModel.NonMandatoryParts));
 
             BindingHelpers.BindComboBox(cbxBusinessSelection, viewModel, nameof(CreateQuoteViewModel.Businesses), nameof(CreateQuoteViewModel.SelectedBusiness), "BusinessName", "BusinessName");
 
@@ -264,13 +253,6 @@ namespace QuoteSwift.Views
         private async System.Threading.Tasks.Task ExportQuoteToTemplateAsync(Quote q)
         {
             await ((AsyncRelayCommand)viewModel.ExportQuoteCommand).ExecuteAsync(q);
-        }
-
-        private void LoadFromPassedObject()
-        {
-            viewModel.LoadFromQuote(quoteToChange);
-            mandatorySource.DataSource = viewModel.MandatoryParts;
-            nonMandatorySource.DataSource = viewModel.NonMandatoryParts;
         }
 
         // View-model bindings manage read-only state


### PR DESCRIPTION
## Summary
- move state management helpers from `FrmAddCustomer` into `AddCustomerViewModel`
- add edit/view mode properties and commands
- expose a command in `CreateQuoteViewModel` for loading a passed quote
- bind forms to the new view‑model APIs and remove obsolete handlers

## Testing
- `xbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: The default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6881e32a7a0c83258e8997b6d4aff35d