### PR TITLE
Remove setup project and refresh README

### DIFF
--- a/QuoteSwift.sln
+++ b/QuoteSwift.sln
@@ -10,8 +10,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuoteSwift", "QuoteSwift.cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MainProgramLibrary", "MainProgramLibrary\MainProgramLibrary.csproj", "{374F4D18-B639-468B-ADC7-88A9F39D6553}"
 EndProject
-Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "QuoteSwift Setup Wizard", "QuoteSwift Setup Wizard\QuoteSwift Setup Wizard.vdproj", "{D846DE8E-C845-4FA7-AE17-1EA9F95F47CE}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,8 +24,6 @@ Global
 		{374F4D18-B639-468B-ADC7-88A9F39D6553}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{374F4D18-B639-468B-ADC7-88A9F39D6553}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{374F4D18-B639-468B-ADC7-88A9F39D6553}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D846DE8E-C845-4FA7-AE17-1EA9F95F47CE}.Debug|Any CPU.ActiveCfg = Debug
-		{D846DE8E-C845-4FA7-AE17-1EA9F95F47CE}.Release|Any CPU.ActiveCfg = Release
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Earlier versions used a `Pass` helper class for this role.
 
 ## Prerequisites
 
-- **.NET Framework 4.8** or later
-- Visual Studio 2019 (or newer) with the *.NET desktop development* workload installed.  Alternatively, the project can be built with the `msbuild` or `dotnet` command line tools.
+- **.NET 9.0 SDK**
+- Visual Studio 2022 (or newer) with the *.NET desktop development* workload installed.  Alternatively, the project can be built with the `dotnet` command line tools.
 
 ## Building the project
 
 1. Clone this repository.
-2. Open `QuoteSwift.sln` in Visual Studio and build the solution, **or** from a Developer Command Prompt run:
+2. Open `QuoteSwift.sln` in Visual Studio and build the solution, **or** run:
 
    ```bash
-   msbuild QuoteSwift.sln
+   dotnet build QuoteSwift.sln
    ```
 
 All projects (the main application and supporting library) are built together.


### PR DESCRIPTION
## Summary
- remove `QuoteSwift Setup Wizard` project from the solution
- document .NET 9 SDK requirements and use `dotnet build` in README

## Testing
- `dotnet build QuoteSwift.sln` *(fails: command not found)*
- `msbuild QuoteSwift.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882525016e8832585ae28e6bd3e6c8f