### PR TITLE
Move CloseAction property to ViewModelBase

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -53,7 +53,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
         public OperationResult LastResult
         {

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -52,7 +52,6 @@ namespace QuoteSwift
         public ICommand StartEditCommand { get; }
         public ICommand StartViewCommand { get; }
 
-        public Action CloseAction { get; set; }
 
         public OperationResult LastResult
         {

--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -37,7 +37,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand StartEditCommand { get; }
 
-        public Action CloseAction { get; set; }
 
         public bool LastOperationSuccessful
         {

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -25,7 +25,6 @@ namespace QuoteSwift
         public ICommand ExitCommand { get; }
         public ICommand CancelCommand { get; }
 
-        public Action CloseAction { get; set; }
 
         public bool LastOperationSuccessful
         {

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -60,7 +60,6 @@ namespace QuoteSwift
         Quote quoteToChange;
         bool changeSpecificObject;
 
-        public Action CloseAction { get; set; }
 
         public ICommand AddQuoteCommand { get; }
         public ICommand SaveQuoteCommand { get; }

--- a/ViewModels/EditBusinessAddressViewModel.cs
+++ b/ViewModels/EditBusinessAddressViewModel.cs
@@ -25,7 +25,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
         public OperationResult LastResult
         {

--- a/ViewModels/EditEmailAddressViewModel.cs
+++ b/ViewModels/EditEmailAddressViewModel.cs
@@ -19,7 +19,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
         public EditEmailAddressViewModel(Business business = null,
                                           Customer customer = null,

--- a/ViewModels/EditPhoneNumberViewModel.cs
+++ b/ViewModels/EditPhoneNumberViewModel.cs
@@ -18,7 +18,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public EditPhoneNumberViewModel(Business business = null, Customer customer = null, string number = "", IMessageService messageService = null, IApplicationService applicationService = null)

--- a/ViewModels/ManageEmailsViewModel.cs
+++ b/ViewModels/ManageEmailsViewModel.cs
@@ -24,7 +24,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand EditSelectedEmailCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public ManageEmailsViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)

--- a/ViewModels/ManagePhoneNumbersViewModel.cs
+++ b/ViewModels/ManagePhoneNumbersViewModel.cs
@@ -32,7 +32,6 @@ namespace QuoteSwift
         public ICommand EditTelephoneCommand { get; }
         public ICommand EditCellphoneCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public ManagePhoneNumbersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)

--- a/ViewModels/ViewBusinessAddressesViewModel.cs
+++ b/ViewModels/ViewBusinessAddressesViewModel.cs
@@ -17,7 +17,6 @@ namespace QuoteSwift
         bool changeSpecificObject;
         Address selectedAddress;
 
-        public Action CloseAction { get; set; }
 
         public ICommand ExitCommand { get; }
         public ICommand CancelCommand { get; }

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -19,7 +19,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public ViewBusinessesViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -24,7 +24,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public ViewCustomersViewModel(IDataService service, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -10,7 +10,7 @@ namespace QuoteSwift
     public class ViewModelBase : ObservableObject
     {
         bool isBusy;
-
+        
         /// <summary>
         /// Indicates whether the view model is performing a background
         /// operation.
@@ -20,6 +20,11 @@ namespace QuoteSwift
             get => isBusy;
             protected set => SetProperty(ref isBusy, value);
         }
+
+        /// <summary>
+        /// Action invoked when a view should be closed.
+        /// </summary>
+        public Action CloseAction { get; set; }
         /// <summary>
         /// Creates an <see cref="AsyncRelayCommand"/> for the supplied asynchronous
         /// load action.

--- a/ViewModels/ViewPOBoxAddressesViewModel.cs
+++ b/ViewModels/ViewPOBoxAddressesViewModel.cs
@@ -17,7 +17,6 @@ namespace QuoteSwift
         bool changeSpecificObject;
         Address selectedAddress;
 
-        public Action CloseAction { get; set; }
 
         public ICommand RemoveSelectedAddressCommand { get; }
         public ICommand SaveChangesCommand { get; }

--- a/ViewModels/ViewPartsViewModel.cs
+++ b/ViewModels/ViewPartsViewModel.cs
@@ -26,7 +26,6 @@ namespace QuoteSwift
         public ICommand CancelCommand { get; }
         public ICommand ExitCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public ViewPartsViewModel(IDataService service, ApplicationData appData, INavigationService navigation = null, IMessageService messageService = null, IApplicationService applicationService = null)

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -29,7 +29,6 @@ namespace QuoteSwift
         public ICommand ExitCommand { get; }
         public ICommand CancelCommand { get; }
 
-        public Action CloseAction { get; set; }
 
 
         public ViewPumpViewModel(IDataService service, ISerializationService serializer,


### PR DESCRIPTION
## Summary
- centralize `CloseAction` on `ViewModelBase`
- remove duplicate `CloseAction` properties from individual view models

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln` *(fails: ResolveComReference task requires Windows)*

------
https://chatgpt.com/codex/tasks/task_e_6881ed34780083259867fd68f946c338