### PR TITLE
Add cancel commands for imports and exports

### DIFF
--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -32,6 +32,7 @@ namespace QuoteSwift
         public ICommand SavePartCommand { get; }
         public ICommand LoadDataCommand { get; }
         public ICommand ImportPartsCommand { get; }
+        public ICommand CancelImportPartsCommand { get; }
         public ICommand ExitCommand { get; }
         public ICommand ResetInputCommand { get; }
         public ICommand CancelCommand { get; }
@@ -128,6 +129,7 @@ namespace QuoteSwift
             });
             LoadDataCommand = CreateLoadCommand(LoadDataAsync);
             ImportPartsCommand = new AsyncRelayCommand((_, t) => ImportPartsAsync(t));
+            CancelImportPartsCommand = new RelayCommand(_ => ((AsyncRelayCommand)ImportPartsCommand).Cancel());
             ExitCommand = CreateExitCommand(() =>
             {
                 navigation?.SaveAllData();

--- a/ViewModels/ViewPumpViewModel.cs
+++ b/ViewModels/ViewPumpViewModel.cs
@@ -26,6 +26,7 @@ namespace QuoteSwift
         public ICommand UpdatePumpCommand { get; }
         public ICommand RemovePumpCommand { get; }
         public ICommand ExportInventoryCommand { get; }
+        public ICommand CancelExportInventoryCommand { get; }
         public ICommand ExitCommand { get; }
         public ICommand CancelCommand { get; }
 
@@ -46,6 +47,7 @@ namespace QuoteSwift
             UpdatePumpCommand = new AsyncRelayCommand(_ => UpdatePumpAsync(), _ => Task.FromResult(SelectedPump != null));
             RemovePumpCommand = new RelayCommand(_ => RemoveSelectedPump(), _ => SelectedPump != null);
             ExportInventoryCommand = new AsyncRelayCommand((_, t) => ExportInventoryActionAsync(t));
+            CancelExportInventoryCommand = new RelayCommand(_ => ((AsyncRelayCommand)ExportInventoryCommand).Cancel());
             ExitCommand = CreateExitCommand(() =>
             {
                 navigation?.SaveAllData();

--- a/Views/FrmAddPart.cs
+++ b/Views/FrmAddPart.cs
@@ -68,7 +68,8 @@ namespace QuoteSwift.Views
 
         private void BtnCancelOperation_Click(object sender, EventArgs e)
         {
-            ((AsyncRelayCommand)ViewModel.ImportPartsCommand).Cancel();
+            if (ViewModel.CancelImportPartsCommand.CanExecute(null))
+                ViewModel.CancelImportPartsCommand.Execute(null);
         }
 
         private void CbAddToPumpSelection_ContextMenuStripChanged(object sender, EventArgs e)

--- a/Views/FrmViewPump.cs
+++ b/Views/FrmViewPump.cs
@@ -70,7 +70,8 @@ namespace QuoteSwift.Views // Repair Quote Swift
 
         private void BtnCancelOperation_Click(object sender, EventArgs e)
         {
-            ((AsyncRelayCommand)ViewModel.ExportInventoryCommand).Cancel();
+            if (ViewModel.CancelExportInventoryCommand.CanExecute(null))
+                ViewModel.CancelExportInventoryCommand.Execute(null);
         }
 
         /** Form Specific Functions And Procedures: 


### PR DESCRIPTION
## Summary
- add `CancelImportPartsCommand` to `AddPartViewModel`
- add `CancelExportInventoryCommand` to `ViewPumpViewModel`
- use these commands in FrmAddPart and FrmViewPump cancel handlers

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace not MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_68821f01da0483258b6bbdf9e48b9d43