### PR TITLE
Fix AsyncRelayCommand ambiguities

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -271,7 +271,7 @@ namespace QuoteSwift
                     EmailInput = string.Empty;
                 }
             });
-            ViewEmailAddressesCommand = new AsyncRelayCommand(async _ =>
+            ViewEmailAddressesCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentBusiness.BusinessEmailAddressList != null)
                 {
@@ -282,7 +282,7 @@ namespace QuoteSwift
                     messageService.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Email Addresses");
                 }
             });
-            ViewAddressesCommand = new AsyncRelayCommand(async _ =>
+            ViewAddressesCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentBusiness.BusinessAddressList != null)
                 {
@@ -293,7 +293,7 @@ namespace QuoteSwift
                     messageService.ShowError("You need to first add an address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business Addresses");
                 }
             });
-            ViewPOBoxAddressesCommand = new AsyncRelayCommand(async _ =>
+            ViewPOBoxAddressesCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentBusiness.BusinessPOBoxAddressList != null)
                 {
@@ -304,7 +304,7 @@ namespace QuoteSwift
                     messageService.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Business P.O.Box Addresses");
                 }
             });
-            ViewPhoneNumbersCommand = new AsyncRelayCommand(async _ =>
+            ViewPhoneNumbersCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentBusiness.BusinessTelephoneNumberList != null || CurrentBusiness.BusinessCellphoneNumberList != null)
                 {

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -264,7 +264,7 @@ namespace QuoteSwift
                     LastOperationSuccessful = false;
                 }
             });
-            ViewPhoneNumbersCommand = new AsyncRelayCommand(async _ =>
+            ViewPhoneNumbersCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentCustomer.CustomerCellphoneNumberList != null || CurrentCustomer.CustomerTelephoneNumberList != null)
                 {
@@ -275,7 +275,7 @@ namespace QuoteSwift
                     messageService.ShowError("You need to first add at least one phone number before you can view the list of phone numbers.\nPlease add a phone number first", "ERROR - Can't View Non-Existing Customer Phone Numbers");
                 }
             });
-            ViewPOBoxAddressesCommand = new AsyncRelayCommand(async _ =>
+            ViewPOBoxAddressesCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentCustomer.CustomerPOBoxAddress != null)
                 {
@@ -286,7 +286,7 @@ namespace QuoteSwift
                     messageService.ShowError("You need to first add an P.O.Box address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer P.O.Box Addresses");
                 }
             });
-            ViewEmailAddressesCommand = new AsyncRelayCommand(async _ =>
+            ViewEmailAddressesCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentCustomer.CustomerEmailList != null)
                 {
@@ -297,7 +297,7 @@ namespace QuoteSwift
                     messageService.ShowError("You need to first add an Email address before you can view the list of addresses.\nPlease add an address first", "ERROR - Can't View Non-Existing Customer Email Addresses");
                 }
             });
-            ViewAddressesCommand = new AsyncRelayCommand(async _ =>
+            ViewAddressesCommand = new AsyncRelayCommand(async (object _) =>
             {
                 if (CurrentCustomer != null)
                 {


### PR DESCRIPTION
## Summary
- disambiguate AsyncRelayCommand constructors by specifying object parameter types

## Testing
- `dotnet build QuoteSwift.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6882608c8c048325bceb09148ccf29a0