### PR TITLE
Fix parameter handling for adding customers

### DIFF
--- a/Infrastructure/CommandBindings.cs
+++ b/Infrastructure/CommandBindings.cs
@@ -18,6 +18,23 @@ namespace QuoteSwift
             };
         }
 
+        public static void Bind(Button button, ICommand command, Func<object> parameterProvider)
+        {
+            if (button == null || command == null)
+                return;
+
+            object GetParam() => parameterProvider?.Invoke();
+
+            button.Enabled = command.CanExecute(GetParam());
+            command.CanExecuteChanged += (s, e) => button.Enabled = command.CanExecute(GetParam());
+            button.Click += (s, e) =>
+            {
+                var param = GetParam();
+                if (command.CanExecute(param))
+                    command.Execute(param);
+            };
+        }
+
         public static void Bind(ToolStripMenuItem item, ICommand command)
         {
             if (item == null || command == null)

--- a/Views/FrmAddCustomer.cs
+++ b/Views/FrmAddCustomer.cs
@@ -56,7 +56,16 @@ namespace QuoteSwift.Views
             btnAddCustomer.DataBindings.Add("Visible", ViewModel, nameof(AddCustomerViewModel.ShowSaveButton));
             btnAddCustomer.DataBindings.Add("Text", ViewModel, nameof(AddCustomerViewModel.SaveButtonText));
 
-            CommandBindings.Bind(btnAddCustomer, ViewModel.SaveCustomerCommand);
+            CommandBindings.Bind(
+                btnAddCustomer,
+                ViewModel.SaveCustomerCommand,
+                () =>
+                {
+                    var business = cbBusinessSelection.SelectedItem as Business ?? Container;
+                    if (ViewModel.CustomerToChange != null && ViewModel.ChangeSpecificObject)
+                        return new object[] { business, ViewModel.CustomerToChange.CustomerCompanyName };
+                    return business;
+                });
             CommandBindings.Bind(btnAddAddress, ViewModel.AddAddressCommand);
             CommandBindings.Bind(btnAddPOBoxAddress, ViewModel.AddPOBoxAddressCommand);
             CommandBindings.Bind(btnAddNumber, ViewModel.AddPhoneNumberCommand);


### PR DESCRIPTION
## Summary
- add overload in `CommandBindings` to supply parameters
- pass business and customer info when saving customers so Add/Update works correctly

## Testing
- `dotnet build QuoteSwift.sln` *(fails: .NET 9 SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_68826ede48388325b6d9eab3fbae66ee