### PR TITLE
Update .NET version and build instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository contains **QuoteSwift**, a Windows Forms application built with 
 ## Building
 1. Open the solution in Visual Studio (2019 or newer) **or** from a Developer Command Prompt run:
    ```bash
-   msbuild QuoteSwift.sln
+   dotnet build QuoteSwift.sln
    ```
 2. All projects build together. After a successful build the main executable will be in `QuoteSwift/bin/Debug` (or `bin/Release`).
 
@@ -19,10 +19,10 @@ This repository contains **QuoteSwift**, a Windows Forms application built with 
 Launch `QuoteSwift.exe` to start the quoting application. When exporting a quote you will be prompted for a location to save the Excel file generated from `QuoteTemplate.xlsx`.
 
 ## Code guidelines
-- Target framework: **.NET Framework 4.8**.
+- Target framework: **.NET 9**.
 - Keep code in the existing C# coding style (PascalCase for public members, camelCase for locals, etc.).
 - The solution does not currently include an automated test suite.
-- After modifying code, compile the solution with `msbuild QuoteSwift.sln` to ensure it builds successfully.
+- After modifying code, compile the solution with `dotnet build QuoteSwift.sln` to ensure it builds successfully.
 
 ## Contributing
 1. Create descriptive commit messages summarizing the change.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Earlier versions used a `Pass` helper class for this role.
 
 ## Prerequisites
 
-- **.NET Framework 4.8** or later
-- Visual Studio 2019 (or newer) with the *.NET desktop development* workload installed.  Alternatively, the project can be built with the `msbuild` or `dotnet` command line tools.
+- **.NET 9 SDK**
+- Visual Studio 2019 (or newer) with the *.NET desktop development* workload installed.  Alternatively, the project can be built with the `dotnet` command line tool.
 
 ## Building the project
 
@@ -18,7 +18,7 @@ Earlier versions used a `Pass` helper class for this role.
 2. Open `QuoteSwift.sln` in Visual Studio and build the solution, **or** from a Developer Command Prompt run:
 
    ```bash
-   msbuild QuoteSwift.sln
+   dotnet build QuoteSwift.sln
    ```
 
 All projects (the main application and supporting library) are built together.


### PR DESCRIPTION
## Summary
- update prerequisites in README to mention .NET 9 SDK
- use `dotnet build` in README build steps
- update AGENTS.md to target .NET 9 and use `dotnet build`

## Testing
- `dotnet build QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882524c83648325b54cdd6ccdda353b