### PR TITLE
Refactor forms to use generic BaseForm

### DIFF
--- a/BaseForm.cs
+++ b/BaseForm.cs
@@ -43,4 +43,15 @@ namespace QuoteSwift
             };
         }
     }
+
+    public abstract class BaseForm<TViewModel> : BaseForm
+    {
+        protected BaseForm(TViewModel viewModel, IMessageService messageService = null, INavigationService navigation = null)
+            : base(messageService, navigation)
+        {
+            ViewModel = viewModel;
+        }
+
+        public TViewModel ViewModel { get; }
+    }
 }

--- a/Views/FrmAddBusiness.cs
+++ b/Views/FrmAddBusiness.cs
@@ -4,28 +4,25 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmAddBusiness : BaseForm
+    public partial class FrmAddBusiness : BaseForm<AddBusinessViewModel>
     {
 
-        readonly AddBusinessViewModel viewModel;
-        public AddBusinessViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
 
         public FrmAddBusiness(AddBusinessViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
+            ViewModel.CloseAction = Close;
 
-            DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.FormTitle));
-            viewModel.PropertyChanged += ViewModel_PropertyChanged;
-            BindIsBusy(viewModel);
+            DataBindings.Add("Text", ViewModel, nameof(AddBusinessViewModel.FormTitle));
+            ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+            BindIsBusy(ViewModel);
         }
 
 
@@ -35,7 +32,7 @@ namespace QuoteSwift.Views
         {
             if (e.PropertyName == nameof(AddBusinessViewModel.IsViewing))
             {
-                updateBusinessInformationToolStripMenuItem.Enabled = viewModel.IsViewing;
+                updateBusinessInformationToolStripMenuItem.Enabled = ViewModel.IsViewing;
             }
         }
 
@@ -43,22 +40,22 @@ namespace QuoteSwift.Views
 
         private async void FrmAddBusiness_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
-            var initResult = viewModel.InitializeCurrentBusinessResult();
+            await ViewModel.LoadDataAsync();
+            var initResult = ViewModel.InitializeCurrentBusinessResult();
             if (!initResult.Success)
             {
                 DisableMainComponents();
             }
 
-            viewModel.EnsureLegalDetails();
+            ViewModel.EnsureLegalDetails();
             SetupBindings();
-            updateBusinessInformationToolStripMenuItem.Enabled = viewModel.IsViewing;
+            updateBusinessInformationToolStripMenuItem.Enabled = ViewModel.IsViewing;
         }
 
 
         private void UpdateBusinessInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            viewModel.ChangeSpecificObject = true;
+            ViewModel.ChangeSpecificObject = true;
         }
 
 
