### PR TITLE
Handle Quote_Part updates in view model

### DIFF
--- a/Views/FrmCreateQuote.Designer.cs
+++ b/Views/FrmCreateQuote.Designer.cs
@@ -827,7 +827,6 @@ namespace QuoteSwift.Views
             this.DgvNonMandatoryPartReplacement.Name = "DgvNonMandatoryPartReplacement";
             this.DgvNonMandatoryPartReplacement.Size = new System.Drawing.Size(791, 325);
             this.DgvNonMandatoryPartReplacement.TabIndex = 3;
-            this.DgvNonMandatoryPartReplacement.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvNonMandatoryPartReplacement_CellEndEdit);
             // 
             // dataGridViewTextBoxColumn1
             // 
@@ -949,7 +948,6 @@ namespace QuoteSwift.Views
             this.dgvMandatoryPartReplacement.Name = "dgvMandatoryPartReplacement";
             this.dgvMandatoryPartReplacement.Size = new System.Drawing.Size(791, 325);
             this.dgvMandatoryPartReplacement.TabIndex = 1;
-            this.dgvMandatoryPartReplacement.CellEndEdit += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvMandatoryPartReplacement_CellEndEdit);
             // 
             // clmPartNumber
             // 

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -116,15 +116,7 @@ namespace QuoteSwift.Views
             DgvNonMandatoryPartReplacement.RowsDefaultCellStyle.BackColor = Color.Bisque;
             DgvNonMandatoryPartReplacement.AlternatingRowsDefaultCellStyle.BackColor = Color.Beige;
         }
-        private void DgvMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
-        {
-            ViewModel.Calculate();
-        }
 
-        private void DgvNonMandatoryPartReplacement_CellEndEdit(object sender, DataGridViewCellEventArgs e)
-        {
-            ViewModel.Calculate();
-        }
 
 
 


### PR DESCRIPTION
## Summary
- watch `MandatoryParts` and `NonMandatoryParts` in `CreateQuoteViewModel`
- react to `Quote_Part` property changes by recalculating totals
- remove cell edit handlers from `FrmCreateQuote`

## Testing
- `xbuild QuoteSwift.sln` *(fails: default XML namespace must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_6882235468dc8325a8f39d043807a4be