### PR TITLE
Fix text rendering initialization order

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -65,6 +65,9 @@ namespace QuoteSwift
 
         static async Task Main()
         {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+
             var serviceProvider = ConfigureServices();
             var appData = serviceProvider.GetRequiredService<ApplicationData>();
             await appData.LoadAsync();
@@ -72,8 +75,6 @@ namespace QuoteSwift
             var mainForm = serviceProvider.GetRequiredService<FrmViewQuotes>();
             mainForm.ViewModel.UpdateData(appData.QuoteMap, appData.BusinessList, appData.PumpList, appData.PartList);
 
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(mainForm);
         }
     }


### PR DESCRIPTION
## Summary
- ensure SetCompatibleTextRenderingDefault is invoked before forms are created

## Testing
- `dotnet build QuoteSwift.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688266ab12208325ad34690822eb90cd