### PR TITLE
Fix missing ICommand using and add notification info

### DIFF
--- a/Services/INotificationService.cs
+++ b/Services/INotificationService.cs
@@ -3,5 +3,6 @@ namespace QuoteSwift
     public interface INotificationService
     {
         void ShowError(string text, string caption);
+        void ShowInformation(string text, string caption);
     }
 }

--- a/Services/MessageBoxNotificationService.cs
+++ b/Services/MessageBoxNotificationService.cs
@@ -8,5 +8,10 @@ namespace QuoteSwift
         {
             MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
+
+        public void ShowInformation(string text, string caption)
+        {
+            MessageBox.Show(text, caption, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
     }
 }

--- a/ViewModels/ViewBusinessesViewModel.cs
+++ b/ViewModels/ViewBusinessesViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace QuoteSwift
 {

--- a/ViewModels/ViewCustomersViewModel.cs
+++ b/ViewModels/ViewCustomersViewModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace QuoteSwift
 {


### PR DESCRIPTION
## Summary
- import `System.Windows.Input` in business and customer viewmodels
- extend `INotificationService` with `ShowInformation` and implement it

## Testing
- `dotnet restore QuoteSwift.sln`
- `dotnet msbuild QuoteSwift.sln /t:Build /p:Configuration=Debug` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688243b9739883258827e0335d785191