@@ -66,50 +63,50 @@ namespace QuoteSwift.Views
 
         private void SetupBindings()
         {
-            BindingHelpers.BindText(txtBusinessName, viewModel.CurrentBusiness, nameof(Business.BusinessName));
-            BindingHelpers.BindText(rtxtExtraInformation, viewModel.CurrentBusiness, nameof(Business.BusinessExtraInformation));
-            BindingHelpers.BindText(mtxtVATNumber, viewModel.CurrentBusiness, "BusinessLegalDetails.VatNumber");
-            BindingHelpers.BindText(mtxtRegistrationNumber, viewModel.CurrentBusiness, "BusinessLegalDetails.RegistrationNumber");
+            BindingHelpers.BindText(txtBusinessName, ViewModel.CurrentBusiness, nameof(Business.BusinessName));
+            BindingHelpers.BindText(rtxtExtraInformation, ViewModel.CurrentBusiness, nameof(Business.BusinessExtraInformation));
+            BindingHelpers.BindText(mtxtVATNumber, ViewModel.CurrentBusiness, "BusinessLegalDetails.VatNumber");
+            BindingHelpers.BindText(mtxtRegistrationNumber, ViewModel.CurrentBusiness, "BusinessLegalDetails.RegistrationNumber");
 
-            BindingHelpers.BindText(txtBusinessAddresssDescription, viewModel, nameof(AddBusinessViewModel.AddressDescription));
-            BindingHelpers.BindText(mtxtStreetnumber, viewModel, nameof(AddBusinessViewModel.StreetNumber));
-            BindingHelpers.BindText(txtStreetName, viewModel, nameof(AddBusinessViewModel.StreetName));
-            BindingHelpers.BindText(txtSuburb, viewModel, nameof(AddBusinessViewModel.Suburb));
-            BindingHelpers.BindText(txtCity, viewModel, nameof(AddBusinessViewModel.City));
-            BindingHelpers.BindText(mtxtAreaCode, viewModel, nameof(AddBusinessViewModel.AreaCode));
+            BindingHelpers.BindText(txtBusinessAddresssDescription, ViewModel, nameof(AddBusinessViewModel.AddressDescription));
+            BindingHelpers.BindText(mtxtStreetnumber, ViewModel, nameof(AddBusinessViewModel.StreetNumber));
+            BindingHelpers.BindText(txtStreetName, ViewModel, nameof(AddBusinessViewModel.StreetName));
+            BindingHelpers.BindText(txtSuburb, ViewModel, nameof(AddBusinessViewModel.Suburb));
+            BindingHelpers.BindText(txtCity, ViewModel, nameof(AddBusinessViewModel.City));
+            BindingHelpers.BindText(mtxtAreaCode, ViewModel, nameof(AddBusinessViewModel.AreaCode));
 
-            BindingHelpers.BindText(txtBusinessPODescription, viewModel, nameof(AddBusinessViewModel.PODescription));
-            BindingHelpers.BindText(mtxtPOBoxStreetNumber, viewModel, nameof(AddBusinessViewModel.POStreetNumber));
-            BindingHelpers.BindText(txtPOBoxSuburb, viewModel, nameof(AddBusinessViewModel.POSuburb));
-            BindingHelpers.BindText(txtPOBoxCity, viewModel, nameof(AddBusinessViewModel.POCity));
-            BindingHelpers.BindText(mtxtPOBoxAreaCode, viewModel, nameof(AddBusinessViewModel.POAreaCode));
+            BindingHelpers.BindText(txtBusinessPODescription, ViewModel, nameof(AddBusinessViewModel.PODescription));
+            BindingHelpers.BindText(mtxtPOBoxStreetNumber, ViewModel, nameof(AddBusinessViewModel.POStreetNumber));
+            BindingHelpers.BindText(txtPOBoxSuburb, ViewModel, nameof(AddBusinessViewModel.POSuburb));
+            BindingHelpers.BindText(txtPOBoxCity, ViewModel, nameof(AddBusinessViewModel.POCity));
+            BindingHelpers.BindText(mtxtPOBoxAreaCode, ViewModel, nameof(AddBusinessViewModel.POAreaCode));
 
-            BindingHelpers.BindText(mtxtTelephoneNumber, viewModel, nameof(AddBusinessViewModel.TelephoneInput));
-            BindingHelpers.BindText(mtxtCellphoneNumber, viewModel, nameof(AddBusinessViewModel.CellphoneInput));
+            BindingHelpers.BindText(mtxtTelephoneNumber, ViewModel, nameof(AddBusinessViewModel.TelephoneInput));
+            BindingHelpers.BindText(mtxtCellphoneNumber, ViewModel, nameof(AddBusinessViewModel.CellphoneInput));
 
-            BindingHelpers.BindText(mtxtEmail, viewModel, nameof(AddBusinessViewModel.EmailInput));
+            BindingHelpers.BindText(mtxtEmail, ViewModel, nameof(AddBusinessViewModel.EmailInput));
 
-            gbxBusinessAddress.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
-            gbxBusinessInformation.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
-            gbxEmailRelated.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
-            gbxLegalInformation.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
-            gbxPhoneRelated.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
-            gbxPOBoxAddress.DataBindings.Add("Enabled", viewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxBusinessAddress.DataBindings.Add("Enabled", ViewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxBusinessInformation.DataBindings.Add("Enabled", ViewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxEmailRelated.DataBindings.Add("Enabled", ViewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxLegalInformation.DataBindings.Add("Enabled", ViewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxPhoneRelated.DataBindings.Add("Enabled", ViewModel, nameof(AddBusinessViewModel.IsEditing));
+            gbxPOBoxAddress.DataBindings.Add("Enabled", ViewModel, nameof(AddBusinessViewModel.IsEditing));
 
-            btnAddBusiness.DataBindings.Add("Visible", viewModel, nameof(AddBusinessViewModel.ShowSaveButton));
-            btnAddBusiness.DataBindings.Add("Text", viewModel, nameof(AddBusinessViewModel.SaveButtonText));
+            btnAddBusiness.DataBindings.Add("Visible", ViewModel, nameof(AddBusinessViewModel.ShowSaveButton));
+            btnAddBusiness.DataBindings.Add("Text", ViewModel, nameof(AddBusinessViewModel.SaveButtonText));
 
-            CommandBindings.Bind(btnAddBusiness, viewModel.SaveBusinessCommand);
-            CommandBindings.Bind(btnAddAddress, viewModel.AddAddressCommand);
-            CommandBindings.Bind(btnAddPOBoxAddress, viewModel.AddPOBoxAddressCommand);
-            CommandBindings.Bind(btnAddNumber, viewModel.AddPhoneNumberCommand);
-            CommandBindings.Bind(btnAddBusinessEmail, viewModel.AddEmailCommand);
-            CommandBindings.Bind(btnViewEmailAddresses, viewModel.ViewEmailAddressesCommand);
-            CommandBindings.Bind(btnViewAddresses, viewModel.ViewAddressesCommand);
-            CommandBindings.Bind(btnViewAllPOBoxAddresses, viewModel.ViewPOBoxAddressesCommand);
-            CommandBindings.Bind(btnViewAll, viewModel.ViewPhoneNumbersCommand);
-            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(btnAddBusiness, ViewModel.SaveBusinessCommand);
+            CommandBindings.Bind(btnAddAddress, ViewModel.AddAddressCommand);
+            CommandBindings.Bind(btnAddPOBoxAddress, ViewModel.AddPOBoxAddressCommand);
+            CommandBindings.Bind(btnAddNumber, ViewModel.AddPhoneNumberCommand);
+            CommandBindings.Bind(btnAddBusinessEmail, ViewModel.AddEmailCommand);
+            CommandBindings.Bind(btnViewEmailAddresses, ViewModel.ViewEmailAddressesCommand);
+            CommandBindings.Bind(btnViewAddresses, ViewModel.ViewAddressesCommand);
+            CommandBindings.Bind(btnViewAllPOBoxAddresses, ViewModel.ViewPOBoxAddressesCommand);
+            CommandBindings.Bind(btnViewAll, ViewModel.ViewPhoneNumbersCommand);
+            CommandBindings.Bind(btnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         private void DisableMainComponents()

--- a/Views/FrmAddCustomer.cs
+++ b/Views/FrmAddCustomer.cs
@@ -4,96 +4,92 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmAddCustomer : BaseForm
+    public partial class FrmAddCustomer : BaseForm<AddCustomerViewModel>
     {
 
-        readonly AddCustomerViewModel viewModel;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
 
-        public AddCustomerViewModel ViewModel => viewModel;
-
         public Business Container { get; set; }
 
         public FrmAddCustomer(AddCustomerViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            viewModel.PropertyChanged += ViewModel_PropertyChanged;
-            DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.FormTitle));
-            viewModel.CurrentCustomer = viewModel.CustomerToChange ?? new Customer();
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+            DataBindings.Add("Text", ViewModel, nameof(AddCustomerViewModel.FormTitle));
+            ViewModel.CurrentCustomer = ViewModel.CustomerToChange ?? new Customer();
+            BindIsBusy(ViewModel);
 
-            BindingHelpers.BindText(txtCustomerCompanyName, viewModel.CurrentCustomer, nameof(Customer.CustomerCompanyName));
-            BindingHelpers.BindText(mtxtVendorNumber, viewModel.CurrentCustomer, nameof(Customer.VendorNumber));
+            BindingHelpers.BindText(txtCustomerCompanyName, ViewModel.CurrentCustomer, nameof(Customer.CustomerCompanyName));
+            BindingHelpers.BindText(mtxtVendorNumber, ViewModel.CurrentCustomer, nameof(Customer.VendorNumber));
 
-            BindingHelpers.BindText(txtCustomerAddresssDescription, viewModel, nameof(AddCustomerViewModel.AddressDescription));
-            BindingHelpers.BindText(txtAtt, viewModel, nameof(AddCustomerViewModel.Att));
-            BindingHelpers.BindText(txtWorkArea, viewModel, nameof(AddCustomerViewModel.WorkArea));
-            BindingHelpers.BindText(txtWorkPlace, viewModel, nameof(AddCustomerViewModel.WorkPlace));
+            BindingHelpers.BindText(txtCustomerAddresssDescription, ViewModel, nameof(AddCustomerViewModel.AddressDescription));
+            BindingHelpers.BindText(txtAtt, ViewModel, nameof(AddCustomerViewModel.Att));
+            BindingHelpers.BindText(txtWorkArea, ViewModel, nameof(AddCustomerViewModel.WorkArea));
+            BindingHelpers.BindText(txtWorkPlace, ViewModel, nameof(AddCustomerViewModel.WorkPlace));
 
-            BindingHelpers.BindText(txtCustomerPODescription, viewModel, nameof(AddCustomerViewModel.PODescription));
-            BindingHelpers.BindText(mtxtPOBoxStreetNumber, viewModel, nameof(AddCustomerViewModel.POStreetNumber));
-            BindingHelpers.BindText(txtPOBoxSuburb, viewModel, nameof(AddCustomerViewModel.POSuburb));
-            BindingHelpers.BindText(txtPOBoxCity, viewModel, nameof(AddCustomerViewModel.POCity));
-            BindingHelpers.BindText(mtxtPOBoxAreaCode, viewModel, nameof(AddCustomerViewModel.POAreaCode));
+            BindingHelpers.BindText(txtCustomerPODescription, ViewModel, nameof(AddCustomerViewModel.PODescription));
+            BindingHelpers.BindText(mtxtPOBoxStreetNumber, ViewModel, nameof(AddCustomerViewModel.POStreetNumber));
+            BindingHelpers.BindText(txtPOBoxSuburb, ViewModel, nameof(AddCustomerViewModel.POSuburb));
+            BindingHelpers.BindText(txtPOBoxCity, ViewModel, nameof(AddCustomerViewModel.POCity));
+            BindingHelpers.BindText(mtxtPOBoxAreaCode, ViewModel, nameof(AddCustomerViewModel.POAreaCode));
 
-            BindingHelpers.BindText(mtxtTelephoneNumber, viewModel, nameof(AddCustomerViewModel.TelephoneInput));
-            BindingHelpers.BindText(mtxtCellphoneNumber, viewModel, nameof(AddCustomerViewModel.CellphoneInput));
+            BindingHelpers.BindText(mtxtTelephoneNumber, ViewModel, nameof(AddCustomerViewModel.TelephoneInput));
+            BindingHelpers.BindText(mtxtCellphoneNumber, ViewModel, nameof(AddCustomerViewModel.CellphoneInput));
 
-            BindingHelpers.BindText(mtxtEmailAddress, viewModel, nameof(AddCustomerViewModel.EmailInput));
+            BindingHelpers.BindText(mtxtEmailAddress, ViewModel, nameof(AddCustomerViewModel.EmailInput));
 
-            gbxCustomerInformation.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
-            gbxCustomerAddress.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
-            gbxEmailRelated.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
-            gbxLegalInformation.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
-            gbxPhoneRelated.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
-            gbxPOBoxAddress.DataBindings.Add("Enabled", viewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxCustomerInformation.DataBindings.Add("Enabled", ViewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxCustomerAddress.DataBindings.Add("Enabled", ViewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxEmailRelated.DataBindings.Add("Enabled", ViewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxLegalInformation.DataBindings.Add("Enabled", ViewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxPhoneRelated.DataBindings.Add("Enabled", ViewModel, nameof(AddCustomerViewModel.IsEditing));
+            gbxPOBoxAddress.DataBindings.Add("Enabled", ViewModel, nameof(AddCustomerViewModel.IsEditing));
 
-            btnAddCustomer.DataBindings.Add("Visible", viewModel, nameof(AddCustomerViewModel.ShowSaveButton));
-            btnAddCustomer.DataBindings.Add("Text", viewModel, nameof(AddCustomerViewModel.SaveButtonText));
+            btnAddCustomer.DataBindings.Add("Visible", ViewModel, nameof(AddCustomerViewModel.ShowSaveButton));
+            btnAddCustomer.DataBindings.Add("Text", ViewModel, nameof(AddCustomerViewModel.SaveButtonText));
 
-            CommandBindings.Bind(btnAddCustomer, viewModel.SaveCustomerCommand);
-            CommandBindings.Bind(btnAddAddress, viewModel.AddAddressCommand);
-            CommandBindings.Bind(btnAddPOBoxAddress, viewModel.AddPOBoxAddressCommand);
-            CommandBindings.Bind(btnAddNumber, viewModel.AddPhoneNumberCommand);
-            CommandBindings.Bind(BtnAddEmail, viewModel.AddEmailCommand);
-            CommandBindings.Bind(btnViewAll, viewModel.ViewPhoneNumbersCommand);
-            CommandBindings.Bind(btnViewAllPOBoxAddresses, viewModel.ViewPOBoxAddressesCommand);
-            CommandBindings.Bind(btnViewEmailAddresses, viewModel.ViewEmailAddressesCommand);
-            CommandBindings.Bind(btnViewAddresses, viewModel.ViewAddressesCommand);
-            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            CommandBindings.Bind(updatedCustomerInformationToolStripMenuItem, viewModel.StartEditCommand);
+            CommandBindings.Bind(btnAddCustomer, ViewModel.SaveCustomerCommand);
+            CommandBindings.Bind(btnAddAddress, ViewModel.AddAddressCommand);
+            CommandBindings.Bind(btnAddPOBoxAddress, ViewModel.AddPOBoxAddressCommand);
+            CommandBindings.Bind(btnAddNumber, ViewModel.AddPhoneNumberCommand);
+            CommandBindings.Bind(BtnAddEmail, ViewModel.AddEmailCommand);
+            CommandBindings.Bind(btnViewAll, ViewModel.ViewPhoneNumbersCommand);
+            CommandBindings.Bind(btnViewAllPOBoxAddresses, ViewModel.ViewPOBoxAddressesCommand);
+            CommandBindings.Bind(btnViewEmailAddresses, ViewModel.ViewEmailAddressesCommand);
+            CommandBindings.Bind(btnViewAddresses, ViewModel.ViewAddressesCommand);
+            CommandBindings.Bind(btnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
+            CommandBindings.Bind(updatedCustomerInformationToolStripMenuItem, ViewModel.StartEditCommand);
         }
 
         void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(AddCustomerViewModel.IsViewing))
             {
-                updatedCustomerInformationToolStripMenuItem.Enabled = viewModel.IsViewing;
+                updatedCustomerInformationToolStripMenuItem.Enabled = ViewModel.IsViewing;
             }
         }
 
 
         private async void FrmAddCustomer_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
-            if (viewModel.BusinessList != null)
+            await ViewModel.LoadDataAsync();
+            if (ViewModel.BusinessList != null)
             {
-                BindingSource source = new BindingSource { DataSource = viewModel.BusinessList };
+                BindingSource source = new BindingSource { DataSource = ViewModel.BusinessList };
                 cbBusinessSelection.DataSource = source.DataSource;
                 cbBusinessSelection.DisplayMember = "BusinessName";
                 cbBusinessSelection.ValueMember = "BusinessName";
             }
 
-            bool initSuccess = viewModel.ValidateInitialization();
+            bool initSuccess = ViewModel.ValidateInitialization();
             if (!initSuccess)
             {
                 DisableMainComponents();
@@ -108,22 +104,22 @@ namespace QuoteSwift.Views
 
         private void BtnViewAll_Click(object sender, EventArgs e)
         {
-            viewModel.ViewPhoneNumbersCommand.Execute(null);
+            ViewModel.ViewPhoneNumbersCommand.Execute(null);
         }
 
         private void BtnViewAllPOBoxAddresses_Click(object sender, EventArgs e)
         {
-            viewModel.ViewPOBoxAddressesCommand.Execute(null);
+            ViewModel.ViewPOBoxAddressesCommand.Execute(null);
         }
 
         private void BtnViewEmailAddresses_Click(object sender, EventArgs e)
         {
-            viewModel.ViewEmailAddressesCommand.Execute(null);
+            ViewModel.ViewEmailAddressesCommand.Execute(null);
         }
 
         private void BtnViewAddresses_Click(object sender, EventArgs e)
         {
-            viewModel.ViewAddressesCommand.Execute(null);
+            ViewModel.ViewAddressesCommand.Execute(null);
         }
 
 

--- a/Views/FrmAddPart.cs
+++ b/Views/FrmAddPart.cs
@@ -4,28 +4,25 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmAddPart : BaseForm
+    public partial class FrmAddPart : BaseForm<AddPartViewModel>
     {
 
-        readonly AddPartViewModel viewModel;
-        public AddPartViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
         readonly Button btnCancelOperation;
 
         public FrmAddPart(AddPartViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            viewModel.Initialize();
+            ViewModel.CloseAction = Close;
+            ViewModel.Initialize();
             SetupBindings();
-            BindIsBusy(viewModel);
+            BindIsBusy(ViewModel);
 
             btnCancelOperation = new Button
             {
@@ -39,39 +36,39 @@ namespace QuoteSwift.Views
 
         void SetupBindings()
         {
-            mtxtPartName.DataBindings.Add("Text", viewModel.CurrentPart, nameof(Part.PartName), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPartDescription.DataBindings.Add("Text", viewModel.CurrentPart, nameof(Part.PartDescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtOriginalPartNumber.DataBindings.Add("Text", viewModel.CurrentPart, nameof(Part.OriginalItemPartNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtNewPartNumber.DataBindings.Add("Text", viewModel.CurrentPart, nameof(Part.NewPartNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtPartPrice.DataBindings.Add("Value", viewModel.CurrentPart, nameof(Part.PartPrice), false, DataSourceUpdateMode.OnPropertyChanged);
-            cbxMandatoryPart.DataBindings.Add("Checked", viewModel.CurrentPart, nameof(Part.MandatoryPart), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtPartName.DataBindings.Add("Text", ViewModel.CurrentPart, nameof(Part.PartName), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtPartDescription.DataBindings.Add("Text", ViewModel.CurrentPart, nameof(Part.PartDescription), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtOriginalPartNumber.DataBindings.Add("Text", ViewModel.CurrentPart, nameof(Part.OriginalItemPartNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtNewPartNumber.DataBindings.Add("Text", ViewModel.CurrentPart, nameof(Part.NewPartNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtPartPrice.DataBindings.Add("Value", ViewModel.CurrentPart, nameof(Part.PartPrice), false, DataSourceUpdateMode.OnPropertyChanged);
+            cbxMandatoryPart.DataBindings.Add("Checked", ViewModel.CurrentPart, nameof(Part.MandatoryPart), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            BindingHelpers.BindReadOnly(mtxtPartName, viewModel, nameof(AddPartViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(mtxtPartDescription, viewModel, nameof(AddPartViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(mtxtOriginalPartNumber, viewModel, nameof(AddPartViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(mtxtNewPartNumber, viewModel, nameof(AddPartViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(mtxtPartPrice, viewModel, nameof(AddPartViewModel.IsReadOnly));
-            BindingHelpers.BindEnabled(cbxMandatoryPart, viewModel, nameof(AddPartViewModel.CanEdit));
-            BindingHelpers.BindVisible(btnAddPart, viewModel, nameof(AddPartViewModel.ShowSaveButton));
-            btnAddPart.DataBindings.Add("Text", viewModel, nameof(AddPartViewModel.SaveButtonText));
+            BindingHelpers.BindReadOnly(mtxtPartName, ViewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtPartDescription, ViewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtOriginalPartNumber, ViewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtNewPartNumber, ViewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtPartPrice, ViewModel, nameof(AddPartViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(cbxMandatoryPart, ViewModel, nameof(AddPartViewModel.CanEdit));
+            BindingHelpers.BindVisible(btnAddPart, ViewModel, nameof(AddPartViewModel.ShowSaveButton));
+            btnAddPart.DataBindings.Add("Text", ViewModel, nameof(AddPartViewModel.SaveButtonText));
 
-            cbAddToPumpSelection.DataSource = viewModel.Pumps;
+            cbAddToPumpSelection.DataSource = ViewModel.Pumps;
             cbAddToPumpSelection.DisplayMember = nameof(Pump.PumpName);
             cbAddToPumpSelection.ValueMember = nameof(Pump.PumpName);
-            cbAddToPumpSelection.DataBindings.Add("SelectedItem", viewModel, nameof(AddPartViewModel.SelectedPump), false, DataSourceUpdateMode.OnPropertyChanged);
-            NudQuantity.DataBindings.Add("Value", viewModel, nameof(AddPartViewModel.Quantity), false, DataSourceUpdateMode.OnPropertyChanged);
+            cbAddToPumpSelection.DataBindings.Add("SelectedItem", ViewModel, nameof(AddPartViewModel.SelectedPump), false, DataSourceUpdateMode.OnPropertyChanged);
+            NudQuantity.DataBindings.Add("Value", ViewModel, nameof(AddPartViewModel.Quantity), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            CommandBindings.Bind(btnAddPart, viewModel.SavePartCommand);
-            CommandBindings.Bind(loadPartBatchToolStripMenuItem, viewModel.ImportPartsCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(resetInputToolStripMenuItem, viewModel.ResetInputCommand);
-            CommandBindings.Bind(updatePartToolStripMenuItem, viewModel.StartEditCommand);
+            CommandBindings.Bind(btnAddPart, ViewModel.SavePartCommand);
+            CommandBindings.Bind(loadPartBatchToolStripMenuItem, ViewModel.ImportPartsCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
+            CommandBindings.Bind(btnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(resetInputToolStripMenuItem, ViewModel.ResetInputCommand);
+            CommandBindings.Bind(updatePartToolStripMenuItem, ViewModel.StartEditCommand);
         }
 
         private void BtnCancelOperation_Click(object sender, EventArgs e)
         {
-            ((AsyncRelayCommand)viewModel.ImportPartsCommand).Cancel();
+            ((AsyncRelayCommand)ViewModel.ImportPartsCommand).Cancel();
         }
 
         private void CbAddToPumpSelection_ContextMenuStripChanged(object sender, EventArgs e)
@@ -81,10 +78,10 @@ namespace QuoteSwift.Views
 
         private async void FrmAddPart_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)viewModel.LoadDataCommand).ExecuteAsync(null);
-            if (viewModel.PartToChange == null)
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
+            if (ViewModel.PartToChange == null)
             {
-                viewModel.ChangeSpecificObject = true;
+                ViewModel.ChangeSpecificObject = true;
             }
         }
 

--- a/Views/FrmAddPump.cs
+++ b/Views/FrmAddPump.cs
@@ -6,10 +6,9 @@ using System.Linq;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmAddPump : BaseForm
+    public partial class FrmAddPump : BaseForm<AddPumpViewModel>
     {
-        readonly AddPumpViewModel viewModel;
-        public AddPumpViewModel ViewModel => viewModel;
+        
         readonly INavigationService navigation;
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
@@ -17,35 +16,34 @@ namespace QuoteSwift.Views
         readonly BindingSource nonMandatorySource = new BindingSource();
 
         public FrmAddPump(AddPumpViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            viewModel.CurrentPump = viewModel.PumpToChange ?? new Pump();
-            BindingHelpers.BindText(mtxtPumpName, viewModel, nameof(AddPumpViewModel.PumpName));
-            BindingHelpers.BindText(mtxtPumpDescription, viewModel, nameof(AddPumpViewModel.PumpDescription));
-            BindingHelpers.BindText(mtxtNewPumpPrice, viewModel, nameof(AddPumpViewModel.NewPumpPrice));
-            mandatorySource.DataSource = viewModel.SelectedMandatoryParts;
-            nonMandatorySource.DataSource = viewModel.SelectedNonMandatoryParts;
-            CommandBindings.Bind(btnAddPump, viewModel.SavePumpCommand);
-            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            viewModel.LoadDataCommand.Execute(null);
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            ViewModel.CurrentPump = ViewModel.PumpToChange ?? new Pump();
+            BindingHelpers.BindText(mtxtPumpName, ViewModel, nameof(AddPumpViewModel.PumpName));
+            BindingHelpers.BindText(mtxtPumpDescription, ViewModel, nameof(AddPumpViewModel.PumpDescription));
+            BindingHelpers.BindText(mtxtNewPumpPrice, ViewModel, nameof(AddPumpViewModel.NewPumpPrice));
+            mandatorySource.DataSource = ViewModel.SelectedMandatoryParts;
+            nonMandatorySource.DataSource = ViewModel.SelectedNonMandatoryParts;
+            CommandBindings.Bind(btnAddPump, ViewModel.SavePumpCommand);
+            CommandBindings.Bind(btnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
+            ViewModel.LoadDataCommand.Execute(null);
+            BindIsBusy(ViewModel);
         }
 
         // Input changes are tracked by the view model
 
         private async void FrmAddPump_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)viewModel.LoadDataCommand).ExecuteAsync(null);
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             SetupBindings();
 
-            if (viewModel.PumpToChange == null)
+            if (ViewModel.PumpToChange == null)
                 mtxtPumpName.Focus();
 
             dgvMandatoryPartView.RowsDefaultCellStyle.BackColor = Color.Bisque;
@@ -83,14 +81,14 @@ namespace QuoteSwift.Views
             clmNMPartQuantity.DataPropertyName = nameof(Pump_Part.PumpPartQuantity);
             dgvNonMandatoryPartView.DataSource = nonMandatorySource;
 
-            BindingHelpers.BindReadOnly(mtxtPumpName, viewModel, nameof(AddPumpViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(mtxtPumpDescription, viewModel, nameof(AddPumpViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(mtxtNewPumpPrice, viewModel, nameof(AddPumpViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(dgvMandatoryPartView, viewModel, nameof(AddPumpViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(dgvNonMandatoryPartView, viewModel, nameof(AddPumpViewModel.IsReadOnly));
-            BindingHelpers.BindEnabled(btnAddPump, viewModel, nameof(AddPumpViewModel.CanEdit));
-            BindingHelpers.BindVisible(btnAddPump, viewModel, nameof(AddPumpViewModel.ShowSaveButton));
-            btnAddPump.DataBindings.Add("Text", viewModel, nameof(AddPumpViewModel.SaveButtonText));
+            BindingHelpers.BindReadOnly(mtxtPumpName, ViewModel, nameof(AddPumpViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtPumpDescription, ViewModel, nameof(AddPumpViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(mtxtNewPumpPrice, ViewModel, nameof(AddPumpViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(dgvMandatoryPartView, ViewModel, nameof(AddPumpViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(dgvNonMandatoryPartView, ViewModel, nameof(AddPumpViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(btnAddPump, ViewModel, nameof(AddPumpViewModel.CanEdit));
+            BindingHelpers.BindVisible(btnAddPump, ViewModel, nameof(AddPumpViewModel.ShowSaveButton));
+            btnAddPump.DataBindings.Add("Text", ViewModel, nameof(AddPumpViewModel.SaveButtonText));
         }
 
 
@@ -101,8 +99,8 @@ namespace QuoteSwift.Views
 
         private void UpdatePumpToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!viewModel.ChangeSpecificObject)
-                viewModel.ChangeSpecificObject = true;
+            if (!ViewModel.ChangeSpecificObject)
+                ViewModel.ChangeSpecificObject = true;
             updatePumpToolStripMenuItem.Enabled = false;
         }
 
@@ -113,8 +111,8 @@ namespace QuoteSwift.Views
 
         protected override void OnClose()
         {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            if (ViewModel.ExitCommand.CanExecute(null))
+                ViewModel.ExitCommand.Execute(null);
         }
     }
 }

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -9,10 +9,9 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmCreateQuote : BaseForm
+    public partial class FrmCreateQuote : BaseForm<CreateQuoteViewModel>
     {
-        readonly CreateQuoteViewModel viewModel;
-        public CreateQuoteViewModel ViewModel => viewModel;
+        
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
         readonly Button btnCancelOperation;
@@ -23,15 +22,14 @@ namespace QuoteSwift.Views
 
 
         public FrmCreateQuote(CreateQuoteViewModel viewModel, IMessageService messageService = null, ISerializationService serializationService = null)
-            : base(messageService)
+            : base(viewModel, messageService)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
-            viewModel.CloseAction = Close;
+            ViewModel.CloseAction = Close;
             this.messageService = messageService;
             this.serializationService = serializationService;
             SetupBindings();
-            BindIsBusy(viewModel);
+            BindIsBusy(ViewModel);
 
             btnCancelOperation = new Button
             {
@@ -53,58 +51,58 @@ namespace QuoteSwift.Views
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
+            if (ViewModel.CancelCommand.CanExecute(null))
+                ViewModel.CancelCommand.Execute(null);
         }
 
         private void BtnCancelOperation_Click(object sender, EventArgs e)
         {
-            ((AsyncRelayCommand)viewModel.ExportQuoteCommand).Cancel();
+            ((AsyncRelayCommand)ViewModel.ExportQuoteCommand).Cancel();
         }
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            if (ViewModel.ExitCommand.CanExecute(null))
+                ViewModel.ExitCommand.Execute(null);
         }
 
 
         private async void FrmCreateQuote_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)viewModel.LoadDataCommand).ExecuteAsync(null);
-            viewModel.QuoteToChange = quoteToChange;
-            viewModel.ChangeSpecificObject = changeSpecificObject;
-            if (viewModel.IsViewing)
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
+            ViewModel.QuoteToChange = quoteToChange;
+            ViewModel.ChangeSpecificObject = changeSpecificObject;
+            if (ViewModel.IsViewing)
             {
-                viewModel.LoadPassedQuoteCommand.Execute(null);
+                ViewModel.LoadPassedQuoteCommand.Execute(null);
             }
-            else if (viewModel.IsEditing && viewModel.QuoteToChange != null)
+            else if (ViewModel.IsEditing && ViewModel.QuoteToChange != null)
             {
-                viewModel.LoadPassedQuoteCommand.Execute(null);
+                ViewModel.LoadPassedQuoteCommand.Execute(null);
 
-                viewModel.QuoteCreationDate = DateTime.Today;
-                viewModel.QuoteExpiryDate = viewModel.QuoteCreationDate.AddMonths(2);
-                viewModel.PaymentTerm = viewModel.QuoteCreationDate.AddMonths(1);
-                viewModel.PaymentTerm = DateTime.Today;
+                ViewModel.QuoteCreationDate = DateTime.Today;
+                ViewModel.QuoteExpiryDate = ViewModel.QuoteCreationDate.AddMonths(2);
+                ViewModel.PaymentTerm = ViewModel.QuoteCreationDate.AddMonths(1);
+                ViewModel.PaymentTerm = DateTime.Today;
 
-                Text = Text.Replace("<< Business Name >>", viewModel.SelectedBusiness.BusinessName);
+                Text = Text.Replace("<< Business Name >>", ViewModel.SelectedBusiness.BusinessName);
 
-                if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
-                    viewModel.QuoteNumber = viewModel.NextQuoteNumber;
+                if (!string.IsNullOrEmpty(ViewModel.NextQuoteNumber))
+                    ViewModel.QuoteNumber = ViewModel.NextQuoteNumber;
             }
             else //Create New
             {
-                viewModel.PrepareComboBoxLists();
-                viewModel.LoadPartlists();
-                if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
-                    viewModel.QuoteNumber = viewModel.NextQuoteNumber;
+                ViewModel.PrepareComboBoxLists();
+                ViewModel.LoadPartlists();
+                if (!string.IsNullOrEmpty(ViewModel.NextQuoteNumber))
+                    ViewModel.QuoteNumber = ViewModel.NextQuoteNumber;
 
-                viewModel.QuoteCreationDate = DateTime.Today;
-                viewModel.QuoteExpiryDate = viewModel.QuoteCreationDate.AddMonths(2);
-                viewModel.PaymentTerm = viewModel.QuoteCreationDate.AddMonths(1);
+                ViewModel.QuoteCreationDate = DateTime.Today;
+                ViewModel.QuoteExpiryDate = ViewModel.QuoteCreationDate.AddMonths(2);
+                ViewModel.PaymentTerm = ViewModel.QuoteCreationDate.AddMonths(1);
 
-                Text = Text.Replace("<< Business Name >>", viewModel.SelectedBusiness.BusinessName);
-                if (viewModel.QuoteMap == null || viewModel.QuoteMap.Count == 0)
+                Text = Text.Replace("<< Business Name >>", ViewModel.SelectedBusiness.BusinessName);
+                if (ViewModel.QuoteMap == null || ViewModel.QuoteMap.Count == 0)
                 {
                     cbxUseAutomaticNumberingScheme.Checked = false;
                     cbxUseAutomaticNumberingScheme.Enabled = false;
@@ -121,12 +119,12 @@ namespace QuoteSwift.Views
         }
         private void DgvMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
         {
-            viewModel.Calculate();
+            ViewModel.Calculate();
         }
 
         private void DgvNonMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
         {
-            viewModel.Calculate();
+            ViewModel.Calculate();
         }
 
 
@@ -148,7 +146,7 @@ namespace QuoteSwift.Views
             clmUnitPrice.DataPropertyName = nameof(Quote_Part.UnitPrice);
             clmTotal.DataPropertyName = nameof(Quote_Part.Price);
             ClmRepairDevider.DataPropertyName = nameof(Quote_Part.RepairDevider);
-            BindingHelpers.BindDataGridView(dgvMandatoryPartReplacement, viewModel, nameof(CreateQuoteViewModel.MandatoryParts));
+            BindingHelpers.BindDataGridView(dgvMandatoryPartReplacement, ViewModel, nameof(CreateQuoteViewModel.MandatoryParts));
 
             DgvNonMandatoryPartReplacement.AutoGenerateColumns = false;
             dataGridViewTextBoxColumn1.DataPropertyName = "PumpPart.PumpPart.NewPartNumber";
@@ -161,78 +159,78 @@ namespace QuoteSwift.Views
             ClmNMUnitPrice.DataPropertyName = nameof(Quote_Part.UnitPrice);
             dataGridViewTextBoxColumn9.DataPropertyName = nameof(Quote_Part.Price);
             ClmNMRepairDevider.DataPropertyName = nameof(Quote_Part.RepairDevider);
-            BindingHelpers.BindDataGridView(DgvNonMandatoryPartReplacement, viewModel, nameof(CreateQuoteViewModel.NonMandatoryParts));
+            BindingHelpers.BindDataGridView(DgvNonMandatoryPartReplacement, ViewModel, nameof(CreateQuoteViewModel.NonMandatoryParts));
 
-            BindingHelpers.BindComboBox(cbxBusinessSelection, viewModel, nameof(CreateQuoteViewModel.Businesses), nameof(CreateQuoteViewModel.SelectedBusiness), "BusinessName", "BusinessName");
+            BindingHelpers.BindComboBox(cbxBusinessSelection, ViewModel, nameof(CreateQuoteViewModel.Businesses), nameof(CreateQuoteViewModel.SelectedBusiness), "BusinessName", "BusinessName");
 
-            BindingHelpers.BindComboBox(cbxPumpSelection, viewModel, nameof(CreateQuoteViewModel.Pumps), nameof(CreateQuoteViewModel.SelectedPump), "PumpName", "PumpName");
+            BindingHelpers.BindComboBox(cbxPumpSelection, ViewModel, nameof(CreateQuoteViewModel.Pumps), nameof(CreateQuoteViewModel.SelectedPump), "PumpName", "PumpName");
 
-            BindingHelpers.BindComboBox(cbxBusinessTelephoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessTelephoneNumbers), null);
-            BindingHelpers.BindComboBox(cbxBusinessCellphoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessCellphoneNumbers), null);
-            BindingHelpers.BindComboBox(cbxBusinessEmailAddressSelection, viewModel, nameof(CreateQuoteViewModel.BusinessEmailAddresses), null);
+            BindingHelpers.BindComboBox(cbxBusinessTelephoneNumberSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessTelephoneNumbers), null);
+            BindingHelpers.BindComboBox(cbxBusinessCellphoneNumberSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessCellphoneNumbers), null);
+            BindingHelpers.BindComboBox(cbxBusinessEmailAddressSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessEmailAddresses), null);
 
-            BindingHelpers.BindComboBox(cbxCustomerSelection, viewModel, nameof(CreateQuoteViewModel.Customers), nameof(CreateQuoteViewModel.SelectedCustomer), "CustomerCompanyName", "CustomerCompanyName");
+            BindingHelpers.BindComboBox(cbxCustomerSelection, ViewModel, nameof(CreateQuoteViewModel.Customers), nameof(CreateQuoteViewModel.SelectedCustomer), "CustomerCompanyName", "CustomerCompanyName");
 
-            BindingHelpers.BindComboBox(cbxCustomerDeliveryAddress, viewModel, nameof(CreateQuoteViewModel.CustomerDeliveryAddresses), nameof(CreateQuoteViewModel.SelectedCustomerDeliveryAddress), "AddressDescription", "AddressDescription");
+            BindingHelpers.BindComboBox(cbxCustomerDeliveryAddress, ViewModel, nameof(CreateQuoteViewModel.CustomerDeliveryAddresses), nameof(CreateQuoteViewModel.SelectedCustomerDeliveryAddress), "AddressDescription", "AddressDescription");
 
-            BindingHelpers.BindComboBox(CbxPOBoxSelection, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxes), nameof(CreateQuoteViewModel.SelectedBusinessPOBox), "AddressDescription", "AddressDescription");
+            BindingHelpers.BindComboBox(CbxPOBoxSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessPOBoxes), nameof(CreateQuoteViewModel.SelectedBusinessPOBox), "AddressDescription", "AddressDescription");
 
-            BindingHelpers.BindComboBox(CbxCustomerPOBoxSelection, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxes), nameof(CreateQuoteViewModel.SelectedCustomerPOBox), "AddressDescription", "AddressDescription");
+            BindingHelpers.BindComboBox(CbxCustomerPOBoxSelection, ViewModel, nameof(CreateQuoteViewModel.CustomerPOBoxes), nameof(CreateQuoteViewModel.SelectedCustomerPOBox), "AddressDescription", "AddressDescription");
 
-            BindingHelpers.BindText(txtCustomerVATNumber, viewModel, nameof(CreateQuoteViewModel.CustomerVATNumber));
-            BindingHelpers.BindText(txtJobNumber, viewModel, nameof(CreateQuoteViewModel.JobNumber));
-            BindingHelpers.BindText(txtReferenceNumber, viewModel, nameof(CreateQuoteViewModel.ReferenceNumber));
-            BindingHelpers.BindText(txtPRNumber, viewModel, nameof(CreateQuoteViewModel.PRNumber));
-            BindingHelpers.BindText(txtLineNumber, viewModel, nameof(CreateQuoteViewModel.LineNumber));
-            BindingHelpers.BindText(txtQuoteNumber, viewModel, nameof(CreateQuoteViewModel.QuoteNumber));
+            BindingHelpers.BindText(txtCustomerVATNumber, ViewModel, nameof(CreateQuoteViewModel.CustomerVATNumber));
+            BindingHelpers.BindText(txtJobNumber, ViewModel, nameof(CreateQuoteViewModel.JobNumber));
+            BindingHelpers.BindText(txtReferenceNumber, ViewModel, nameof(CreateQuoteViewModel.ReferenceNumber));
+            BindingHelpers.BindText(txtPRNumber, ViewModel, nameof(CreateQuoteViewModel.PRNumber));
+            BindingHelpers.BindText(txtLineNumber, ViewModel, nameof(CreateQuoteViewModel.LineNumber));
+            BindingHelpers.BindText(txtQuoteNumber, ViewModel, nameof(CreateQuoteViewModel.QuoteNumber));
 
-            BindingHelpers.BindText(rtxCustomerDeliveryDescripton, viewModel, nameof(CreateQuoteViewModel.CustomerDeliveryDescription));
-            BindingHelpers.BindValue(dtpQuoteCreationDate, viewModel, nameof(CreateQuoteViewModel.QuoteCreationDate));
-            BindingHelpers.BindValue(dtpQuoteExpiryDate, viewModel, nameof(CreateQuoteViewModel.QuoteExpiryDate));
-            BindingHelpers.BindValue(dtpPaymentTerm, viewModel, nameof(CreateQuoteViewModel.PaymentTerm));
-            mtxtRebate.DataBindings.Add("Value", viewModel, nameof(CreateQuoteViewModel.RebateInput), false, DataSourceUpdateMode.OnPropertyChanged);
+            BindingHelpers.BindText(rtxCustomerDeliveryDescripton, ViewModel, nameof(CreateQuoteViewModel.CustomerDeliveryDescription));
+            BindingHelpers.BindValue(dtpQuoteCreationDate, ViewModel, nameof(CreateQuoteViewModel.QuoteCreationDate));
+            BindingHelpers.BindValue(dtpQuoteExpiryDate, ViewModel, nameof(CreateQuoteViewModel.QuoteExpiryDate));
+            BindingHelpers.BindValue(dtpPaymentTerm, ViewModel, nameof(CreateQuoteViewModel.PaymentTerm));
+            mtxtRebate.DataBindings.Add("Value", ViewModel, nameof(CreateQuoteViewModel.RebateInput), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            BindingHelpers.BindText(cbxBusinessTelephoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessTelephone));
-            BindingHelpers.BindText(cbxBusinessCellphoneNumberSelection, viewModel, nameof(CreateQuoteViewModel.BusinessCellphone));
-            BindingHelpers.BindText(cbxBusinessEmailAddressSelection, viewModel, nameof(CreateQuoteViewModel.BusinessEmail));
+            BindingHelpers.BindText(cbxBusinessTelephoneNumberSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessTelephone));
+            BindingHelpers.BindText(cbxBusinessCellphoneNumberSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessCellphone));
+            BindingHelpers.BindText(cbxBusinessEmailAddressSelection, ViewModel, nameof(CreateQuoteViewModel.BusinessEmail));
 
-            BindingHelpers.BindText(lblBusinessPOBoxNumber, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxNumberDisplay));
-            BindingHelpers.BindText(lblBusinessPOBoxSuburb, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxSuburbDisplay));
-            BindingHelpers.BindText(lblBusinessPOBoxCity, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxCityDisplay));
-            BindingHelpers.BindText(lblBusinessPOBoxAreaCode, viewModel, nameof(CreateQuoteViewModel.BusinessPOBoxAreaCodeDisplay));
-            BindingHelpers.BindText(lblBusinessRegistrationNumber, viewModel, nameof(CreateQuoteViewModel.BusinessRegistrationNumberDisplay));
-            BindingHelpers.BindText(lblBusinessVATNumber, viewModel, nameof(CreateQuoteViewModel.BusinessVATNumberDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxNumber, ViewModel, nameof(CreateQuoteViewModel.BusinessPOBoxNumberDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxSuburb, ViewModel, nameof(CreateQuoteViewModel.BusinessPOBoxSuburbDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxCity, ViewModel, nameof(CreateQuoteViewModel.BusinessPOBoxCityDisplay));
+            BindingHelpers.BindText(lblBusinessPOBoxAreaCode, ViewModel, nameof(CreateQuoteViewModel.BusinessPOBoxAreaCodeDisplay));
+            BindingHelpers.BindText(lblBusinessRegistrationNumber, ViewModel, nameof(CreateQuoteViewModel.BusinessRegistrationNumberDisplay));
+            BindingHelpers.BindText(lblBusinessVATNumber, ViewModel, nameof(CreateQuoteViewModel.BusinessVATNumberDisplay));
 
-            BindingHelpers.BindText(lblCustomerPOBoxStreetName, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxStreetNameDisplay));
-            BindingHelpers.BindText(lblCustomerPOBoxSuburb, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxSuburbDisplay));
-            BindingHelpers.BindText(lblCustomerPOBoxCity, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxCityDisplay));
-            BindingHelpers.BindText(lblCustomerPOBoxAreaCode, viewModel, nameof(CreateQuoteViewModel.CustomerPOBoxAreaCodeDisplay));
-            BindingHelpers.BindText(lblCustomerVendorNumber, viewModel, nameof(CreateQuoteViewModel.CustomerVendorNumberDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxStreetName, ViewModel, nameof(CreateQuoteViewModel.CustomerPOBoxStreetNameDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxSuburb, ViewModel, nameof(CreateQuoteViewModel.CustomerPOBoxSuburbDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxCity, ViewModel, nameof(CreateQuoteViewModel.CustomerPOBoxCityDisplay));
+            BindingHelpers.BindText(lblCustomerPOBoxAreaCode, ViewModel, nameof(CreateQuoteViewModel.CustomerPOBoxAreaCodeDisplay));
+            BindingHelpers.BindText(lblCustomerVendorNumber, ViewModel, nameof(CreateQuoteViewModel.CustomerVendorNumberDisplay));
 
-            BindingHelpers.BindText(lblNewPumpUnitPrice, viewModel, nameof(CreateQuoteViewModel.PumpPriceDisplay));
-            BindingHelpers.BindText(lblRebateValue, viewModel, nameof(CreateQuoteViewModel.RebateDisplay));
-            BindingHelpers.BindText(lblSubTotalValue, viewModel, nameof(CreateQuoteViewModel.SubTotalDisplay));
-            BindingHelpers.BindText(lblVATValue, viewModel, nameof(CreateQuoteViewModel.VATDisplay));
-            BindingHelpers.BindText(lblTotalDueValue, viewModel, nameof(CreateQuoteViewModel.TotalDueDisplay));
-            BindingHelpers.BindText(lblRepairPercentage, viewModel, nameof(CreateQuoteViewModel.RepairPercentageDisplay));
+            BindingHelpers.BindText(lblNewPumpUnitPrice, ViewModel, nameof(CreateQuoteViewModel.PumpPriceDisplay));
+            BindingHelpers.BindText(lblRebateValue, ViewModel, nameof(CreateQuoteViewModel.RebateDisplay));
+            BindingHelpers.BindText(lblSubTotalValue, ViewModel, nameof(CreateQuoteViewModel.SubTotalDisplay));
+            BindingHelpers.BindText(lblVATValue, ViewModel, nameof(CreateQuoteViewModel.VATDisplay));
+            BindingHelpers.BindText(lblTotalDueValue, ViewModel, nameof(CreateQuoteViewModel.TotalDueDisplay));
+            BindingHelpers.BindText(lblRepairPercentage, ViewModel, nameof(CreateQuoteViewModel.RepairPercentageDisplay));
 
-            gbxBusinessInformation.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
-            gbxBusinessPOBoxDetails.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
-            gbxQuoteNumberManagement.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
-            gbxCustomerDeliveryAddressInformation.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
-            gbxPumpRestorationDetails.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsEditing));
-            BindingHelpers.BindReadOnly(dgvMandatoryPartReplacement, viewModel, nameof(CreateQuoteViewModel.IsReadOnly));
-            BindingHelpers.BindReadOnly(DgvNonMandatoryPartReplacement, viewModel, nameof(CreateQuoteViewModel.IsReadOnly));
-            BindingHelpers.BindEnabled(cbxPumpSelection, viewModel, nameof(CreateQuoteViewModel.IsEditing));
-            BindingHelpers.BindVisible(btnComplete, viewModel, nameof(CreateQuoteViewModel.ShowSaveButton));
-            btnComplete.DataBindings.Add("Text", viewModel, nameof(CreateQuoteViewModel.SaveButtonText));
-            CommandBindings.Bind(btnComplete, viewModel.CompleteQuoteCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            CommandBindings.Bind(BtnCalculateRebate, viewModel.CalculateRebateCommand);
-            CommandBindings.Bind(dtpQuoteCreationDate, viewModel.UpdateDatesCommand);
-            CommandBindings.Bind(dtpQuoteExpiryDate, viewModel.UpdateDatesCommand);
+            gbxBusinessInformation.DataBindings.Add("Enabled", ViewModel, nameof(CreateQuoteViewModel.IsEditing));
+            gbxBusinessPOBoxDetails.DataBindings.Add("Enabled", ViewModel, nameof(CreateQuoteViewModel.IsEditing));
+            gbxQuoteNumberManagement.DataBindings.Add("Enabled", ViewModel, nameof(CreateQuoteViewModel.IsEditing));
+            gbxCustomerDeliveryAddressInformation.DataBindings.Add("Enabled", ViewModel, nameof(CreateQuoteViewModel.IsEditing));
+            gbxPumpRestorationDetails.DataBindings.Add("Enabled", ViewModel, nameof(CreateQuoteViewModel.IsEditing));
+            BindingHelpers.BindReadOnly(dgvMandatoryPartReplacement, ViewModel, nameof(CreateQuoteViewModel.IsReadOnly));
+            BindingHelpers.BindReadOnly(DgvNonMandatoryPartReplacement, ViewModel, nameof(CreateQuoteViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(cbxPumpSelection, ViewModel, nameof(CreateQuoteViewModel.IsEditing));
+            BindingHelpers.BindVisible(btnComplete, ViewModel, nameof(CreateQuoteViewModel.ShowSaveButton));
+            btnComplete.DataBindings.Add("Text", ViewModel, nameof(CreateQuoteViewModel.SaveButtonText));
+            CommandBindings.Bind(btnComplete, ViewModel.CompleteQuoteCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
+            CommandBindings.Bind(BtnCalculateRebate, ViewModel.CalculateRebateCommand);
+            CommandBindings.Bind(dtpQuoteCreationDate, ViewModel.UpdateDatesCommand);
+            CommandBindings.Bind(dtpQuoteExpiryDate, ViewModel.UpdateDatesCommand);
 
-            createNewQuoteUsingThisQuoteToolStripMenuItem.DataBindings.Add("Enabled", viewModel, nameof(CreateQuoteViewModel.IsViewing));
+            createNewQuoteUsingThisQuoteToolStripMenuItem.DataBindings.Add("Enabled", ViewModel, nameof(CreateQuoteViewModel.IsViewing));
         }
 
         private void CbxUseAutomaticNumberingScheme_CheckedChanged(object sender, EventArgs e)
@@ -240,8 +238,8 @@ namespace QuoteSwift.Views
             if (cbxUseAutomaticNumberingScheme.Checked)
             {
                 txtQuoteNumber.ReadOnly = true;
-                if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
-                    viewModel.QuoteNumber = viewModel.NextQuoteNumber;
+                if (!string.IsNullOrEmpty(ViewModel.NextQuoteNumber))
+                    ViewModel.QuoteNumber = ViewModel.NextQuoteNumber;
             }
             else
             {
@@ -252,7 +250,7 @@ namespace QuoteSwift.Views
 
         private async System.Threading.Tasks.Task ExportQuoteToTemplateAsync(Quote q)
         {
-            await ((AsyncRelayCommand)viewModel.ExportQuoteCommand).ExecuteAsync(q);
+            await ((AsyncRelayCommand)ViewModel.ExportQuoteCommand).ExecuteAsync(q);
         }
 
         // View-model bindings manage read-only state
@@ -261,10 +259,10 @@ namespace QuoteSwift.Views
         private void CreateNewQuoteUsingThisQuoteToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (quoteToChange == null) quoteToChange = NewQuote;
-            viewModel.QuoteToChange = quoteToChange;
-            viewModel.ChangeSpecificObject = true;
-            if (!string.IsNullOrEmpty(viewModel.NextQuoteNumber))
-                viewModel.QuoteNumber = viewModel.NextQuoteNumber;
+            ViewModel.QuoteToChange = quoteToChange;
+            ViewModel.ChangeSpecificObject = true;
+            if (!string.IsNullOrEmpty(ViewModel.NextQuoteNumber))
+                ViewModel.QuoteNumber = ViewModel.NextQuoteNumber;
         }
 
         private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
@@ -274,8 +272,8 @@ namespace QuoteSwift.Views
 
         protected override void OnClose()
         {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            if (ViewModel.ExitCommand.CanExecute(null))
+                ViewModel.ExitCommand.Execute(null);
         }
 
 }

--- a/Views/FrmEditBusinessAddress.cs
+++ b/Views/FrmEditBusinessAddress.cs
@@ -3,42 +3,39 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmEditBusinessAddress : BaseForm
+    public partial class FrmEditBusinessAddress : BaseForm<EditBusinessAddressViewModel>
     {
         readonly IMessageService messageService;
         readonly INavigationService navigation;
-        readonly EditBusinessAddressViewModel viewModel;
-        public EditBusinessAddressViewModel ViewModel => viewModel;
 
         public FrmEditBusinessAddress(EditBusinessAddressViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.messageService = messageService;
             this.navigation = navigation;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
         }
 
         void SetupBindings()
         {
-            txtBusinessAddresssDescription.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.AddressDescription), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtStreetnumber.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.StreetNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtStreetName.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.StreetName), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtSuburb.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.Suburb), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtCity.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.City), false, DataSourceUpdateMode.OnPropertyChanged);
-            mtxtAreaCode.DataBindings.Add("Text", viewModel, nameof(EditBusinessAddressViewModel.AreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtBusinessAddresssDescription.DataBindings.Add("Text", ViewModel, nameof(EditBusinessAddressViewModel.AddressDescription), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtStreetnumber.DataBindings.Add("Text", ViewModel, nameof(EditBusinessAddressViewModel.StreetNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtStreetName.DataBindings.Add("Text", ViewModel, nameof(EditBusinessAddressViewModel.StreetName), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtSuburb.DataBindings.Add("Text", ViewModel, nameof(EditBusinessAddressViewModel.Suburb), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtCity.DataBindings.Add("Text", ViewModel, nameof(EditBusinessAddressViewModel.City), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtAreaCode.DataBindings.Add("Text", ViewModel, nameof(EditBusinessAddressViewModel.AreaCode), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            CommandBindings.Bind(BtnUpdateAddress, viewModel.SaveCommand);
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(BtnUpdateAddress, ViewModel.SaveCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         private void FrmEditBusinessAddress_Load(object sender, EventArgs e)
         {
-            if (viewModel.Address != null)
+            if (ViewModel.Address != null)
             {
                 txtStreetName.Enabled = false;
             }

--- a/Views/FrmEditEmailAddress.cs
+++ b/Views/FrmEditEmailAddress.cs
@@ -3,36 +3,33 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmEditEmailAddress : BaseForm
+    public partial class FrmEditEmailAddress : BaseForm<EditEmailAddressViewModel>
     {
 
         readonly IMessageService messageService;
         readonly INavigationService navigation;
-        readonly EditEmailAddressViewModel viewModel;
-        public EditEmailAddressViewModel ViewModel => viewModel;
 
         public FrmEditEmailAddress(EditEmailAddressViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.messageService = messageService;
             this.navigation = navigation;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
-            CommandBindings.Bind(btnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(btnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         void SetupBindings()
         {
-            mtxtEmail.DataBindings.Add("Text", viewModel, nameof(EditEmailAddressViewModel.CurrentEmail), false, DataSourceUpdateMode.OnPropertyChanged);
+            mtxtEmail.DataBindings.Add("Text", ViewModel, nameof(EditEmailAddressViewModel.CurrentEmail), false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
         private void BtnUpdateBusinessEmail_Click(object sender, EventArgs e)
         {
-            viewModel.SaveCommand.Execute(null);
+            ViewModel.SaveCommand.Execute(null);
         }
 
         private void FrmEditEmailAddress_Load(object sender, EventArgs e)

--- a/Views/FrmEditPhoneNumber.cs
+++ b/Views/FrmEditPhoneNumber.cs
@@ -3,31 +3,28 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmEditPhoneNumber : BaseForm
+    public partial class FrmEditPhoneNumber : BaseForm<EditPhoneNumberViewModel>
     {
 
         readonly IMessageService messageService;
         readonly INavigationService navigation;
-        readonly EditPhoneNumberViewModel viewModel;
-        public EditPhoneNumberViewModel ViewModel => viewModel;
 
         public FrmEditPhoneNumber(EditPhoneNumberViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.messageService = messageService;
             this.navigation = navigation;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         void SetupBindings()
         {
-            txtPhoneNumber.DataBindings.Add("Text", viewModel, nameof(EditPhoneNumberViewModel.CurrentNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtPhoneNumber.DataBindings.Add("Text", ViewModel, nameof(EditPhoneNumberViewModel.CurrentNumber), false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
         private void FrmEditPhoneNumber_Load(object sender, EventArgs e)
@@ -36,8 +33,8 @@ namespace QuoteSwift.Views
 
         private void BtnUpdateNumber_Click(object sender, EventArgs e)
         {
-            if (viewModel.UpdateNumberAndCloseCommand.CanExecute(null))
-                viewModel.UpdateNumberAndCloseCommand.Execute(null);
+            if (ViewModel.UpdateNumberAndCloseCommand.CanExecute(null))
+                ViewModel.UpdateNumberAndCloseCommand.Execute(null);
         }
 
         // CommandBindings handle Cancel and Exit actions

--- a/Views/FrmManageAllEmails.cs
+++ b/Views/FrmManageAllEmails.cs
@@ -4,51 +4,48 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmManageAllEmails : BaseForm
+    public partial class FrmManageAllEmails : BaseForm<ManageEmailsViewModel>
     {
 
-        readonly ManageEmailsViewModel viewModel;
-        public ManageEmailsViewModel ViewModel => viewModel;
         readonly IMessageService messageService;
         readonly INavigationService navigation;
 
         public FrmManageAllEmails(ManageEmailsViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
         }
 
         void SetupBindings()
         {
-            DgvEmails.DataSource = viewModel.Emails;
-            SelectionBindings.BindSelectedItem(DgvEmails, viewModel, nameof(ManageEmailsViewModel.SelectedEmail));
+            DgvEmails.DataSource = ViewModel.Emails;
+            SelectionBindings.BindSelectedItem(DgvEmails, ViewModel, nameof(ManageEmailsViewModel.SelectedEmail));
 
-            txtNewEmail.DataBindings.Add("Text", viewModel, nameof(ManageEmailsViewModel.NewEmail), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtNewEmail.DataBindings.Add("Text", ViewModel, nameof(ManageEmailsViewModel.NewEmail), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            CommandBindings.Bind(btnAddEmail, viewModel.AddEmailCommand);
-            CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedEmailCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(BtnChangeAddressInfo, viewModel.EditSelectedEmailCommand);
+            CommandBindings.Bind(btnAddEmail, ViewModel.AddEmailCommand);
+            CommandBindings.Bind(btnRemoveAddress, ViewModel.RemoveSelectedEmailCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(BtnChangeAddressInfo, ViewModel.EditSelectedEmailCommand);
         }
 
         private void FrmManageAllEmails_Load(object sender, EventArgs e)
         {
-            if (viewModel.Business != null && viewModel.Business.BusinessEmailAddressList != null)
+            if (ViewModel.Business != null && ViewModel.Business.BusinessEmailAddressList != null)
             {
-                Text = Text.Replace("< Business Name >", viewModel.Business.BusinessName);
+                Text = Text.Replace("< Business Name >", ViewModel.Business.BusinessName);
 
                 // components remain editable
             }
-            else if (viewModel.Customer != null && viewModel.Customer.CustomerEmailList != null)
+            else if (ViewModel.Customer != null && ViewModel.Customer.CustomerEmailList != null)
             {
-                Text = Text.Replace("< Business Name >", viewModel.Customer.CustomerName);
+                Text = Text.Replace("< Business Name >", ViewModel.Customer.CustomerName);
 
                 // components remain editable
             }

--- a/Views/FrmManagingPhoneNumbers.cs
+++ b/Views/FrmManagingPhoneNumbers.cs
@@ -4,61 +4,58 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmManagingPhoneNumbers : BaseForm
+    public partial class FrmManagingPhoneNumbers : BaseForm<ManagePhoneNumbersViewModel>
     {
 
-        readonly ManagePhoneNumbersViewModel viewModel;
-        public ManagePhoneNumbersViewModel ViewModel => viewModel;
         readonly IMessageService messageService;
         readonly INavigationService navigation;
 
         public FrmManagingPhoneNumbers(ManagePhoneNumbersViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
         }
 
         void SetupBindings()
         {
-            dgvTelephoneNumbers.DataSource = viewModel.TelephoneNumbers;
-            SelectionBindings.BindSelectedItem(dgvTelephoneNumbers, viewModel, nameof(ManagePhoneNumbersViewModel.SelectedTelephoneNumber));
+            dgvTelephoneNumbers.DataSource = ViewModel.TelephoneNumbers;
+            SelectionBindings.BindSelectedItem(dgvTelephoneNumbers, ViewModel, nameof(ManagePhoneNumbersViewModel.SelectedTelephoneNumber));
 
-            dgvCellphoneNumbers.DataSource = viewModel.CellphoneNumbers;
-            SelectionBindings.BindSelectedItem(dgvCellphoneNumbers, viewModel, nameof(ManagePhoneNumbersViewModel.SelectedCellphoneNumber));
+            dgvCellphoneNumbers.DataSource = ViewModel.CellphoneNumbers;
+            SelectionBindings.BindSelectedItem(dgvCellphoneNumbers, ViewModel, nameof(ManagePhoneNumbersViewModel.SelectedCellphoneNumber));
 
-            txtNewTelephone.DataBindings.Add("Text", viewModel, nameof(ManagePhoneNumbersViewModel.NewTelephoneNumber), false, DataSourceUpdateMode.OnPropertyChanged);
-            txtNewCellphone.DataBindings.Add("Text", viewModel, nameof(ManagePhoneNumbersViewModel.NewCellphoneNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtNewTelephone.DataBindings.Add("Text", ViewModel, nameof(ManagePhoneNumbersViewModel.NewTelephoneNumber), false, DataSourceUpdateMode.OnPropertyChanged);
+            txtNewCellphone.DataBindings.Add("Text", ViewModel, nameof(ManagePhoneNumbersViewModel.NewCellphoneNumber), false, DataSourceUpdateMode.OnPropertyChanged);
 
-            CommandBindings.Bind(btnAddTelephone, viewModel.AddTelephoneCommand);
-            CommandBindings.Bind(btnAddCellphone, viewModel.AddCellphoneCommand);
+            CommandBindings.Bind(btnAddTelephone, ViewModel.AddTelephoneCommand);
+            CommandBindings.Bind(btnAddCellphone, ViewModel.AddCellphoneCommand);
 
-            CommandBindings.Bind(btnRemoveTelNumber, viewModel.RemoveSelectedTelephoneCommand);
-            CommandBindings.Bind(btnRemoveCellNumber, viewModel.RemoveSelectedCellphoneCommand);
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(BtnUpdateTelephoneNumber, viewModel.EditTelephoneCommand);
-            CommandBindings.Bind(BtnUpdateCellphoneNumber, viewModel.EditCellphoneCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(btnRemoveTelNumber, ViewModel.RemoveSelectedTelephoneCommand);
+            CommandBindings.Bind(btnRemoveCellNumber, ViewModel.RemoveSelectedCellphoneCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(BtnUpdateTelephoneNumber, ViewModel.EditTelephoneCommand);
+            CommandBindings.Bind(BtnUpdateCellphoneNumber, ViewModel.EditCellphoneCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
 
 
         private void FrmManagingPhoneNumbers_Load(object sender, EventArgs e)
         {
-            if (viewModel.Business != null && (viewModel.Business.BusinessTelephoneNumberList != null || viewModel.Business.BusinessCellphoneNumberList != null))
+            if (ViewModel.Business != null && (ViewModel.Business.BusinessTelephoneNumberList != null || ViewModel.Business.BusinessCellphoneNumberList != null))
             {
-                Text = Text.Replace("< Business Name >", viewModel.Business.BusinessName);
+                Text = Text.Replace("< Business Name >", ViewModel.Business.BusinessName);
 
                 // components remain editable
             }
-            else if (viewModel.Customer != null && (viewModel.Customer.CustomerCellphoneNumberList != null || viewModel.Customer.CustomerTelephoneNumberList != null))
+            else if (ViewModel.Customer != null && (ViewModel.Customer.CustomerCellphoneNumberList != null || ViewModel.Customer.CustomerTelephoneNumberList != null))
             {
-                Text = Text.Replace("< Business Name >", viewModel.Customer.CustomerName);
+                Text = Text.Replace("< Business Name >", ViewModel.Customer.CustomerName);
 
                 // components remain editable
             }

--- a/Views/FrmViewAllBusinesses.cs
+++ b/Views/FrmViewAllBusinesses.cs
@@ -5,37 +5,34 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmViewAllBusinesses : BaseForm
+    public partial class FrmViewAllBusinesses : BaseForm<ViewBusinessesViewModel>
     {
 
-        readonly ViewBusinessesViewModel viewModel;
-        public ViewBusinessesViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly BindingSource businessBindingSource = new BindingSource();
 
         public FrmViewAllBusinesses(ViewBusinessesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         void SetupBindings()
         {
-            businessBindingSource.DataSource = viewModel;
+            businessBindingSource.DataSource = ViewModel;
             businessBindingSource.DataMember = nameof(ViewBusinessesViewModel.Businesses);
             DgvBusinessList.DataSource = businessBindingSource;
-            SelectionBindings.BindSelectedItem(DgvBusinessList, viewModel, nameof(ViewBusinessesViewModel.SelectedBusiness));
-            CommandBindings.Bind(btnUpdateBusiness, viewModel.UpdateBusinessCommand);
-            CommandBindings.Bind(btnAddBusiness, viewModel.AddBusinessCommand);
+            SelectionBindings.BindSelectedItem(DgvBusinessList, ViewModel, nameof(ViewBusinessesViewModel.SelectedBusiness));
+            CommandBindings.Bind(btnUpdateBusiness, ViewModel.UpdateBusinessCommand);
+            CommandBindings.Bind(btnAddBusiness, ViewModel.AddBusinessCommand);
         }
 
         // CommandBindings handle Exit action
@@ -48,8 +45,8 @@ namespace QuoteSwift.Views
 
         private void BtnRemoveSelected_Click(object sender, EventArgs e)
         {
-            if (viewModel.RemoveBusinessCommand.CanExecute(null))
-                viewModel.RemoveBusinessCommand.Execute(null);
+            if (ViewModel.RemoveBusinessCommand.CanExecute(null))
+                ViewModel.RemoveBusinessCommand.Execute(null);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/Views/FrmViewBusinessAddresses.cs
+++ b/Views/FrmViewBusinessAddresses.cs
@@ -4,39 +4,36 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmViewBusinessAddresses : BaseForm
+    public partial class FrmViewBusinessAddresses : BaseForm<ViewBusinessAddressesViewModel>
     {
 
-        readonly ViewBusinessAddressesViewModel viewModel;
         readonly INavigationService navigation;
         Business business;
         Customer customer;
-        public ViewBusinessAddressesViewModel ViewModel => viewModel;
 
         void SetupBindings()
         {
-            DgvViewAllBusinessAddresses.DataSource = viewModel.Addresses;
-            SelectionBindings.BindSelectedItem(DgvViewAllBusinessAddresses, viewModel,
+            DgvViewAllBusinessAddresses.DataSource = ViewModel.Addresses;
+            SelectionBindings.BindSelectedItem(DgvViewAllBusinessAddresses, ViewModel,
                 nameof(ViewBusinessAddressesViewModel.SelectedAddress));
 
-            BindingHelpers.BindReadOnly(DgvViewAllBusinessAddresses, viewModel, nameof(ViewBusinessAddressesViewModel.IsReadOnly));
-            BindingHelpers.BindEnabled(BtnRemoveSelected, viewModel, nameof(ViewBusinessAddressesViewModel.CanEdit));
-            BindingHelpers.BindEnabled(BtnChangeAddressInfo, viewModel, nameof(ViewBusinessAddressesViewModel.CanEdit));
+            BindingHelpers.BindReadOnly(DgvViewAllBusinessAddresses, ViewModel, nameof(ViewBusinessAddressesViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(BtnRemoveSelected, ViewModel, nameof(ViewBusinessAddressesViewModel.CanEdit));
+            BindingHelpers.BindEnabled(BtnChangeAddressInfo, ViewModel, nameof(ViewBusinessAddressesViewModel.CanEdit));
 
-            CommandBindings.Bind(BtnRemoveSelected, viewModel.RemoveSelectedAddressCommand);
-            CommandBindings.Bind(BtnChangeAddressInfo, viewModel.EditAddressCommand);
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(BtnRemoveSelected, ViewModel.RemoveSelectedAddressCommand);
+            CommandBindings.Bind(BtnChangeAddressInfo, ViewModel.EditAddressCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         public FrmViewBusinessAddresses(ViewBusinessAddressesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
         }
 
@@ -48,8 +45,8 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            if (ViewModel.ExitCommand.CanExecute(null))
+                ViewModel.ExitCommand.Execute(null);
         }
 
         private void FrmViewBusinessAddresses_Load(object sender, EventArgs e)
@@ -58,7 +55,7 @@ namespace QuoteSwift.Views
             {
                 Text = Text.Replace("<<Business name>>", business.BusinessName);
 
-                if (viewModel.IsReadOnly)
+                if (ViewModel.IsReadOnly)
                 {
                     BtnCancel.Enabled = true;
                 }
@@ -68,14 +65,14 @@ namespace QuoteSwift.Views
             {
                 Text = Text.Replace("<<Business name>>", customer.CustomerName);
 
-                if (viewModel.IsReadOnly)
+                if (ViewModel.IsReadOnly)
                 {
                     BtnCancel.Enabled = true;
                 }
 
             }
 
-            viewModel.UpdateData(business, customer);
+            ViewModel.UpdateData(business, customer);
 
             DgvViewAllBusinessAddresses.RowsDefaultCellStyle.BackColor = Color.Bisque;
             DgvViewAllBusinessAddresses.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
@@ -83,13 +80,13 @@ namespace QuoteSwift.Views
 
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
         {
-            viewModel.EditAddressCommand.Execute(null);
+            ViewModel.EditAddressCommand.Execute(null);
         }
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
+            if (ViewModel.CancelCommand.CanExecute(null))
+                ViewModel.CancelCommand.Execute(null);
         }
 
 

--- a/Views/FrmViewCustomers.cs
+++ b/Views/FrmViewCustomers.cs
@@ -4,36 +4,34 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmViewCustomers : BaseForm
+    public partial class FrmViewCustomers : BaseForm<ViewCustomersViewModel>
     {
-        readonly ViewCustomersViewModel viewModel;
-        public ViewCustomersViewModel ViewModel => viewModel;
+
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly BindingSource customersBindingSource = new BindingSource();
         public FrmViewCustomers(ViewCustomersViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
+            ViewModel.CloseAction = Close;
             SetupBindings();
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
-            BindIsBusy(viewModel);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
+            BindIsBusy(ViewModel);
         }
 
         void SetupBindings()
         {
-            customersBindingSource.DataSource = viewModel;
+            customersBindingSource.DataSource = ViewModel;
             customersBindingSource.DataMember = nameof(ViewCustomersViewModel.Customers);
             DgvCustomerList.DataSource = customersBindingSource;
-            SelectionBindings.BindSelectedItem(DgvCustomerList, viewModel, nameof(ViewCustomersViewModel.SelectedCustomer));
-            CommandBindings.Bind(btnUpdateSelectedCustomer, viewModel.UpdateCustomerCommand);
-            CommandBindings.Bind(btnAddCustomer, viewModel.AddCustomerCommand);
-            BindingHelpers.BindComboBox(cbBusinessSelection, viewModel,
+            SelectionBindings.BindSelectedItem(DgvCustomerList, ViewModel, nameof(ViewCustomersViewModel.SelectedCustomer));
+            CommandBindings.Bind(btnUpdateSelectedCustomer, ViewModel.UpdateCustomerCommand);
+            CommandBindings.Bind(btnAddCustomer, ViewModel.AddCustomerCommand);
+            BindingHelpers.BindComboBox(cbBusinessSelection, ViewModel,
                 nameof(ViewCustomersViewModel.Businesses), nameof(ViewCustomersViewModel.SelectedBusiness),
                 "BusinessName", "BusinessName");
         }
@@ -42,7 +40,7 @@ namespace QuoteSwift.Views
 
         private async void FrmViewCustomers_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
+            await ViewModel.LoadDataAsync();
             clmCustomerCompanyName.DataPropertyName = nameof(Customer.CustomerCompanyName);
             clmPreviousQuoteDate.DataPropertyName = nameof(Customer.PreviousQuoteDate);
             DgvCustomerList.AutoGenerateColumns = false;
@@ -52,8 +50,8 @@ namespace QuoteSwift.Views
 
         private void BtnRemoveSelectedCustomer_Click(object sender, EventArgs e)
         {
-            if (viewModel.RemoveCustomerCommand.CanExecute(null))
-                viewModel.RemoveCustomerCommand.Execute(null);
+            if (ViewModel.RemoveCustomerCommand.CanExecute(null))
+                ViewModel.RemoveCustomerCommand.Execute(null);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/Views/FrmViewPOBoxAddresses.cs
+++ b/Views/FrmViewPOBoxAddresses.cs
@@ -4,38 +4,35 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmViewPOBoxAddresses : BaseForm
+    public partial class FrmViewPOBoxAddresses : BaseForm<ViewPOBoxAddressesViewModel>
     {
 
-        readonly ViewPOBoxAddressesViewModel viewModel;
         readonly INavigationService navigation;
         Business business;
         Customer customer;
-        public ViewPOBoxAddressesViewModel ViewModel => viewModel;
 
         void SetupBindings()
         {
-            dgvPOBoxAddresses.DataSource = viewModel.Addresses;
-            SelectionBindings.BindSelectedItem(dgvPOBoxAddresses, viewModel,
+            dgvPOBoxAddresses.DataSource = ViewModel.Addresses;
+            SelectionBindings.BindSelectedItem(dgvPOBoxAddresses, ViewModel,
                 nameof(ViewPOBoxAddressesViewModel.SelectedAddress));
 
-            BindingHelpers.BindReadOnly(dgvPOBoxAddresses, viewModel, nameof(ViewPOBoxAddressesViewModel.IsReadOnly));
-            BindingHelpers.BindEnabled(btnRemoveAddress, viewModel, nameof(ViewPOBoxAddressesViewModel.CanEdit));
+            BindingHelpers.BindReadOnly(dgvPOBoxAddresses, ViewModel, nameof(ViewPOBoxAddressesViewModel.IsReadOnly));
+            BindingHelpers.BindEnabled(btnRemoveAddress, ViewModel, nameof(ViewPOBoxAddressesViewModel.CanEdit));
 
-            CommandBindings.Bind(btnRemoveAddress, viewModel.RemoveSelectedAddressCommand);
-            CommandBindings.Bind(btnChangeAddressInfo, viewModel.EditAddressCommand);
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(btnRemoveAddress, ViewModel.RemoveSelectedAddressCommand);
+            CommandBindings.Bind(btnChangeAddressInfo, ViewModel.EditAddressCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         public FrmViewPOBoxAddresses(ViewPOBoxAddressesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
         }
 
@@ -47,21 +44,21 @@ namespace QuoteSwift.Views
 
         private void CloseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (viewModel.ExitCommand.CanExecute(null))
-                viewModel.ExitCommand.Execute(null);
+            if (ViewModel.ExitCommand.CanExecute(null))
+                ViewModel.ExitCommand.Execute(null);
         }
 
 
         private void BtnCancel_Click(object sender, EventArgs e)
         {
-            if (viewModel.CancelCommand.CanExecute(null))
-                viewModel.CancelCommand.Execute(null);
+            if (ViewModel.CancelCommand.CanExecute(null))
+                ViewModel.CancelCommand.Execute(null);
         }
 
         private void BtnChangeAddressInfo_Click(object sender, EventArgs e)
         {
-            if (viewModel.EditAddressCommand.CanExecute(null))
-                viewModel.EditAddressCommand.Execute(null);
+            if (ViewModel.EditAddressCommand.CanExecute(null))
+                ViewModel.EditAddressCommand.Execute(null);
         }
 
         private void FrmViewPOBoxAddresses_Load(object sender, EventArgs e)
@@ -70,7 +67,7 @@ namespace QuoteSwift.Views
             {
                 Text = Text.Replace("<<Business name>>", business.BusinessName);
 
-                if (viewModel.IsReadOnly)
+                if (ViewModel.IsReadOnly)
                 {
                     BtnCancel.Enabled = true;
                 }
@@ -80,14 +77,14 @@ namespace QuoteSwift.Views
             {
                 Text = Text.Replace("<<Business name>>", customer.CustomerName);
 
-                if (viewModel.IsReadOnly)
+                if (ViewModel.IsReadOnly)
                 {
                     BtnCancel.Enabled = true;
                 }
 
             }
 
-            viewModel.UpdateData(business, customer);
+            ViewModel.UpdateData(business, customer);
 
             dgvPOBoxAddresses.RowsDefaultCellStyle.BackColor = Color.Bisque;
             dgvPOBoxAddresses.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;

--- a/Views/FrmViewParts.cs
+++ b/Views/FrmViewParts.cs
@@ -5,46 +5,44 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmViewParts : BaseForm
+    public partial class FrmViewParts : BaseForm<ViewPartsViewModel>
     {
 
-        readonly ViewPartsViewModel viewModel;
-        public ViewPartsViewModel ViewModel => viewModel;
+
 
         readonly BindingSource partsBindingSource = new BindingSource();
         readonly ISerializationService serializationService;
         readonly IMessageService messageService;
         public FrmViewParts(ViewPartsViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.serializationService = serializationService;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
-            viewModel.LoadDataCommand.Execute(null);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
+            ViewModel.LoadDataCommand.Execute(null);
             SetupBindings();
-            CommandBindings.Bind(BtnCancel, viewModel.CancelCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
         void SetupBindings()
         {
-            partsBindingSource.DataSource = viewModel;
+            partsBindingSource.DataSource = ViewModel;
             partsBindingSource.DataMember = nameof(ViewPartsViewModel.AllParts);
             dgvAllParts.DataSource = partsBindingSource;
 
-            SelectionBindings.BindSelectedItem(dgvAllParts, viewModel, nameof(ViewPartsViewModel.SelectedPart));
+            SelectionBindings.BindSelectedItem(dgvAllParts, ViewModel, nameof(ViewPartsViewModel.SelectedPart));
 
-            CommandBindings.Bind(btnAddPart, viewModel.AddPartCommand);
-            CommandBindings.Bind(btnViewSelectedPart, viewModel.UpdatePartCommand);
-            CommandBindings.Bind(btnRemovePart, viewModel.RemovePartCommand);
+            CommandBindings.Bind(btnAddPart, ViewModel.AddPartCommand);
+            CommandBindings.Bind(btnViewSelectedPart, ViewModel.UpdatePartCommand);
+            CommandBindings.Bind(btnRemovePart, ViewModel.RemovePartCommand);
         }
 
         private void FrmViewParts_Activated(object sender, EventArgs e)
         {
-            viewModel.LoadDataCommand.Execute(null);
+            ViewModel.LoadDataCommand.Execute(null);
         }
 
         /** Form Specific Functions And Procedures: 
@@ -67,8 +65,8 @@ namespace QuoteSwift.Views
 
         protected override void OnClose()
         {
-            if (viewModel.SaveChangesCommand.CanExecute(null))
-                viewModel.SaveChangesCommand.Execute(null);
+            if (ViewModel.SaveChangesCommand.CanExecute(null))
+                ViewModel.SaveChangesCommand.Execute(null);
         }
     }
 }

--- a/Views/FrmViewPump.cs
+++ b/Views/FrmViewPump.cs
@@ -4,11 +4,9 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views // Repair Quote Swift
 {
-    public partial class FrmViewPump : BaseForm
+    public partial class FrmViewPump : BaseForm<ViewPumpViewModel>
     {
 
-        readonly ViewPumpViewModel viewModel;
-        public ViewPumpViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly Button btnCancelOperation;
@@ -16,34 +14,33 @@ namespace QuoteSwift.Views // Repair Quote Swift
 
         void SetupBindings()
         {
-            pumpBindingSource.DataSource = viewModel;
+            pumpBindingSource.DataSource = ViewModel;
             pumpBindingSource.DataMember = nameof(ViewPumpViewModel.Pumps);
             dgvPumpList.DataSource = pumpBindingSource;
 
-            SelectionBindings.BindSelectedItem(dgvPumpList, viewModel, nameof(ViewPumpViewModel.SelectedPump));
+            SelectionBindings.BindSelectedItem(dgvPumpList, ViewModel, nameof(ViewPumpViewModel.SelectedPump));
 
-            CommandBindings.Bind(btnViewSelectedPump, viewModel.UpdatePumpCommand);
-            CommandBindings.Bind(btnAddPump, viewModel.AddPumpCommand);
-            CommandBindings.Bind(btnRemovePumpSelection, viewModel.RemovePumpCommand);
+            CommandBindings.Bind(btnViewSelectedPump, ViewModel.UpdatePumpCommand);
+            CommandBindings.Bind(btnAddPump, ViewModel.AddPumpCommand);
+            CommandBindings.Bind(btnRemovePumpSelection, ViewModel.RemovePumpCommand);
 
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
 
             exportInventoryToolStripMenuItem.Click += async (s, e) =>
             {
-                if (viewModel.ExportInventoryCommand.CanExecute(null))
-                    await ((AsyncRelayCommand)viewModel.ExportInventoryCommand).ExecuteAsync(null);
+                if (ViewModel.ExportInventoryCommand.CanExecute(null))
+                    await ((AsyncRelayCommand)ViewModel.ExportInventoryCommand).ExecuteAsync(null);
             };
         }
 
         public FrmViewPump(ViewPumpViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null)
-            : base(messageService, navigation)
+            : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.messageService = messageService;
-            viewModel.CloseAction = Close;
-            BindIsBusy(viewModel);
+            ViewModel.CloseAction = Close;
+            BindIsBusy(ViewModel);
             SetupBindings();
 
             btnCancelOperation = new Button
@@ -73,7 +70,7 @@ namespace QuoteSwift.Views // Repair Quote Swift
 
         private void BtnCancelOperation_Click(object sender, EventArgs e)
         {
-            ((AsyncRelayCommand)viewModel.ExportInventoryCommand).Cancel();
+            ((AsyncRelayCommand)ViewModel.ExportInventoryCommand).Cancel();
         }
 
         /** Form Specific Functions And Procedures: 
@@ -92,7 +89,7 @@ namespace QuoteSwift.Views // Repair Quote Swift
 
         protected override void OnClose()
         {
-            viewModel.SaveChanges();
+            ViewModel.SaveChanges();
         }
 
         /*********************************************************************************/

--- a/Views/FrmViewQuotes.cs
+++ b/Views/FrmViewQuotes.cs
@@ -3,69 +3,66 @@ using System.Windows.Forms;
 
 namespace QuoteSwift.Views
 {
-    public partial class FrmViewQuotes : BaseForm
+    public partial class FrmViewQuotes : BaseForm<QuotesViewModel>
     {
 
-        readonly QuotesViewModel viewModel;
-        public QuotesViewModel ViewModel => viewModel;
         readonly INavigationService navigation;
         readonly IMessageService messageService;
         readonly ISerializationService serializationService;
         readonly BindingSource quotesBindingSource = new BindingSource();
 
         public FrmViewQuotes(QuotesViewModel viewModel, INavigationService navigation = null, IMessageService messageService = null, ISerializationService serializationService = null)
-        : base(messageService, navigation)
+        : base(viewModel, messageService, navigation)
         {
             InitializeComponent();
-            this.viewModel = viewModel;
             this.navigation = navigation;
             this.serializationService = serializationService;
             this.messageService = messageService;
-            quotesBindingSource.DataSource = viewModel.Quotes;
+            quotesBindingSource.DataSource = ViewModel.Quotes;
             dgvPreviousQuotes.DataSource = quotesBindingSource;
             SetupBindings();
-            BindIsBusy(viewModel);
+            BindIsBusy(ViewModel);
         }
 
         void SetupBindings()
         {
-            SelectionBindings.BindSelectedItem(dgvPreviousQuotes, viewModel, nameof(QuotesViewModel.SelectedQuote));
+            SelectionBindings.BindSelectedItem(dgvPreviousQuotes, ViewModel, nameof(QuotesViewModel.SelectedQuote));
 
-            CommandBindings.Bind(btnCreateNewQuote, viewModel.CreateQuoteCommand);
-            CommandBindings.Bind(btnViewSelectedQuote, viewModel.ViewQuoteCommand);
-            CommandBindings.Bind(btnCreateNewQuoteOnSelection, viewModel.CreateQuoteFromSelectionCommand);
+            CommandBindings.Bind(btnCreateNewQuote, ViewModel.CreateQuoteCommand);
+            CommandBindings.Bind(btnViewSelectedQuote, ViewModel.ViewQuoteCommand);
+            CommandBindings.Bind(btnCreateNewQuoteOnSelection, ViewModel.CreateQuoteFromSelectionCommand);
 
-            CommandBindings.Bind(manageBusinessesToolStripMenuItem, viewModel.ViewBusinessesCommand);
-            CommandBindings.Bind(addNewBusinessToolStripMenuItem, viewModel.AddBusinessCommand);
-            CommandBindings.Bind(ViewAllBusinessesToolStripMenuItem, viewModel.ViewBusinessesCommand);
+            CommandBindings.Bind(manageBusinessesToolStripMenuItem, ViewModel.ViewBusinessesCommand);
+            CommandBindings.Bind(addNewBusinessToolStripMenuItem, ViewModel.AddBusinessCommand);
+            CommandBindings.Bind(ViewAllBusinessesToolStripMenuItem, ViewModel.ViewBusinessesCommand);
 
-            CommandBindings.Bind(manageCustomersToolStripMenuItem, viewModel.ViewCustomersCommand);
-            CommandBindings.Bind(addNewCustomerToolStripMenuItem, viewModel.AddCustomerCommand);
-            CommandBindings.Bind(viewAllCustomersToolStripMenuItem, viewModel.ViewCustomersCommand);
+            CommandBindings.Bind(manageCustomersToolStripMenuItem, ViewModel.ViewCustomersCommand);
+            CommandBindings.Bind(addNewCustomerToolStripMenuItem, ViewModel.AddCustomerCommand);
+            CommandBindings.Bind(viewAllCustomersToolStripMenuItem, ViewModel.ViewCustomersCommand);
 
-            CommandBindings.Bind(managePumpsToolStripMenuItem, viewModel.ViewPumpsCommand);
-            CommandBindings.Bind(createNewPumpToolStripMenuItem, viewModel.CreatePumpCommand);
-            CommandBindings.Bind(viewAllPumpsToolStripMenuItem, viewModel.ViewPumpsCommand);
+            CommandBindings.Bind(managePumpsToolStripMenuItem, ViewModel.ViewPumpsCommand);
+            CommandBindings.Bind(createNewPumpToolStripMenuItem, ViewModel.CreatePumpCommand);
+            CommandBindings.Bind(viewAllPumpsToolStripMenuItem, ViewModel.ViewPumpsCommand);
 
-            CommandBindings.Bind(managePumpPartsToolStripMenuItem, viewModel.ViewPartsCommand);
-            CommandBindings.Bind(addNewPartToolStripMenuItem, viewModel.AddPartCommand);
-            CommandBindings.Bind(viewAllPartsToolStripMenuItem, viewModel.ViewPartsCommand);
-            CommandBindings.Bind(closeToolStripMenuItem, viewModel.ExitCommand);
+            CommandBindings.Bind(managePumpPartsToolStripMenuItem, ViewModel.ViewPartsCommand);
+            CommandBindings.Bind(addNewPartToolStripMenuItem, ViewModel.AddPartCommand);
+            CommandBindings.Bind(viewAllPartsToolStripMenuItem, ViewModel.ViewPartsCommand);
+            CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
         }
 
 
         bool columnsConfigured = false;
         private async void FrmViewQuotes_Load(object sender, EventArgs e)
         {
-            await viewModel.LoadDataAsync();
-            quotesBindingSource.DataSource = viewModel.Quotes;
+            await ViewModel.LoadDataAsync();
+            quotesBindingSource.DataSource = ViewModel.Quotes;
             ConfigureColumns();
         }
 
         readonly int count = 0;
         protected override void OnClose()
         {
-            viewModel.SaveChanges();
+            ViewModel.SaveChanges();
         }
 
         void ConfigureColumns()
@@ -136,7 +133,7 @@ namespace QuoteSwift.Views
 
         private void FrmViewQuotes_Activated(object sender, EventArgs e)
         {
-            quotesBindingSource.DataSource = viewModel.Quotes;
+            quotesBindingSource.DataSource = ViewModel.Quotes;
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `BaseForm<TViewModel>` with a `ViewModel` property
- use the generic base form across all WinForms
- remove redundant view model fields

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_6881fadfc28c83259bcf51c1c94f0d9c