### PR TITLE
Allow editing when creating new items

### DIFF
--- a/ViewModels/AddBusinessViewModel.cs
+++ b/ViewModels/AddBusinessViewModel.cs
@@ -164,7 +164,7 @@ namespace QuoteSwift
             set => SetProperty(ref emailInput, value);
         }
 
-        public bool IsEditing => changeSpecificObject;
+        public bool IsEditing => changeSpecificObject || businessToChange == null;
 
         public bool IsViewing => businessToChange != null && !changeSpecificObject;
 
@@ -210,7 +210,7 @@ namespace QuoteSwift
             });
             SaveBusinessCommand = new RelayCommand(_ =>
             {
-                if (ChangeSpecificObject)
+                if (BusinessToChange != null && ChangeSpecificObject)
                 {
                     var result = UpdateBusiness();
                     LastResult = result;
@@ -422,7 +422,7 @@ namespace QuoteSwift
             }
         }
 
-        public bool IsReadOnly => !changeSpecificObject;
+        public bool IsReadOnly => businessToChange != null && !changeSpecificObject;
 
         public bool CanEdit => changeSpecificObject;
 

--- a/ViewModels/AddCustomerViewModel.cs
+++ b/ViewModels/AddCustomerViewModel.cs
@@ -151,7 +151,7 @@ namespace QuoteSwift
             set => SetProperty(ref emailInput, value);
         }
 
-        public bool IsEditing => changeSpecificObject;
+        public bool IsEditing => changeSpecificObject || customerToChange == null;
 
         public bool IsViewing => customerToChange != null && !changeSpecificObject;
 
@@ -203,7 +203,7 @@ namespace QuoteSwift
             });
             SaveCustomerCommand = new RelayCommand(p =>
             {
-                if (ChangeSpecificObject)
+                if (CustomerToChange != null && ChangeSpecificObject)
                 {
                     if (p is object[] arr && arr.Length == 2 && arr[0] is Business b && arr[1] is string name)
                     {
@@ -413,7 +413,7 @@ namespace QuoteSwift
             }
         }
 
-        public bool IsReadOnly => !changeSpecificObject;
+        public bool IsReadOnly => customerToChange != null && !changeSpecificObject;
 
         public bool CanEdit => changeSpecificObject;
 

--- a/ViewModels/AddPumpViewModel.cs
+++ b/ViewModels/AddPumpViewModel.cs
@@ -39,7 +39,7 @@ namespace QuoteSwift
             }
         }
 
-        public bool IsEditing => changeSpecificObject;
+        public bool IsEditing => changeSpecificObject || pumpToChange == null;
 
         public bool IsViewing => pumpToChange != null && !changeSpecificObject;
 
@@ -105,7 +105,7 @@ namespace QuoteSwift
             }
         }
 
-        public bool IsReadOnly => !changeSpecificObject;
+        public bool IsReadOnly => pumpToChange != null && !changeSpecificObject;
 
         public bool CanEdit => changeSpecificObject;
 
@@ -182,7 +182,7 @@ namespace QuoteSwift
             UpdatePumpCommand = new RelayCommand(_ => LastOperationSuccessful = UpdatePump());
             SavePumpCommand = new RelayCommand(_ =>
             {
-                if (ChangeSpecificObject)
+                if (PumpToChange != null && ChangeSpecificObject)
                     LastOperationSuccessful = UpdatePump();
                 else
                     LastOperationSuccessful = AddPump();

--- a/ViewModels/CreateQuoteViewModel.cs
+++ b/ViewModels/CreateQuoteViewModel.cs
@@ -120,13 +120,13 @@ namespace QuoteSwift
             }
         }
 
-        public bool IsEditing => changeSpecificObject;
+        public bool IsEditing => changeSpecificObject || quoteToChange == null;
 
         public bool IsViewing => quoteToChange != null && !changeSpecificObject;
 
         public bool IsAdding => quoteToChange == null && !changeSpecificObject;
 
-        public bool IsReadOnly => !changeSpecificObject;
+        public bool IsReadOnly => quoteToChange != null && !changeSpecificObject;
 
         public bool CanEdit => changeSpecificObject;
 


### PR DESCRIPTION
## Summary
- enable edit mode for new entries by adjusting `IsEditing` and `IsReadOnly`
- update save commands to only update when an existing object is being changed

## Testing
- `dotnet build QuoteSwift.sln` *(fails: NETSDK1100/MSB4803)*

------
https://chatgpt.com/codex/tasks/task_e_688269a8316083259e3643cc499750a9