### PR TITLE
Update build docs for .NET 9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This repository contains **QuoteSwift**, a Windows Forms application built with C# and .NET Framework 4.8. It helps manage pump quotes, parts and customer information. Quotes can be exported directly to Excel using `QuoteTemplate.xlsx`.
+This repository contains **QuoteSwift**, a Windows Forms application built with C# and .NET 9. It helps manage pump quotes, parts and customer information. Quotes can be exported directly to Excel using `QuoteTemplate.xlsx`.
 
 ## Repository layout
 - **QuoteSwift.sln** – Visual Studio solution including the main WinForms app and supporting class library (`MainProgramLibrary`).
@@ -9,9 +9,9 @@ This repository contains **QuoteSwift**, a Windows Forms application built with 
 - JSON files such as `BusinessList.json`, `Parts.json` and `PumpList.json` hold data used by the application.
 
 ## Building
-1. Open the solution in Visual Studio (2019 or newer) **or** from a Developer Command Prompt run:
+1. Open the solution in Visual Studio (2019 or newer) **or** from any command prompt run:
    ```bash
-   msbuild QuoteSwift.sln
+   dotnet build QuoteSwift.sln
    ```
 2. All projects build together. After a successful build the main executable will be in `QuoteSwift/bin/Debug` (or `bin/Release`).
 
@@ -19,10 +19,10 @@ This repository contains **QuoteSwift**, a Windows Forms application built with 
 Launch `QuoteSwift.exe` to start the quoting application. When exporting a quote you will be prompted for a location to save the Excel file generated from `QuoteTemplate.xlsx`.
 
 ## Code guidelines
-- Target framework: **.NET Framework 4.8**.
+- Target framework: **.NET 9**.
 - Keep code in the existing C# coding style (PascalCase for public members, camelCase for locals, etc.).
 - The solution does not currently include an automated test suite.
-- After modifying code, compile the solution with `msbuild QuoteSwift.sln` to ensure it builds successfully.
+- After modifying code, compile the solution with `dotnet build QuoteSwift.sln` to ensure it builds successfully.
 
 ## Contributing
 1. Create descriptive commit messages summarizing the change.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Earlier versions used a `Pass` helper class for this role.
 
 ## Prerequisites
 
-- **.NET 9.0 SDK**
+ - **.NET 9 SDK**
 - Visual Studio 2022 (or newer) with the *.NET desktop development* workload installed.  Alternatively, the project can be built with the `dotnet` command line tools.
 
 ## Building the project


### PR DESCRIPTION
## Summary
- reference .NET 9 SDK in README prerequisites
- change build steps to use `dotnet build QuoteSwift.sln`
- update AGENTS.md target framework and build commands for .NET 9

## Testing
- `dotnet build QuoteSwift.sln -v:m -p:EnableWindowsTargeting=true` *(fails: ResolveComReference not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6882577692fc83258d5f917c7a897f7a