### PR TITLE
Fix braces causing build errors

### DIFF
--- a/ViewModels/AddPartViewModel.cs
+++ b/ViewModels/AddPartViewModel.cs
@@ -484,6 +484,7 @@ namespace QuoteSwift
                     }
                 }
             }
+            }
             finally
             {
                 IsBusy = false;

--- a/Views/FrmCreateQuote.cs
+++ b/Views/FrmCreateQuote.cs
@@ -253,4 +253,5 @@ namespace QuoteSwift.Views
                 ViewModel.ExitCommand.Execute(null);
         }
 
+    }
 }


### PR DESCRIPTION
## Summary
- add missing closing bracket for `ImportPartsFromCsvAsync`
- close namespace in `FrmCreateQuote`

## Testing
- `xbuild QuoteSwift.sln /p:Configuration=Debug` *(fails: project format not supported in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68823e48910c83259199cd86d84b5ff6