### PR TITLE
Remove manual LoadDataCommand execution

### DIFF
--- a/Views/FrmAddBusiness.cs
+++ b/Views/FrmAddBusiness.cs
@@ -38,9 +38,8 @@ namespace QuoteSwift.Views
 
 
 
-        private async void FrmAddBusiness_Load(object sender, EventArgs e)
+        private void FrmAddBusiness_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             var initResult = ViewModel.InitializeCurrentBusinessResult();
             if (!initResult.Success)
             {

--- a/Views/FrmAddCustomer.cs
+++ b/Views/FrmAddCustomer.cs
@@ -78,9 +78,8 @@ namespace QuoteSwift.Views
         }
 
 
-        private async void FrmAddCustomer_Load(object sender, EventArgs e)
+        private void FrmAddCustomer_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             if (ViewModel.BusinessList != null)
             {
                 BindingSource source = new BindingSource { DataSource = ViewModel.BusinessList };

--- a/Views/FrmAddPart.cs
+++ b/Views/FrmAddPart.cs
@@ -77,9 +77,8 @@ namespace QuoteSwift.Views
             if (!cbxMandatoryPart.Enabled) cbxMandatoryPart.Enabled = true;
         }
 
-        private async void FrmAddPart_Load(object sender, EventArgs e)
+        private void FrmAddPart_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             if (ViewModel.PartToChange == null)
             {
                 ViewModel.ChangeSpecificObject = true;

--- a/Views/FrmAddPump.cs
+++ b/Views/FrmAddPump.cs
@@ -37,9 +37,8 @@ namespace QuoteSwift.Views
 
         // Input changes are tracked by the view model
 
-        private async void FrmAddPump_Load(object sender, EventArgs e)
+        private void FrmAddPump_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             SetupBindings();
 
             if (ViewModel.PumpToChange == null)

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -67,9 +67,8 @@ namespace QuoteSwift.Views
         }
 
 
-        private async void FrmCreateQuote_Load(object sender, EventArgs e)
+        private void FrmCreateQuote_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             ViewModel.QuoteToChange = quoteToChange;
             ViewModel.ChangeSpecificObject = changeSpecificObject;
             if (ViewModel.IsViewing)

--- a/Views/FrmViewCustomers.cs
+++ b/Views/FrmViewCustomers.cs
@@ -38,9 +38,8 @@ namespace QuoteSwift.Views
 
         // CommandBindings handle Exit action
 
-        private async void FrmViewCustomers_Load(object sender, EventArgs e)
+        private void FrmViewCustomers_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             clmCustomerCompanyName.DataPropertyName = nameof(Customer.CustomerCompanyName);
             clmPreviousQuoteDate.DataPropertyName = nameof(Customer.PreviousQuoteDate);
             DgvCustomerList.AutoGenerateColumns = false;

--- a/Views/FrmViewParts.cs
+++ b/Views/FrmViewParts.cs
@@ -39,9 +39,8 @@ namespace QuoteSwift.Views
             CommandBindings.Bind(btnRemovePart, ViewModel.RemovePartCommand);
         }
 
-        private async void FrmViewParts_Activated(object sender, EventArgs e)
+        private void FrmViewParts_Activated(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
         }
 
         /** Form Specific Functions And Procedures: 

--- a/Views/FrmViewQuotes.cs
+++ b/Views/FrmViewQuotes.cs
@@ -52,9 +52,8 @@ namespace QuoteSwift.Views
 
 
         bool columnsConfigured = false;
-        private async void FrmViewQuotes_Load(object sender, EventArgs e)
+        private void FrmViewQuotes_Load(object sender, EventArgs e)
         {
-            await ((AsyncRelayCommand)ViewModel.LoadDataCommand).ExecuteAsync(null);
             quotesBindingSource.DataSource = ViewModel.Quotes;
             ConfigureColumns();
         }


### PR DESCRIPTION
## Summary
- forms no longer call `LoadDataCommand` directly on load
- rely on `NavigationService.LoadIfAvailableAsync` for initialization

## Testing
- `xbuild QuoteSwift.sln /nologo` *(fails: default XML namespace error)*

------
https://chatgpt.com/codex/tasks/task_e_68823c4d0c4c8325ad2f4c18880db56f