### PR TITLE
Use Async Loading Commands

### DIFF
--- a/Views/FrmAddBusiness.cs
+++ b/Views/FrmAddBusiness.cs
@@ -40,7 +40,7 @@ namespace QuoteSwift.Views
 
         private async void FrmAddBusiness_Load(object sender, EventArgs e)
         {
-            await ViewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             var initResult = ViewModel.InitializeCurrentBusinessResult();
             if (!initResult.Success)
             {

--- a/Views/FrmAddCustomer.cs
+++ b/Views/FrmAddCustomer.cs
@@ -80,7 +80,7 @@ namespace QuoteSwift.Views
 
         private async void FrmAddCustomer_Load(object sender, EventArgs e)
         {
-            await ViewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             if (ViewModel.BusinessList != null)
             {
                 BindingSource source = new BindingSource { DataSource = ViewModel.BusinessList };

--- a/Views/FrmAddPump.cs
+++ b/Views/FrmAddPump.cs
@@ -32,7 +32,6 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnAddPump, ViewModel.SavePumpCommand);
             CommandBindings.Bind(btnCancel, ViewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
-            ViewModel.LoadDataCommand.Execute(null);
             BindIsBusy(ViewModel);
         }
 

--- a/Views/FrmViewCustomers.cs
+++ b/Views/FrmViewCustomers.cs
@@ -40,7 +40,7 @@ namespace QuoteSwift.Views
 
         private async void FrmViewCustomers_Load(object sender, EventArgs e)
         {
-            await ViewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             clmCustomerCompanyName.DataPropertyName = nameof(Customer.CustomerCompanyName);
             clmPreviousQuoteDate.DataPropertyName = nameof(Customer.PreviousQuoteDate);
             DgvCustomerList.AutoGenerateColumns = false;

--- a/Views/FrmViewParts.cs
+++ b/Views/FrmViewParts.cs
@@ -21,7 +21,6 @@ namespace QuoteSwift.Views
             this.messageService = messageService;
             ViewModel.CloseAction = Close;
             BindIsBusy(ViewModel);
-            ViewModel.LoadDataCommand.Execute(null);
             SetupBindings();
             CommandBindings.Bind(BtnCancel, ViewModel.CancelCommand);
             CommandBindings.Bind(closeToolStripMenuItem, ViewModel.ExitCommand);
@@ -40,9 +39,9 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnRemovePart, ViewModel.RemovePartCommand);
         }
 
-        private void FrmViewParts_Activated(object sender, EventArgs e)
+        private async void FrmViewParts_Activated(object sender, EventArgs e)
         {
-            ViewModel.LoadDataCommand.Execute(null);
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/Views/FrmViewQuotes.cs
+++ b/Views/FrmViewQuotes.cs
@@ -54,7 +54,7 @@ namespace QuoteSwift.Views
         bool columnsConfigured = false;
         private async void FrmViewQuotes_Load(object sender, EventArgs e)
         {
-            await ViewModel.LoadDataAsync();
+            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             quotesBindingSource.DataSource = ViewModel.Quotes;
             ConfigureColumns();
         }


### PR DESCRIPTION
## Summary
- await the async `LoadDataCommand` in form load events
- drop unused synchronous call in Add Pump form
- keep UI busy state during async loading

## Testing
- `dotnet msbuild QuoteSwift.sln /t:Rebuild /p:Configuration=Debug` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ff58e9d883258fc4bf2c813d7036